### PR TITLE
Custom kernel connection file

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ You can use a custom kernel connection file to connect to a previously created k
 
 For example, you can run a kernel inside a Docker container and make Hydrogen connect to it automatically. If you are using Docker this would allow you to develop from Atom but with all the dependencies, autocompletion, environment, etc of a Docker container.
 
-Hydrogen will look for a kernel JSON connection file under `./hydrogen/kernel/hydrogen-kernel.json` inside your project. If that file exists, Hydrogen will try to connect to the kernel specified by that connection file.
+Hydrogen will look for a kernel JSON connection file under `./hydrogen/connection.json` inside your project. If that file exists, Hydrogen will try to connect to the kernel specified by that connection file.
 
 Here's a simple recipe for doing and testing that with Python:
 
@@ -181,7 +181,7 @@ FROM python:2.7
 RUN pip install markdown
 
 RUN pip install ipykernel
-RUN echo "alias hydrokernel='python -m ipykernel "'--ip=$(hostname -I)'" -f /tmp/kernel/hydrogen-kernel.json'" >> /etc/bash.bashrc
+RUN echo "alias hydrokernel='python -m ipykernel "'--ip=$(hostname -I)'" -f /tmp/hydrogen/connection.json'" >> /etc/bash.bashrc
 ```
 
 You will test using the Python package `markdown` from inside the Docker container in your local Atom editor, with autocompletion, etc.
@@ -190,12 +190,12 @@ The last two lines are the only (temporal) addition to your `Dockerfile` that wi
 
 ```
 RUN pip install ipykernel
-RUN echo "alias hydrokernel='python -m ipykernel "'--ip=$(hostname -I)'" -f /tmp/kernel/hydrogen-kernel.json'" >> /etc/bash.bashrc
+RUN echo "alias hydrokernel='python -m ipykernel "'--ip=$(hostname -I)'" -f /tmp/hydrogen/connection.json'" >> /etc/bash.bashrc
 ```
 
 The first of those two lines will install the Python package `ipykernel`, which is the only requisite to run the remote Python kernel.
 
-The second line creates a handy shortcut named `hydrokernel` to run a Python kernel that listens on the container's IP address and writes the connection file to `/tmp/kernel/hydrogen-kernel.json`.
+The second line creates a handy shortcut named `hydrokernel` to run a Python kernel that listens on the container's IP address and writes the connection file to `/tmp/hydrogen/connection.json`.
 
 * Build your container with:
 
@@ -203,10 +203,10 @@ The second line creates a handy shortcut named `hydrokernel` to run a Python ker
 docker build -t python-docker .
 ```
 
-* Run your container mounting a volume that maps `./hydrogen/kernel/` in your local project directory to `/tmp/kernel/` in your container. That's the trick that will allow Hydrogen to connect to the kernel running inside your container automatically. It's probably better to run it with the command `bash` and start the kernel manually, so that you can restart it if you need to (or if it dies).
+* Run your container mounting a volume that maps `./hydrogen/` in your local project directory to `/tmp/hydrogen/` in your container. That's the trick that will allow Hydrogen to connect to the kernel running inside your container automatically. It's probably better to run it with the command `bash` and start the kernel manually, so that you can restart it if you need to (or if it dies).
 
 ```
-docker run -it --name python-docker -v $(pwd)/hydrogen/kernel:/tmp/kernel python-docker bash
+docker run -it --name python-docker -v $(pwd)/hydrogen:/tmp/hydrogen python-docker bash
 ```
 
 * Next, you just have to call the alias command we created in the `Dockerfile`, that will start the kernel with all the parameters needed:
@@ -228,10 +228,10 @@ To read more about this, see https://github.com/ipython/ipython/issues/2049
 
 
 To connect another client to this kernel, use:
-    --existing /tmp/kernel/hydrogen-kernel.json
+    --existing /tmp/hydrogen/connection.json
 ```
 
-* And you will see that a file was created in `./hydrogen/kernel/hydrogen-kernel.json` inside your project directory.
+* And you will see that a file was created in `./hydrogen/connection.json` inside your project directory.
 
 * Now you can create a file `test.py` with:
 

--- a/lib/config-manager.coffee
+++ b/lib/config-manager.coffee
@@ -9,18 +9,31 @@ module.exports = ConfigManager =
     fileStoragePath: path.join(__dirname, '..', 'kernel-configs')
 
     writeConfigFile: (onCompleted) ->
-        try
-            fs.mkdirSync(@fileStoragePath)
-        catch e
-            if e.code != 'EEXIST'
-                throw e
-        filename = 'kernel-' + uuid.v4() + '.json'
-        portfinder.findMany 5, (ports) =>
-            config = @buildConfiguration ports
-            configString = JSON.stringify config
-            filepath = path.join(@fileStoragePath, filename)
-            fs.writeFileSync filepath, configString
-            onCompleted filepath, config
+        customKernelConnectionPath = path.join atom.project.rootDirectories[0].path, 'hydrogen', 'kernel', 'hydrogen-kernel.json'
+        fs.access customKernelConnectionPath, (err) =>
+            if err?
+                try
+                    console.log "fileStoragePath: ", @fileStoragePath
+                    fs.mkdirSync(@fileStoragePath)
+                catch e
+                    if e.code != 'EEXIST'
+                        throw e
+                filename = 'kernel-' + uuid.v4() + '.json'
+                portfinder.findMany 5, (ports) =>
+                    config = @buildConfiguration ports
+                    configString = JSON.stringify config
+                    filepath = path.join(@fileStoragePath, filename)
+                    fs.writeFileSync filepath, configString
+                    console.log "Creating kernel connection: ", filepath
+                    onCompleted filepath, config
+            else
+                fs.readFile customKernelConnectionPath, 'utf8', (err, data) ->
+                    unless err?
+                        config = JSON.parse data
+                        console.log "Using custom kernel connection: ", customKernelConnectionPath
+                        atom.notifications.addInfo 'Custom kernel connection:',
+                            detail: "Make sure to manually start the custom kernel that serves the connection in #{customKernelConnectionPath}", dismissable: true
+                        onCompleted customKernelConnectionPath, config, true
 
     buildConfiguration: (ports) ->
         config =

--- a/lib/config-manager.coffee
+++ b/lib/config-manager.coffee
@@ -9,7 +9,7 @@ module.exports = ConfigManager =
     fileStoragePath: path.join(__dirname, '..', 'kernel-configs')
 
     writeConfigFile: (onCompleted) ->
-        customKernelConnectionPath = path.join atom.project.rootDirectories[0].path, 'hydrogen', 'kernel', 'hydrogen-kernel.json'
+        customKernelConnectionPath = path.join atom.project.rootDirectories[0].path, 'hydrogen', 'connection.json'
         fs.access customKernelConnectionPath, (err) =>
             if err?
                 try

--- a/lib/config-manager.coffee
+++ b/lib/config-manager.coffee
@@ -9,31 +9,18 @@ module.exports = ConfigManager =
     fileStoragePath: path.join(__dirname, '..', 'kernel-configs')
 
     writeConfigFile: (onCompleted) ->
-        customKernelConnectionPath = path.join atom.project.rootDirectories[0].path, 'hydrogen', 'connection.json'
-        fs.access customKernelConnectionPath, (err) =>
-            if err?
-                try
-                    console.log "fileStoragePath: ", @fileStoragePath
-                    fs.mkdirSync(@fileStoragePath)
-                catch e
-                    if e.code != 'EEXIST'
-                        throw e
-                filename = 'kernel-' + uuid.v4() + '.json'
-                portfinder.findMany 5, (ports) =>
-                    config = @buildConfiguration ports
-                    configString = JSON.stringify config
-                    filepath = path.join(@fileStoragePath, filename)
-                    fs.writeFileSync filepath, configString
-                    console.log "Creating kernel connection: ", filepath
-                    onCompleted filepath, config
-            else
-                fs.readFile customKernelConnectionPath, 'utf8', (err, data) ->
-                    unless err?
-                        config = JSON.parse data
-                        console.log "Using custom kernel connection: ", customKernelConnectionPath
-                        atom.notifications.addInfo 'Custom kernel connection:',
-                            detail: "Make sure to manually start the custom kernel that serves the connection in #{customKernelConnectionPath}", dismissable: true
-                        onCompleted customKernelConnectionPath, config, true
+        try
+            fs.mkdirSync(@fileStoragePath)
+        catch e
+            if e.code != 'EEXIST'
+                throw e
+        filename = 'kernel-' + uuid.v4() + '.json'
+        portfinder.findMany 5, (ports) =>
+            config = @buildConfiguration ports
+            configString = JSON.stringify config
+            filepath = path.join(@fileStoragePath, filename)
+            fs.writeFileSync filepath, configString
+            onCompleted filepath, config
 
     buildConfiguration: (ports) ->
         config =

--- a/lib/kernel-manager.coffee
+++ b/lib/kernel-manager.coffee
@@ -174,8 +174,8 @@ module.exports = KernelManager =
             if e.code != 'ENOENT'
                 trow e
             console.log(e)
-            ConfigManager.writeConfigFile (filepath, config, onlyConnect = false) =>
-                kernel = new Kernel kernelSpec, grammar, config, filepath, onlyConnect
+            ConfigManager.writeConfigFile (filepath, config) =>
+                kernel = new Kernel kernelSpec, grammar, config, filepath, onlyConnect=false
                 finishKernelStartup kernel
 
 

--- a/lib/kernel-manager.coffee
+++ b/lib/kernel-manager.coffee
@@ -149,8 +149,8 @@ module.exports = KernelManager =
 
         kernelSpec.grammarLanguage = grammarLanguage
 
-        ConfigManager.writeConfigFile (filepath, config) =>
-            kernel = new Kernel kernelSpec, grammar, config, filepath
+        ConfigManager.writeConfigFile (filepath, config, onlyConnect = false) =>
+            kernel = new Kernel kernelSpec, grammar, config, filepath, onlyConnect
 
             @_runningKernels[grammarLanguage] = kernel
 

--- a/lib/kernel.coffee
+++ b/lib/kernel.coffee
@@ -30,7 +30,7 @@ class Kernel
         if @onlyConnect
           atom.notifications.addInfo 'Using custom kernel connection:',
               detail: @configPath
-        unless @onlyConnect
+        else
             if @language == 'python' and not @kernelSpec.argv?
                 commandString = "ipython"
                 args = [


### PR DESCRIPTION
Allow using a custom kernel connection file from inside the project directory, it looks for `./hydrogen/kernel/hydrogen-kernel.json` inside the project and uses it as the kernel connection.

This would presumably solve #287, allowing the development using a kernel inside a Docker container.

The `README.md` is also updated including a thorough but simple recipe to test it with Docker.

I think @slavaGanzin and @lgeiger may want to test it out.