### PR TITLE
Add buttons on watches sidebar

### DIFF
--- a/lib/result-view.coffee
+++ b/lib/result-view.coffee
@@ -136,6 +136,11 @@ class ResultView
                 or container.offsetHeight > 500
                   container.innerText = container.innerText.replace /\\n/g, "\n"
                   @setMultiline true
+                else
+                  @tooltips.add atom.tooltips.add(container, {title: "Copy to clipboard"})
+                  container.onclick = =>
+                    atom.clipboard.write(@getAllText())
+                    atom.notifications.addSuccess("Copied to clipboard")
             else
                 console.error "Unrecognized result:", result
 

--- a/lib/watch-sidebar.coffee
+++ b/lib/watch-sidebar.coffee
@@ -18,7 +18,7 @@ class WatchSidebar
         @toolbar.classList.add('toolbar', 'block')
 
         languageDisplay = document.createElement('button')
-        languageDisplay.classList.add('btn', 'icon', 'icon-sync', 'language')
+        languageDisplay.classList.add('btn', 'icon', 'icon-sync')
         languageDisplay.innerText = "Watch: #{@language}"
         languageDisplay.onclick = =>
             editor = atom.workspace.getActiveTextEditor()

--- a/lib/watch-sidebar.coffee
+++ b/lib/watch-sidebar.coffee
@@ -1,4 +1,5 @@
 {$} = require 'atom-space-pen-views'
+{CompositeDisposable} = require 'atom'
 _ = require 'lodash'
 
 WatchView = require './watch-view'
@@ -13,17 +14,30 @@ class WatchSidebar
         @element = document.createElement('div')
         @element.classList.add('hydrogen', 'watch-sidebar')
 
-        title = document.createElement('h1')
-        title.classList.add('watch-sidebar-title')
-        title.innerText = "Hydrogen Watch"
+        @toolbar = document.createElement('div')
+        @toolbar.classList.add('toolbar', 'block')
 
-        languageDisplay = document.createElement('h3')
-        languageDisplay.classList.add('watch-sidebar-language')
-        languageDisplay.innerText = "Kernel: #{@language}"
+        languageDisplay = document.createElement('button')
+        languageDisplay.classList.add('btn', 'icon', 'icon-sync', 'language')
+        languageDisplay.innerText = "Watch: #{@language}"
         languageDisplay.onclick = =>
             editor = atom.workspace.getActiveTextEditor()
             editorView = atom.views.getView(editor)
             atom.commands.dispatch(editorView, 'hydrogen:select-watch-kernel')
+
+        @commands = document.createElement('div')
+        @commands.classList.add('btn-group')
+        @removeButton = document.createElement('button')
+        @removeButton.classList.add('btn', 'icon', 'icon-trashcan')
+        @removeButton.onclick = => @removeWatch()
+        @toggleButton = document.createElement('button')
+        @toggleButton.classList.add('btn', 'icon', 'icon-remove-close')
+        @toggleButton.onclick = => this.hide()
+
+        @tooltips = new CompositeDisposable()
+        @tooltips.add atom.tooltips.add(@toggleButton, {title: "Toggle Watches"})
+        @tooltips.add atom.tooltips.add(languageDisplay, {title: "Change Watch Kernel"})
+        @tooltips.add atom.tooltips.add(@removeButton, {title: "Remove Watch"})
 
         # watch = new WatchView(@kernel, @grammar)
 
@@ -42,8 +56,12 @@ class WatchSidebar
         @resizeHandle.classList.add('watch-resize-handle')
         $(@resizeHandle).on 'mousedown', @resizeStarted
 
-        @element.appendChild(title)
-        @element.appendChild(languageDisplay)
+        @toolbar.appendChild(languageDisplay)
+        @toolbar.appendChild(@commands)
+        @commands.appendChild(@removeButton)
+        @commands.appendChild(@toggleButton)
+
+        @element.appendChild(@toolbar)
         @element.appendChild(@watchesContainer)
         @element.appendChild(@addButton)
         @element.appendChild(@resizeHandle)

--- a/styles/hydrogen.less
+++ b/styles/hydrogen.less
@@ -192,26 +192,15 @@
     padding: 10px;
     border-left: 1px solid @base-border-color;
 
