### PR TITLE
Kernel: Revert `jupyter/console-text` hack

### DIFF
--- a/lib/kernel.coffee
+++ b/lib/kernel.coffee
@@ -230,8 +230,7 @@ class Kernel
 
             else if msg_type is 'inspect_reply'
                 callback
-                    data:
-                        'jupyter/console-text': message.content.data['text/plain']
+                    data: message.content.data
                     found: message.content.found
 
             else


### PR DESCRIPTION
* This hack isn't necessary after adding `text/plain` to
  `consoleTextTransform`.