### PR TITLE
ResultView: Show status if `transformime` failed

### DIFF
--- a/lib/result-view.coffee
+++ b/lib/result-view.coffee
@@ -88,10 +88,6 @@ class ResultView
                 @statusContainer.style.display = 'inline-block'
             return
 
-        console.log "ResultView: Hide status container"
-        @_hasResult = true
-        @statusContainer.style.display = 'none'
-
         if result.stream is 'stderr'
             container = @errorContainer
         else if result.stream is 'stdout'
@@ -102,6 +98,10 @@ class ResultView
             container = @resultContainer
 
         onSuccess = ({mimetype, el}) =>
+            console.log "ResultView: Hide status container"
+            @_hasResult = true
+            @statusContainer.style.display = 'none'
+
             mimeType = mimetype
             htmlElement = el
 


### PR DESCRIPTION
* If `transformime` fails to transform the result, then ensure that at
  least the status container is shown. Otherwise, the block decorations
  break.