### PR TITLE
Add select-kernel to list of activation commands

### DIFF
--- a/lib/kernel-picker.coffee
+++ b/lib/kernel-picker.coffee
@@ -41,7 +41,6 @@ class SignalListView extends SelectListView
         @languageOptions = _.map @getKernelSpecs(), (kernelSpec) ->
             return {
                 name: kernelSpec.display_name
-                value: kernelSpec.language
                 kernelSpec: kernelSpec
             }
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -112,7 +112,8 @@ module.exports = Hydrogen =
 
         else if command is 'switch-kernel'
             kernel = KernelManager.getRunningKernelFor language
-            KernelManager.destroyRunningKernel kernel
+            if kernel
+                KernelManager.destroyRunningKernel kernel
             @clearResultBubbles()
             KernelManager.setKernelMapping kernelSpec, grammar
             KernelManager.startKernel kernelSpec, grammar, =>

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   ],
   "activationCommands": {
     "atom-text-editor": [
+      "hydrogen:select-kernel",
       "hydrogen:run",
       "hydrogen:run-and-move-down",
       "hydrogen:run-all",


### PR DESCRIPTION
I've noticed that 0a2bd2e also fixes a bug triggered when `hydrogen:select-kernel` was invoked for a file that had no running kernel.