### PR TITLE
Fix: watch scrolling

### DIFF
--- a/styles/hydrogen.less
+++ b/styles/hydrogen.less
@@ -217,10 +217,9 @@
 }
 
 .hydrogen.watch-sidebar {
-    height: 100%;
     width: 300px;
     min-width: 200px;
-    overflow-y: scroll;
+    overflow-y: overlay;
     padding: 10px;
     border-left: 1px solid @base-border-color;
 


### PR DESCRIPTION
Closes #216 

Atom 1.6 doesn't like `height: 100%`: https://github.com/atom/atom/issues/11104#issuecomment-194141483