### PR TITLE
Colorful Output in the inspector and commands for closing and minimizing

### DIFF
--- a/lib/inspector.coffee
+++ b/lib/inspector.coffee
@@ -1,0 +1,64 @@
+convertAnsi = require 'ansi-to-html'
+{MessagePanelView, PlainMessageView} = require 'atom-message-panel'
+
+KernelManager = require './kernel-manager'
+
+module.exports = Inspector =
+    inspect: ->
+        @editor = atom.workspace.getActiveTextEditor()
+        language = @editor.getGrammar().name.toLowerCase()
+
+        [code, cursor_pos] = @getCodeToInspect()
+
+        KernelManager.inspect language, code, cursor_pos, (result) =>
+            console.log 'inspect result:', result
+            found = result['found']
+            if found is true
+                if not @convert?
+                    @convert = new convertAnsi()
+                data = result['data']
+                lines = data['text/plain'].split('\n')
+                firstline = @convert.toHtml(lines[0])
+                lines.splice(0,1)
+                message = @convert.toHtml(lines.join('\n'))
+
+                if not @inspector?
+                    console.log "Opening Inspector"
+                    @inspector = new MessagePanelView
+                        title: 'Hydrogen Inspector'
+                else
+                    @inspector.clear()
+
+                @inspector.attach()
+                @inspector.add new PlainMessageView
+                    message: firstline
+                    className: 'inspect-message'
+                    raw: true
+                @inspector.add new PlainMessageView
+                    message: message
+                    className: 'inspect-message'
+                    raw: true
+
+            else
+                atom.notifications.addInfo("No introspection available!")
+                if @inspector
+                    @inspector.close()
+
+    getCodeToInspect: ->
+        if @editor.getSelectedText() != ''
+            code = @editor.getSelectedText()
+            cursor_pos = code.length
+        else
+            cursor = @editor.getLastCursor()
+            row = cursor.getBufferRow()
+            code = @editor.lineTextForBufferRow(row)
+            cursor_pos = cursor.getBufferColumn()
+        return [code, cursor_pos]
+
+    toggleInspectorSize: ->
+        if @inspector?
+            @inspector.toggle()
+
+    closeInspector: ->
+        if @inspector?
+            @inspector.close()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -2,7 +2,7 @@
 
 fs = require 'fs'
 _ = require 'lodash'
-stripAnsi = require 'strip-ansi'
+convertAnsi = require 'ansi-to-html'
 {MessagePanelView, PlainMessageView} = require 'atom-message-panel'
 
 
@@ -403,10 +403,11 @@ module.exports = Hydrogen =
             found = result['found']
             if found is true
                 data = result['data']
-                lines = stripAnsi(data['text/plain']).split('\n')
-                firstline = lines[0]
+                lines = data['text/plain'].split('\n')
+                convert = new convertAnsi()
+                firstline = convert.toHtml(lines[0])
                 lines.splice(0,1)
-                message = lines.join('\n')
+                message = convert.toHtml(lines.join('\n'))
                 if not @inspector?
                     console.log "Opening Inspector"
                     @inspector = new MessagePanelView
@@ -417,10 +418,12 @@ module.exports = Hydrogen =
                 @inspector.add new PlainMessageView
                     message: firstline
                     className: 'inspect-message'
+                    raw: true
 
                 @inspector.add new PlainMessageView
                     message: message
                     className: 'inspect-message'
+                    raw: true
 
             else
                 atom.notifications.addInfo("No introspection available!")

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -38,9 +38,11 @@ module.exports = Hydrogen =
             'hydrogen:remove-watch': => @watchSidebar.removeWatch()
             'hydrogen:update-kernels': -> KernelManager.updateKernels()
             'hydrogen:inspect': => @inspect()
+            'hydrogen:close-inspector': => @closeInspector()
 
         @subscriptions.add atom.commands.add 'atom-workspace',
             'hydrogen:clear-results': => @clearResultBubbles()