-    .watch-sidebar-title {
-        text-align: center;
-        margin-top: 5px;
-        margin-bottom: 5px;
-    }
-
-    .watch-sidebar-language {
-        margin-top: 5px;
-        margin-bottom: 5px;
-        text-align: center;
-        cursor: pointer;
-
-        &:hover {
-            text-decoration: underline;
+    .toolbar {
+        margin-bottom: 10px;
+        .btn-group{
+            float: right;
         }
     }
 
     .watch-view {
         width: 100%;
-        margin-top: 10px;
         .watch-input {
             padding: 3px;
             border-radius: 3px;
@@ -282,7 +271,7 @@
             display: inline-block;
             width: 100%;
             max-height: 400px;
-            overflow-y: scroll;
+            overflow-y: overlay;
             white-space: pre-wrap;
         }
 

--- a/styles/hydrogen.less
+++ b/styles/hydrogen.less
@@ -11,6 +11,10 @@
     z-index: 6;
 }
 
+.bottom{
+    z-index: 4;
+}
+
 .hydrogen.output-bubble {
     @light-bubble-background: fadein(lighten(@syntax-background-color, 40%), 100%);
     @dark-bubble-background: fadein(lighten(@syntax-background-color, 10%), 100%);

--- a/styles/hydrogen.less
+++ b/styles/hydrogen.less
@@ -188,17 +188,19 @@
     height: 100%;
     width: 300px;
     min-width: 200px;
-    overflow-y: scroll;
-    margin: 5px;
+    overflow-y: overlay;
+    padding: 10px;
+    border-left: 1px solid @base-border-color;
 
     .watch-sidebar-title {
         text-align: center;
-        // padding-top: 15px;
+        margin-top: 5px;
         margin-bottom: 5px;
     }
 
     .watch-sidebar-language {
         margin-top: 5px;
+        margin-bottom: 5px;
         text-align: center;
         cursor: pointer;
 
@@ -209,19 +211,20 @@
 
     .watch-view {
         width: 100%;
-        margin-top: 20px;
-
+        margin-top: 10px;
         .watch-input {
+            padding: 3px;
             border-radius: 3px;
             background-color: @syntax-background-color;
-            margin: 5px;
             font-size: @font-size;
             min-height: 3em;
+            border: 1px solid @base-border-color;
         }
 
         .history-scrollbar {
           overflow-x: scroll;
-          height: 7px;
+          overflow-y: hidden;
+          height: 10px;
           .hidden {
             height: 1px;
             width: 1000px;
@@ -242,8 +245,7 @@
     }
 
     .add-watch {
-        margin: 2%;
-        width: 96%;
+        width: 100%;
     }
 
     .output-bubble.empty {
@@ -253,12 +255,14 @@
     .output-bubble {
         position: static;
         display: flex;
-        border-radius: 0px;
-        margin: 5px;
+        border-radius: 3px;
+        margin: 0px;
         font-size: @font-size * 5/6;
         box-shadow: none;
         padding-left: 0px;
         padding-right: 0px;
+        border: 1px solid @base-border-color;
+        margin-bottom: 10px;
 
 
         &.rich .rich-close-button {
@@ -267,10 +271,10 @@
 
         &:not(.rich) {
             .bubble-action-panel {
-                display: inline-flex;
+                display: flex;
                 flex-direction: column;
                 width: 30px;
-                border-radius: 0;
+                border-radius: 0 3px 3px 0;
             }
         }
 

--- a/styles/hydrogen.less
+++ b/styles/hydrogen.less
@@ -79,7 +79,8 @@
 
         .bubble-output-container {
             padding: 3px;
-            overflow: scroll;
+            padding-right: 10px;
+            overflow: auto;
         }
 
         .rich-close-button::before {
@@ -254,7 +255,7 @@
         display: flex;
         border-radius: 0px;
         margin: 5px;
-        font-size: @font-size;
+        font-size: @font-size * 5/6;
         box-shadow: none;
         padding-left: 0px;
         padding-right: 0px;


### PR DESCRIPTION
I added buttons to the watches sidebar to trigger the `toggle watches` and `remove watch` commands. What do you think about the styling?

old vs new:

<img width="320" alt="old" src="https://cloud.githubusercontent.com/assets/13285808/13299928/b69ccc26-db3d-11e5-9aca-317d19a61ae7.png"> <img width="313" alt="new" src="https://cloud.githubusercontent.com/assets/13285808/13299927/b69499f2-db3d-11e5-9337-2fd7ce5988e1.png">

The possibility to copy one line outputs by clicking on them was added as well:

![copy](https://cloud.githubusercontent.com/assets/13285808/13299946/db287dd8-db3d-11e5-96a5-3a0c3ec61e57.png)

It fixes #174 with this hack https://github.com/atom/atom/issues/6857


Apart from that this PR fixes some styling issues mostly related to scrollbars by changing `overflow` from `scroll` to `overlay`. Can you test if it works on Windows and Linux as well?