### PR TITLE
Add visual indication of modified code (See issue #130)

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -27,6 +27,14 @@ module.exports = Hydrogen =
                           {"Python Django": "python", "Ruby (Rails)": "ruby"}'
             type: 'string'
             default: '{}'
+          highlightExecuted:
+            title: 'Highlight Executed Code Until Modified'
+            description: 'Highlight lines of code that have been executed. The
+                          highlight will be removed automatically when the code
+                          is modified so you will know your Jupyter context is
+                          out of date.'
+            type: 'boolean'
+            default: false
 
     subscriptions: null
     statusBarElement: null
@@ -183,7 +191,9 @@ module.exports = Hydrogen =
                         console.log(range)
 
                     if code?
-                        @highlightBlock(range)
+                        if atom.config.get('Hydrogen.highlightExecuted')?
+                          @highlightBlock(range)
+
                         @clearBubblesOnRow(range.end.row)
                         view = @insertResultBubble(range.end.row)
 
@@ -351,7 +361,7 @@ module.exports = Hydrogen =
     getFoldContents: (row) ->
         buffer = @editor.getBuffer()
         range = @getFoldRange(@editor, row)
-        
+
         return [
                 buffer.getTextInRange(range),
                 range

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -295,11 +295,13 @@ module.exports = Hydrogen =
 
         if selectedText != ''
             selectedRange = @editor.getSelectedBufferRange()
-            # endRow = selectedRange.end.row
+
             # if selectedRange.end.column is 0
-            #     endRow = endRow - 1
-            # while @blank(endRow)
-            #     endRow = endRow - 1
+            #     selectedRange.end.row -= 1
+
+            while @blank(selectedRange.end.row - 1)
+                selectedRange.end.row -= 1
+
             return [selectedText, selectedRange]
 
         cursor = @editor.getLastCursor()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -203,7 +203,6 @@ module.exports = Hydrogen =
 
                     if codeBlock?
                         [code, range] = codeBlock
-                        console.log(range)
 
                     if code?
                         if atom.config.get('Hydrogen.highlightExecuted')?
@@ -306,10 +305,8 @@ module.exports = Hydrogen =
         cursor = @editor.getLastCursor()
 
         row = cursor.getBufferRow()
-        console.log "row:", row
 
         indentLevel = cursor.getIndentLevel()
-        # indentLevel = @editor.suggestedIndentForBufferRow row
 
         foldable = @editor.isFoldableAtBufferRow(row)
         foldRange = @editor.languageMode.rowRangeForCodeFoldAtBufferRow(row)
@@ -318,19 +315,15 @@ module.exports = Hydrogen =
             foldable = false
 
         if foldable
-            console.log('foldable')
             range = @rowRangeToBufferRange(foldRange)
             return [buffer.getTextInRange(range), range]
         else if @blank(row)
-            console.log('blank')
             return @findPrecedingBlock(row, indentLevel)
         else if @isEnd(row)
-            console.log('end')
             rowRange = @findContainingFoldRange(row)
             range = @rowRangeToBufferRange(rowRange)
             return [buffer.getTextInRange(range), range]
         else
-            console.log('other')
             return [@getRowText(row), cursor.getCurrentLineBufferRange()]
 
     findPrecedingBlock: (row, indentLevel) ->

--- a/styles/hydrogen.less
+++ b/styles/hydrogen.less
@@ -11,6 +11,12 @@
     z-index: 6;
 }
 
+.atom-text-editor, :host, atom-text-editor, atom-text-editor::shadow {
+    .line.hydrogen-run {
+        background-color: lighten(@background-color-highlight, 10%);
+    }
+}
+
 .hydrogen.output-bubble {
     @light-bubble-background: fadein(lighten(@syntax-background-color, 40%), 100%);
     @dark-bubble-background: fadein(lighten(@syntax-background-color, 10%), 100%);

--- a/styles/hydrogen.less
+++ b/styles/hydrogen.less
@@ -5,8 +5,13 @@
 @import "ui-variables";
 @import "syntax-variables";
 
-@background-color-light: lighten(@syntax-background-color, 5%);
-@background-color-dark: darken(@syntax-background-color, 5%);
+@run-color-light: lighten(@syntax-background-color, 5%);
+@run-color-dark: darken(@syntax-background-color, 5%);
+@run-color: contrast(@syntax-background-color, @run-color-dark, @run-color-light, 20%);
+
+@highlight-color-light: lighten(@syntax-background-color, 10%);
+@highlight-color-dark: darken(@syntax-background-color, 10%);
+@highlight-color: contrast(@syntax-background-color, @highlight-color-dark, @highlight-color-light, 20%);
 
 // this is a hack to deal with a failing of the markers API
 // https://github.com/atom/atom/issues/6857
@@ -16,7 +21,11 @@
 
 .atom-text-editor, :host, atom-text-editor, atom-text-editor::shadow {
     .line.hydrogen-run {
-        background-color: contrast(@syntax-text-color, @background-color-dark, @background-color-light, 20%);
+        background-color: @run-color;
+
+        &.cursor-line {
+            background-color: @highlight-color;
+        }
     }
 }
 

--- a/styles/hydrogen.less
+++ b/styles/hydrogen.less
@@ -5,6 +5,9 @@
 @import "ui-variables";
 @import "syntax-variables";
 
+@background-color-light: lighten(@syntax-background-color, 5%);
+@background-color-dark: darken(@syntax-background-color, 5%);
+
 // this is a hack to deal with a failing of the markers API
 // https://github.com/atom/atom/issues/6857
 .tab-bar {
@@ -13,7 +16,7 @@
 
 .atom-text-editor, :host, atom-text-editor, atom-text-editor::shadow {
     .line.hydrogen-run {
-        background-color: lighten(@background-color-highlight, 10%);
+        background-color: contrast(@syntax-text-color, @background-color-dark, @background-color-light, 20%);
     }
 }
 


### PR DESCRIPTION
Here is a basic implementation of the visual highlights discussed in #130. A few notes:

* I added an opt-in config switch.
* The highlights are now cleared when the kernel is restarted.
* There is a block of Ruby-specific code [here](https://github.com/onyxfish/hydrogen/blob/master/lib/main.coffee#L298) that I couldn't suss out the purpose of. All my test cases seem to work fine with it commented out.
* I haven't been able to get the `contrast` selection for the highlight color to work to my satisfaction. Do you have a better idea how to select a good color?
* There may be a weird case where the selected code errors and you don't display a persistent result bubble, but the highlight persists. I had a hard time tracing the logic of showing/not showing the result "flag" so I wasn't sure where to check if the highlight should persist.

I substantially reimplemented the code to find the correct row range. I think it's quite bit simpler now. Hopefully you agree.

Let me know if you see other issues! I tested against Python and Ruby.