### PR TITLE
Statusbar: Fix error when editor is undefined

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -64,8 +64,9 @@ module.exports = Hydrogen =
         @editor = atom.workspace.getActiveTextEditor()
 
         @subscriptions.add atom.workspace.observeActivePaneItem (item) =>
-            @editor = item
-            @setStatusBarElement()
+            if item
+                @editor = item
+                @setStatusBarElement()
 
         KernelManager.updateKernelSpecs()
 


### PR DESCRIPTION
This happens for example if a pane is split down and closed again.

The check was removed in #322.