### PR TITLE
Fix: display images correctly in watch sidebar

### DIFF
--- a/styles/hydrogen.less
+++ b/styles/hydrogen.less
@@ -347,15 +347,19 @@
                 width: 30px;
                 background-color: darken(@bubble-background, 10%);
             }
+
+            .bubble-output-container {
+                border-radius: 3px 0 0 3px;
+            }
         }
 
         .bubble-output-container {
             display: inline-block;
             width: 100%;
+            max-width: 100%;
             max-height: 400px;
             overflow: scroll;
             white-space: pre-wrap;
-            border-radius: 3px 0 0 3px;
         }
 
 
@@ -371,6 +375,8 @@
             }
 
             video, img, svg {
+                height: 100%;
+                width: 100%;
                 display: block;
                 max-width: 100% !important;
                 max-height: 450px !important;


### PR DESCRIPTION
Another styling related :bug:.
PR:
<img width="325" alt="bildschirmfoto 2016-03-29 um 22 21 25" src="https://cloud.githubusercontent.com/assets/13285808/14122743/459106a2-f5fd-11e5-9446-e599f7157b59.png">
v0.8.1:
<img width="314" alt="bildschirmfoto 2016-03-29 um 22 22 09" src="https://cloud.githubusercontent.com/assets/13285808/14122753/4f354e2a-f5fd-11e5-9ca9-93e7f68fcb70.png">
