### PR TITLE
remove kernel commands

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -31,7 +31,6 @@ module.exports = Hydrogen =
             'hydrogen:run-all': => @runAll()
             'hydrogen:run-all-above': => @runAllAbove()
             'hydrogen:run-and-move-down': => @runAndMoveDown()
-            'hydrogen:show-kernel-commands': => @showKernelCommands()
             'hydrogen:toggle-watches': => @toggleWatchSidebar()
             'hydrogen:select-watch-kernel': => @showWatchKernelPicker()
             'hydrogen:select-kernel': => @showKernelPicker()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -64,11 +64,9 @@ module.exports = Hydrogen =
         @statusBarElement = document.createElement('div')
         @statusBarElement.classList.add('hydrogen')
         @statusBarElement.classList.add('status-container')
-        @statusBarElement.onclick = ->
-            editorView = atom.views.getView atom.workspace.getActiveTextEditor()
-            atom.commands.dispatch(editorView, 'hydrogen:show-kernel-commands')
-        @statusBarTile = statusBar.addLeftTile(item: @statusBarElement,
-                                               priority: 100)
+        @statusBarElement.onclick = @showKernelCommands.bind this
+        @statusBarTile = statusBar.addLeftTile
+          item: @statusBarElement, priority: 100
 
 
     provide: ->


### PR DESCRIPTION
Because 'hydrogen:interrupt-kernel', 'hydrogen:restart-kernel', 'hydrogen:select-kernel' now are in command palette, so 'hydrogen:show-kernel-commands' duplicates functionality
