### PR TITLE
execute whole file with one command

### DIFF
--- a/keymaps/hydrogen.cson
+++ b/keymaps/hydrogen.cson
@@ -10,6 +10,7 @@
 '.platform-darwin atom-text-editor':
   'cmd-alt-enter': 'hydrogen:run-and-move-down'
   'shift-alt-enter': 'hydrogen:run'
+  'cmd-ctrl-enter': 'hydrogen:run-all'
 
 '.platform-darwin atom-workspace':
   'cmd-alt-backspace': 'hydrogen:clear-results'
@@ -17,6 +18,7 @@
 '.platform-win32 atom-text-editor, .platform-linux atom-text-editor':
   'ctrl-alt-enter': 'hydrogen:run-and-move-down'
   'shift-alt-enter': 'hydrogen:run'
+  'ctrl-shift-alt-enter': 'hydrogen:run-all'
 
 '.platform-win32 atom-workspace, .platform-linux atom-workspace':
   'ctrl-backspace': 'hydrogen:clear-results'

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -327,13 +327,13 @@ module.exports = Hydrogen =
                 onStarted(runningKernel)
 
     findCodeBlock: (runAll = false) ->
+        if runAll
+            return [@editor.getText(), @editor.getLastBufferRow()]
+
         cursor = @editor.getLastCursor()
 
         row = cursor.getBufferRow()
         console.log "row:", row
-
-        if runAll
-            return [@editor.getText(), row]
 
         buffer = @editor.getBuffer()
         selectedText = @editor.getSelectedText()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -330,11 +330,6 @@ module.exports = Hydrogen =
         if runAll
             return [@editor.getText(), @editor.getLastBufferRow()]
 
-        cursor = @editor.getLastCursor()
-
-        row = cursor.getBufferRow()
-        console.log "row:", row
-
         buffer = @editor.getBuffer()
         selectedText = @editor.getSelectedText()
 
@@ -346,6 +341,11 @@ module.exports = Hydrogen =
             while @blank(endRow) and endRow > selectedRange.start.row
                 endRow = endRow - 1
             return [selectedText, endRow]
+
+        cursor = @editor.getLastCursor()
+
+        row = cursor.getBufferRow()
+        console.log "row:", row
 
         indentLevel = cursor.getIndentLevel()
         # indentLevel = @editor.suggestedIndentForBufferRow row

--- a/menus/hydrogen.cson
+++ b/menus/hydrogen.cson
@@ -18,6 +18,9 @@
         }, {
           'label': 'Run and Move Down'
           'command': 'hydrogen:run-and-move-down'
+        }, {
+          'label': 'Run All'
+          'command': 'hydrogen:run-all'
         }
       ]
     ]


### PR DESCRIPTION
As mentioned in issue https://github.com/nteract/hydrogen/issues/74.

Mac: `cmd-ctrl-enter`
Windows: `ctrl-shift-alt-enter`

The result bubble will appear on the last line.

The Mac shortcut is very nice. But I'm not shure if the Windows shortcut is convenient.
Do you have a better idea?