+            'hydrogen:toggle-inspector-size': => @toggleInspectorSize()
 
         @subscriptions.add(atom.workspace.observeActivePaneItem(
             @updateCurrentEditor.bind(this)))
@@ -398,7 +400,7 @@ module.exports = Hydrogen =
 
         [code, cursor_pos] = @getCodeToInspect()
 
-        KernelManager.inspect language, code, cursor_pos, (result) ->
+        KernelManager.inspect language, code, cursor_pos, (result) =>
             console.log 'inspect result:', result
             found = result['found']
             if found is true
@@ -442,3 +444,11 @@ module.exports = Hydrogen =
             code = @getRow(row)
             cursor_pos = cursor.getBufferColumn()
         return [code, cursor_pos]
+
+    toggleInspectorSize: ->
+        if @inspector?
+            @inspector.toggle()
+
+    closeInspector: ->
+        if @inspector?
+            @inspector.close()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -402,24 +402,26 @@ module.exports = Hydrogen =
             console.log 'inspect result:', result
             found = result['found']
             if found is true
+                if not @convert?
+                    @convert = new convertAnsi()
                 data = result['data']
                 lines = data['text/plain'].split('\n')
-                convert = new convertAnsi()
-                firstline = convert.toHtml(lines[0])
+                firstline = @convert.toHtml(lines[0])
                 lines.splice(0,1)
-                message = convert.toHtml(lines.join('\n'))
+                message = @convert.toHtml(lines.join('\n'))
+
                 if not @inspector?
                     console.log "Opening Inspector"
                     @inspector = new MessagePanelView
                         title: 'Hydrogen Inspector'
                 else
                     @inspector.clear()
+
                 @inspector.attach()
                 @inspector.add new PlainMessageView
                     message: firstline
                     className: 'inspect-message'
                     raw: true
-
                 @inspector.add new PlainMessageView
                     message: message
                     className: 'inspect-message'

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -2,8 +2,6 @@
 
 fs = require 'fs'
 _ = require 'lodash'
-convertAnsi = require 'ansi-to-html'
-{MessagePanelView, PlainMessageView} = require 'atom-message-panel'
 
 
 KernelManager = require './kernel-manager'
@@ -12,6 +10,7 @@ SignalListView = require './signal-list-view'
 WatchSidebar = require './watch-sidebar'
 WatchLanguagePicker = require './watch-language-picker'
 AutocompleteProvider = require './autocomplete-provider'
+Inspector = require './inspector'
 
 module.exports = Hydrogen =
     config: require './config'
@@ -37,12 +36,12 @@ module.exports = Hydrogen =
             'hydrogen:add-watch': => @watchSidebar.addWatchFromEditor()
             'hydrogen:remove-watch': => @watchSidebar.removeWatch()
             'hydrogen:update-kernels': -> KernelManager.updateKernels()
-            'hydrogen:inspect': => @inspect()
-            'hydrogen:close-inspector': => @closeInspector()
+            'hydrogen:inspect': -> Inspector.inspect()
+            'hydrogen:close-inspector': -> Inspector.closeInspector()
 
         @subscriptions.add atom.commands.add 'atom-workspace',
             'hydrogen:clear-results': => @clearResultBubbles()
-            'hydrogen:toggle-inspector-size': => @toggleInspectorSize()
+            'hydrogen:toggle-inspector-size': -> Inspector.toggleInspectorSize()
 
         @subscriptions.add(atom.workspace.observeActivePaneItem(
             @updateCurrentEditor.bind(this)))
@@ -395,60 +394,3 @@ module.exports = Hydrogen =
                 @getRows(range[0], range[1]),
                 range[1]
             ]
