### PR TITLE
Select kernel from available and not only running

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -306,10 +306,7 @@ module.exports = Hydrogen =
 
     showKernelPicker: ->
         unless @kernelPicker?
-            @kernelPicker = new KernelPicker( =>
-              KernelManager.getAllKernelSpecsFor(
-                KernelManager.getGrammarLanguageFor(@editor.getGrammar())
-            ))
+            @kernelPicker = new KernelPicker KernelManager.getAllKernelSpecs.bind(KernelManager)
             @kernelPicker.onConfirmed = ({kernel}) =>
                 @handleKernelCommand {
                   command: 'switch-kernel'


### PR DESCRIPTION
> Because I fucked up with all javascript grammars I have in my setup, so I just want to match kernel to grammar. Editing JSON is not user "unfrendly", it's just a mess. 

> And for example I work with jade(pug). It has inline jstransformers http://jade-lang.com/reference/filters/ and I want to switch between languages for one grammar.

Anyone could just switch to proper kernel. If he gets something like this https://github.com/nteract/hydrogen/issues/283#issuecomment-223997205

