### PR TITLE
Code Introspection

### DIFF
--- a/lib/kernel-manager.coffee
+++ b/lib/kernel-manager.coffee
@@ -7,12 +7,12 @@ Kernel = require './kernel'
 module.exports = KernelManager =
     runningKernels: {}
     kernelsUpdatedOnce: false
-      
+
     getAvailableKernels: ->
         kernels = _.pluck @getConfigJson('kernelspec', {kernelspecs:{}}).kernelspecs, 'spec'
         @updateKernels() unless @kernelsUpdatedOnce
         kernels
-               
+
     updateKernels: ->
       saveKernelsToConfig = (out) =>
         try
@@ -29,13 +29,13 @@ module.exports = KernelManager =
           @setConfigJson 'kernelspec', kernelspec
           atom.notifications.addInfo 'Hydrogen Kernels updated:',
             detail: (_.pluck @getAvailableKernels(), 'display_name').join('\n')
-      
+
       @kernelsUpdatedOnce = true
       child_process.exec 'jupyter kernelspec list --json --log-level=CRITICAL', (e, stdout, stderr) ->
           return saveKernelsToConfig stdout unless e
           child_process.exec 'ipython kernelspec list --json --log-level=CRITICAL', (e, stdout, stderr) ->
               saveKernelsToConfig stdout
-       
+
     getRunningKernels: ->
         return _.clone(@runningKernels)
 
@@ -164,6 +164,13 @@ module.exports = KernelManager =
         kernel = @getRunningKernelForLanguage(language)
         if kernel?
             kernel.complete(code, onResults)
+        else
+            throw "No such kernel!"
+
+    inspect: (language, code, cursor_pos, onResults) ->
+        kernel = @getRunningKernelForLanguage(language)
+        if kernel?
+            kernel.inspect(code, cursor_pos, onResults)
         else
             throw "No such kernel!"
 

--- a/lib/kernel.coffee
+++ b/lib/kernel.coffee
@@ -198,6 +198,33 @@ class Kernel
 
         @signedSend message, @shellSocket
 
+
+    inspect: (code, cursor_pos, onResults) ->
+        console.log "sending inspect"
+
+        requestId = "inspect_" + uuid.v4()
+
+        header =
+                msg_id: requestId
+                username: ""
+                session: "00000000-0000-0000-0000-000000000000"
+                msg_type: "inspect_request"
+                version: "5.0"
+
+        content =
+                code: code
+                cursor_pos: cursor_pos
+                detail_level : 0
+
+        message =
+                header: header
+                content: content
+
+        @executionCallbacks[requestId] = onResults
+
+        @signedSend message, @shellSocket
+
+
     addWatchCallback: (watchCallback) ->
         @watchCallbacks.push(watchCallback)
 
@@ -214,6 +241,11 @@ class Kernel
                     matches = message.contents.matches
                     # matches = _.map matches, (match) -> {text: match}
                     callback(matches)
+                else if message.type == 'inspect_reply'
+                    callback {
+                        data: message.contents.data
+                        found: message.contents.found
+                    }
                 else
                     callback {
                         data: 'ok'

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,5 +1,4 @@
 {CompositeDisposable} = require 'atom'
-{$} = require 'atom-space-pen-views'
 
 fs = require 'fs'
 zmq = require 'zmq'

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,4 +1,5 @@
 {CompositeDisposable} = require 'atom'
+{$} = require 'atom-space-pen-views'
 
 fs = require 'fs'
 zmq = require 'zmq'
@@ -409,13 +410,16 @@ module.exports = Hydrogen =
             found = result['found']
             if found is true
                 data = result['data']
-                atom.workspace.open('Hydrogen Inspector', {split:'down'}).then (editor) ->
+                atom.workspace.open('.Hydrogen Inspector', {split:'down'}).then (editor) ->
                     if editor.isEmpty() is false
                         buffer = editor.getBuffer()
                         buffer.deleteRows(0, buffer.getLineCount())
-
+                    editor.setSoftWrapped(true)
+                    editor.setLineNumberGutterVisible(false)
                     editor.insertText(stripAnsi(data['text/plain']))
                     editor.moveToTop()
                     atom.workspace.activatePreviousPane()
+                    # Hack for easy closing
+                    editor.save()
             else
                 atom.notifications.addInfo("No introspection available!")

--- a/styles/hydrogen.less
+++ b/styles/hydrogen.less
@@ -8,11 +8,15 @@
 // this is a hack to deal with a failing of the markers API
 // https://github.com/atom/atom/issues/6857
 .tab-bar {
-    z-index: 6;
+    z-index: 5;
 }
 
 .bottom{
     z-index: 4;
+}
+
+atom-overlay.autocomplete-plus {
+  z-index: 6;
 }
 
 .hydrogen.output-bubble {


### PR DESCRIPTION
Support introspection (https://jupyter-client.readthedocs.org/en/latest/messaging.html#introspection).

The kernel messaging works well.

Unfortunately the result display is very basic. I couldn't get a proper display panel to work so for now the inspection result just appears in an normal editor. So there are some major problems:
- the highlights from the atom spell checker are ugly
- the file is saved in order to allow the panel to be closed without an popup

![bildschirmfoto 2016-03-11 um 15 07 57](https://cloud.githubusercontent.com/assets/13285808/13704223/1d57599a-e79b-11e5-996c-0e69f434c417.png)

Is this a functionality you would like to see in hydrogen?
What ist the best way to display the inspection result? And how can can this be achieved?