-    inspect: ->
-        language = @editor.getGrammar().name.toLowerCase()
-
-        [code, cursor_pos] = @getCodeToInspect()
-
-        KernelManager.inspect language, code, cursor_pos, (result) =>
-            console.log 'inspect result:', result
-            found = result['found']
-            if found is true
-                if not @convert?
-                    @convert = new convertAnsi()
-                data = result['data']
-                lines = data['text/plain'].split('\n')
-                firstline = @convert.toHtml(lines[0])
-                lines.splice(0,1)
-                message = @convert.toHtml(lines.join('\n'))
-
-                if not @inspector?
-                    console.log "Opening Inspector"
-                    @inspector = new MessagePanelView
-                        title: 'Hydrogen Inspector'
-                else
-                    @inspector.clear()
-
-                @inspector.attach()
-                @inspector.add new PlainMessageView
-                    message: firstline
-                    className: 'inspect-message'
-                    raw: true
-                @inspector.add new PlainMessageView
-                    message: message
-                    className: 'inspect-message'
-                    raw: true
-
-            else
-                atom.notifications.addInfo("No introspection available!")
-                if @inspector
-                    @inspector.close()
-
-    getCodeToInspect: ->
-        if @editor.getSelectedText() != ''
-            code = @editor.getSelectedText()
-            cursor_pos = code.length
-        else
-            cursor = @editor.getLastCursor()
-            row = cursor.getBufferRow()
-            code = @getRow(row)
-            cursor_pos = cursor.getBufferColumn()
-        return [code, cursor_pos]
-
-    toggleInspectorSize: ->
-        if @inspector?
-            @inspector.toggle()
-
-    closeInspector: ->
-        if @inspector?
-            @inspector.close()

--- a/package.json
+++ b/package.json
@@ -38,8 +38,7 @@
     "jmp": "0.4.x",
     "strip-ansi": "3.0.1",
     "uuid": "^2.0.1",
-    "ansi-to-html": "0.4.1",
-    "atom-message-panel": "1.2.4"
+    "ansi-to-html": "0.4.1"
   },
   "consumedServices": {
     "status-bar": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,9 @@
     "lodash": "^3.8.0",
     "jmp": "0.4.x",
     "strip-ansi": "3.0.1",
-    "uuid": "^2.0.1"
+    "uuid": "^2.0.1",
+    "ansi-to-html": "0.4.1",
+    "atom-message-panel": "1.2.4"
   },
   "consumedServices": {
     "status-bar": {

--- a/styles/hydrogen.less
+++ b/styles/hydrogen.less
@@ -342,6 +342,7 @@ atom-overlay.autocomplete-plus {
 .hydrogen.status-container {
     display: inline-block;
     cursor: pointer;
+    vertical-align: top;
 
     .status:hover {
         text-decoration: underline;

--- a/styles/hydrogen.less
+++ b/styles/hydrogen.less
@@ -342,7 +342,6 @@ atom-overlay.autocomplete-plus {
 .hydrogen.status-container {
     display: inline-block;
     cursor: pointer;
-    vertical-align: top;
 
     .status:hover {
         text-decoration: underline;
@@ -416,4 +415,13 @@ atom-overlay.autocomplete-plus {
 .plain-message.inspect-message {
     white-space: pre-wrap;
     font-size: @font-size;
+    span[style] {
+        color: @text-color-info !important;
+    }
+}
+
+.heading-summary.inspect-message {
+    span[style] {
+        color: @text-color-info !important;
+    }
 }


### PR DESCRIPTION
The ansi colors are hardcoded. In order to make them look good with every theme they all get displayed in `@text-color-info`.

@rgbkrk I tried to use `transformime` but somehow I wasn't able to get it to work all the way. However the inspect reply is just `text/plain`, at least for the python kernel. So I think this solution is fine for now.

<img width="613" alt="color" src="https://cloud.githubusercontent.com/assets/13285808/13748051/72c0ad84-e9fb-11e5-9cf3-510dc5586d95.png">


I added two commands to toggle the size and to close the inspector.
Should we map a default key binding for the `inspect` command? `cmd-ctrl-i` would work great for me.