### PR TITLE
Refactor KernelManager as a class

### DIFF
--- a/lib/autocomplete-provider.coffee
+++ b/lib/autocomplete-provider.coffee
@@ -50,8 +50,8 @@ module.exports = (kernelManager) ->
                 return null
 
             grammar = editor.getGrammar()
-            grammarLanguage = kernelManager.getGrammarLanguageFor grammar
-            kernel = kernelManager.getRunningKernelFor grammarLanguage
+            language = kernelManager.getLanguageFor grammar
+            kernel = kernelManager.getRunningKernelFor language
             unless kernel?
                 return null
 
@@ -67,9 +67,9 @@ module.exports = (kernelManager) ->
 
         getPrefix: (editor, bufferPosition) ->
             grammar = editor.getGrammar()
-            grammarLanguage = kernelManager.getGrammarLanguageFor grammar
+            language = kernelManager.getLanguageFor grammar
 
-            regex = @regexes[grammarLanguage] ? @defaultRegex
+            regex = @regexes[language] ? @defaultRegex
 
             # Get the text for the line up to the triggered buffer position
             line = editor.getTextInRange(

--- a/lib/autocomplete-provider.coffee
+++ b/lib/autocomplete-provider.coffee
@@ -1,12 +1,11 @@
 _ = require 'lodash'
 
 Config = require './config'
-KernelManager = require './kernel-manager'
 
-module.exports = AutocompleteProvider = do ->
+module.exports = (kernelManager) ->
     languageMappings = Config.getJson 'languageMappings'
 
-    selectors = _.uniq KernelManager.getAllKernelSpecs().map ({language}) ->
+    selectors = _.uniq kernelManager.getAllKernelSpecs().map ({language}) ->
         if language in languageMappings
             return '.source.' + languageMappings[language].toLowerCase()
         return '.source.' + language.toLowerCase()
@@ -36,22 +35,23 @@ module.exports = AutocompleteProvider = do ->
             # adapted from http://php.net/manual/en/language.variables.basics.php
             php: /[$a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/
 
-        # This will take priority over the default provider, which has a priority of 0.
-        # `excludeLowerPriority` will suppress any providers with a lower priority
-        # i.e. The default provider will be suppressed
+        # This will take priority over the default provider, which has a
+        # priority of 0.
+        # `excludeLowerPriority` will suppress any providers with a lower
+        # priority i.e. The default provider will be suppressed
         inclusionPriority: 1
 
         # Required: Return a promise, an array of suggestions, or null.
         getSuggestions: ({editor, bufferPosition, scopeDescriptor, prefix}) ->
-            console.log "getSuggestions: prefix:", prefix
+            console.log 'getSuggestions: prefix:', prefix
             prefix = @getPrefix editor, bufferPosition
-            console.log "getSuggestions: new prefix:", prefix
+            console.log 'getSuggestions: new prefix:', prefix
             if prefix.trim().length < 3
                 return null
 
             grammar = editor.getGrammar()
-            grammarLanguage = KernelManager.getGrammarLanguageFor grammar
-            kernel = KernelManager.getRunningKernelFor grammarLanguage
+            grammarLanguage = kernelManager.getGrammarLanguageFor grammar
+            kernel = kernelManager.getRunningKernelFor grammarLanguage
             unless kernel?
                 return null
 
@@ -67,21 +67,23 @@ module.exports = AutocompleteProvider = do ->
 
         getPrefix: (editor, bufferPosition) ->
             grammar = editor.getGrammar()
-            grammarLanguage = KernelManager.getGrammarLanguageFor grammar
+            grammarLanguage = kernelManager.getGrammarLanguageFor grammar
 
             regex = @regexes[grammarLanguage] ? @defaultRegex
 
             # Get the text for the line up to the triggered buffer position
-            line = editor.getTextInRange([[bufferPosition.row, 0], bufferPosition])
+            line = editor.getTextInRange(
+                [[bufferPosition.row, 0], bufferPosition]
+            )
 
             # Match the regex to the line, and return the match
             line.match(regex)?[0] or ''
 
-        # (optional): called _after_ the suggestion `replacementPrefix` is replaced
-        # by the suggestion `text` in the buffer
+        # (optional): called _after_ the suggestion `replacementPrefix` is
+        # replaced by the suggestion `text` in the buffer
         onDidInsertSuggestion: ({editor, triggerPosition, suggestion}) ->
 
-        # (optional): called when your provider needs to be cleaned up. Unsubscribe
-        # from things, kill any processes, etc.
+        # (optional): called when your provider needs to be cleaned up.
+        # Unsubscribe from things, kill any processes, etc.
         dispose: ->
     }

--- a/lib/inspector.coffee
+++ b/lib/inspector.coffee
@@ -1,16 +1,18 @@
 {MessagePanelView, PlainMessageView} = require 'atom-message-panel'
 transformime = require 'transformime'
 
-KernelManager = require './kernel-manager'
+module.exports =
+class Inspector
+    constructor: (@kernelManager) ->
+        @editor = atom.workspace.getActiveTextEditor()
 
-module.exports = Inspector =
     inspect: ->
         @editor = atom.workspace.getActiveTextEditor()
         grammar = @editor.getGrammar()
-        grammarLanguage = KernelManager.getGrammarLanguageFor grammar
-        kernel = KernelManager.getRunningKernelFor grammarLanguage
+        grammarLanguage = @kernelManager.getGrammarLanguageFor grammar
+        kernel = @kernelManager.getRunningKernelFor grammarLanguage
         unless kernel?
-            atom.notifications.addInfo "No kernel running!"
+            atom.notifications.addInfo 'No kernel running!'
             @inspector?.close()
             return
 
@@ -23,22 +25,22 @@ module.exports = Inspector =
                 onInspectResult = ({mimetype, el}) =>
                     lines = el.innerHTML.split('\n')
                     firstline = lines[0]
-                    lines.splice(0,1)
+                    lines.splice(0, 1)
                     message = lines.join('\n')
                     @getInspector()
                     @addInspectResult(firstline, message)
 
                 onError = (error) ->
-                    console.error "Inspector: Rendering error:", error
+                    console.error 'Inspector: Rendering error:', error
 
                 transform(result.data).then onInspectResult, onError
 
             else
-                atom.notifications.addInfo "No introspection available!"
+                atom.notifications.addInfo 'No introspection available!'
                 @inspector?.close()
 
     getCodeToInspect: ->
-        if @editor.getSelectedText() != ''
+        if @editor.getSelectedText()
             code = @editor.getSelectedText()
             cursor_pos = code.length
         else
@@ -50,7 +52,7 @@ module.exports = Inspector =
 
     getInspector: ->
         if not @inspector?
-            console.log "Opening Inspector"
+            console.log 'Opening Inspector'
             @inspector = new MessagePanelView
                 title: 'Hydrogen Inspector'
         else

--- a/lib/inspector.coffee
+++ b/lib/inspector.coffee
@@ -9,8 +9,8 @@ class Inspector
     inspect: ->
         @editor = atom.workspace.getActiveTextEditor()
         grammar = @editor.getGrammar()
-        grammarLanguage = @kernelManager.getGrammarLanguageFor grammar
-        kernel = @kernelManager.getRunningKernelFor grammarLanguage
+        language = @kernelManager.getLanguageFor grammar
+        kernel = @kernelManager.getRunningKernelFor language
         unless kernel?
             atom.notifications.addInfo 'No kernel running!'
             @inspector?.close()

--- a/lib/kernel-manager.coffee
+++ b/lib/kernel-manager.coffee
@@ -18,19 +18,19 @@ class KernelManager
 
 
     destroyRunningKernel: (kernel) ->
-        delete @_runningKernels[kernel.kernelSpec.grammarLanguage]
+        delete @_runningKernels[kernel.kernelSpec.language]
         kernel.destroy()
 
 
     startKernelFor: (grammar, onStarted) ->
-        grammarLanguage = @getGrammarLanguageFor grammar
+        language = @getLanguageFor grammar
 
-        console.log 'startKernelFor:', grammarLanguage
+        console.log 'startKernelFor:', language
 
-        kernelSpec = @getKernelSpecFor grammarLanguage
+        kernelSpec = @getKernelSpecFor language
 
         unless kernelSpec?
-            message = "No kernel for language `#{grammarLanguage}` found"
+            message = "No kernel for language `#{language}` found"
             options =
                 detail: 'Check that the language for this file is set in Atom
                          and that you have a Jupyter kernel installed for it.'
@@ -41,15 +41,15 @@ class KernelManager
 
 
     startKernel: (kernelSpec, grammar, onStarted) ->
-        grammarLanguage = @getGrammarLanguageFor grammar
+        language = @getLanguageFor grammar
 
-        kernelSpec.grammarLanguage = grammarLanguage
+        kernelSpec.language = language
 
         rootDirectory = atom.project.rootDirectories[0].path
         connectionFile = path.join rootDirectory, 'hydrogen', 'connection.json'
 
         finishKernelStartup = (kernel) =>
-            @_runningKernels[grammarLanguage] = kernel
+            @_runningKernels[language] = kernel
 
             startupCode = Config.getJson('startupCode')[kernelSpec.display_name]
             if startupCode?
@@ -82,11 +82,11 @@ class KernelManager
         return _.clone @_runningKernels
 
 
-    getRunningKernelFor: (grammarLanguage) ->
-        return @_runningKernels[grammarLanguage]
+    getRunningKernelFor: (language) ->
+        return @_runningKernels[language]
 
 
-    getGrammarLanguageFor: (grammar) ->
+    getLanguageFor: (grammar) ->
         return grammar?.name.toLowerCase()
 
 
@@ -95,38 +95,38 @@ class KernelManager
         return kernelSpecs
 
 
-    getAllKernelSpecsFor: (grammarLanguage) ->
-        unless grammarLanguage?
+    getAllKernelSpecsFor: (language) ->
+        unless language?
             return []
 
         kernelSpecs = @getAllKernelSpecs().filter (spec) =>
-            @kernelSpecProvidesLanguage spec, grammarLanguage
+            @kernelSpecProvidesLanguage spec, language
 
         return kernelSpecs
 
 
-    getKernelSpecFor: (grammarLanguage) ->
-        unless grammarLanguage?
+    getKernelSpecFor: (language) ->
+        unless language?
             return null
 
-        kernelMapping = Config.getJson('kernelMappings')?[grammarLanguage]
+        kernelMapping = Config.getJson('kernelMappings')?[language]
         if kernelMapping?
             kernelSpecs = @getAllKernelSpecs().filter (spec) ->
                 return spec.display_name is kernelMapping
         else
-            kernelSpecs = @getAllKernelSpecsFor grammarLanguage
+            kernelSpecs = @getAllKernelSpecsFor language
 
         return kernelSpecs[0]
 
 
-    kernelSpecProvidesLanguage: (kernelSpec, grammarLanguage) ->
+    kernelSpecProvidesLanguage: (kernelSpec, language) ->
         kernelLanguage = kernelSpec.language
         mappedLanguage = Config.getJson('languageMappings')[kernelLanguage]
 
         if mappedLanguage
-            return mappedLanguage is grammarLanguage
+            return mappedLanguage is language
 
-        return kernelLanguage.toLowerCase() is grammarLanguage
+        return kernelLanguage.toLowerCase() is language
 
 
     parseKernelSpecSettings: ->
@@ -192,7 +192,7 @@ class KernelManager
 
 
     setKernelMapping: (kernel, grammar) ->
-        language = @getGrammarLanguageFor grammar
+        language = @getLanguageFor grammar
 
         mapping = {}
         mapping[language] = kernel.display_name

--- a/lib/kernel-manager.coffee
+++ b/lib/kernel-manager.coffee
@@ -7,8 +7,126 @@ Config = require './config'
 ConfigManager = require './config-manager'
 Kernel = require './kernel'
 
-module.exports = KernelManager =
-    _runningKernels: {}
+module.exports =
+class KernelManager
+    constructor: ->
+        @_runningKernels = {}
+
+
+    destroy: ->
+        _.forEach @_runningKernels, (kernel) => @destroyRunningKernel kernel
+
+
+    destroyRunningKernel: (kernel) ->
+        delete @_runningKernels[kernel.kernelSpec.grammarLanguage]
+        kernel.destroy()
+
+
+    startKernelFor: (grammar, onStarted) ->
+        grammarLanguage = @getGrammarLanguageFor grammar
+
+        console.log 'startKernelFor:', grammarLanguage
+
+        kernelSpec = @getKernelSpecFor grammarLanguage
+
+        unless kernelSpec?
+            message = "No kernel for language `#{grammarLanguage}` found"
+            options =
+                detail: 'Check that the language for this file is set in Atom
+                         and that you have a Jupyter kernel installed for it.'
+            atom.notifications.addError message, options
+            return
+
+        @startKernel kernelSpec, grammar, onStarted
+
+
+    startKernel: (kernelSpec, grammar, onStarted) ->
+        grammarLanguage = @getGrammarLanguageFor grammar
+
+        kernelSpec.grammarLanguage = grammarLanguage
+
+        rootDirectory = atom.project.rootDirectories[0].path
+        connectionFile = path.join rootDirectory, 'hydrogen', 'connection.json'
+
+        finishKernelStartup = (kernel) =>
+            @_runningKernels[grammarLanguage] = kernel
+
+            startupCode = Config.getJson('startupCode')[kernelSpec.display_name]
+            if startupCode?
+                console.log 'executing startup code'
+                startupCode = startupCode + ' \n'
+                kernel.execute startupCode
+
+            onStarted?(kernel)
+
+        try
+            data = fs.readFileSync connectionFile, 'utf8'
+            config = JSON.parse data
+            console.log 'KernelManager: Using connection file: ', connectionFile
+            kernel = new Kernel(
+                kernelSpec, grammar, config, connectionFile, true
+            )
+            finishKernelStartup kernel
+
+        catch e
+            unless e.code is 'ENOENT'
+                throw e
+            ConfigManager.writeConfigFile (filepath, config) ->
+                kernel = new Kernel(
+                    kernelSpec, grammar, config, filepath, onlyConnect = false
+                )
+                finishKernelStartup kernel
+
+
+    getAllRunningKernels: ->
+        return _.clone @_runningKernels
+
+
+    getRunningKernelFor: (grammarLanguage) ->
+        return @_runningKernels[grammarLanguage]
+
+
+    getGrammarLanguageFor: (grammar) ->
+        return grammar?.name.toLowerCase()
+
+
+    getAllKernelSpecs: ->
+        kernelSpecs = _.map @parseKernelSpecSettings(), 'spec'
+        return kernelSpecs
+
+
+    getAllKernelSpecsFor: (grammarLanguage) ->
+        unless grammarLanguage?
+            return []
+
+        kernelSpecs = @getAllKernelSpecs().filter (spec) =>
+            @kernelSpecProvidesLanguage spec, grammarLanguage
+
+        return kernelSpecs
+
+
+    getKernelSpecFor: (grammarLanguage) ->
+        unless grammarLanguage?
+            return null
+
+        kernelMapping = Config.getJson('kernelMappings')?[grammarLanguage]
+        if kernelMapping?
+            kernelSpecs = @getAllKernelSpecs().filter (spec) ->
+                return spec.display_name is kernelMapping
+        else
+            kernelSpecs = @getAllKernelSpecsFor grammarLanguage
+
+        return kernelSpecs[0]
+
+
+    kernelSpecProvidesLanguage: (kernelSpec, grammarLanguage) ->
+        kernelLanguage = kernelSpec.language
+        mappedLanguage = Config.getJson('languageMappings')[kernelLanguage]
+
+        if mappedLanguage
+            return mappedLanguage is grammarLanguage
+
+        return kernelLanguage.toLowerCase() is grammarLanguage
 
 
     parseKernelSpecSettings: ->
@@ -21,10 +139,6 @@ module.exports = KernelManager =
         return _.pickBy settings.kernelspecs, ({spec}) ->
             return spec?.language and spec.display_name and spec.argv
 
-    setKernelMapping: (kernel, grammar) ->
-        mapping = {}
-        mapping[@getGrammarLanguageFor grammar] = kernel.display_name
-        Config.setJson 'kernelMappings', mapping, true
 
     saveKernelSpecs: (jsonString) ->
         console.log 'saveKernelSpecs:', jsonString
@@ -77,115 +191,10 @@ module.exports = KernelManager =
                     err
 
 
-    getGrammarLanguageFor: (grammar) ->
-        return grammar?.name.toLowerCase()
+    setKernelMapping: (kernel, grammar) ->
+        language = @getGrammarLanguageFor grammar
 
+        mapping = {}
+        mapping[language] = kernel.display_name
 
-    kernelSpecProvidesGrammarLanguage: (kernelSpec, grammarLanguage) ->
-        kernelLanguage = kernelSpec.language
-        mappedLanguage = Config.getJson('languageMappings')[kernelLanguage]
-
-        if mappedLanguage
-            return mappedLanguage is grammarLanguage
-
-        return kernelLanguage.toLowerCase() is grammarLanguage
-
-
-    getAllKernelSpecs: ->
-        kernelSpecs = _.map @parseKernelSpecSettings(), 'spec'
-        return kernelSpecs
-
-
-    getAllKernelSpecsFor: (grammarLanguage) ->
-        unless grammarLanguage?
-            return []
-
-        kernelSpecs = @getAllKernelSpecs().filter (spec) =>
-            return @kernelSpecProvidesGrammarLanguage spec, grammarLanguage
-
-        return kernelSpecs
-
-
-    getKernelSpecFor: (grammarLanguage) ->
-        unless grammarLanguage?
-            return null
-
-        kernelMapping = Config.getJson('kernelMappings')?[grammarLanguage]
-        if kernelMapping?
-            kernelSpecs = @getAllKernelSpecs().filter (spec) ->
-                return spec.display_name is kernelMapping
-        else
-            kernelSpecs = @getAllKernelSpecsFor grammarLanguage
-
-        return kernelSpecs[0]
-
-
-    getAllRunningKernels: ->
-        return _.clone(@_runningKernels)
-
-
-    getRunningKernelFor: (grammarLanguage) ->
-        return @_runningKernels[grammarLanguage]
-
-
-    startKernelFor: (grammar, onStarted) ->
-        grammarLanguage = KernelManager.getGrammarLanguageFor grammar
-
-        console.log 'startKernelFor:', grammarLanguage
-
-        kernelSpec = @getKernelSpecFor grammarLanguage
-
-        unless kernelSpec?
-            message = "No kernel for language `#{grammarLanguage}` found"
-            options =
-                detail: 'Check that the language for this file is set in Atom
-                         and that you have a Jupyter kernel installed for it.'
-            atom.notifications.addError message, options
-            return
-
-        @startKernel kernelSpec, grammar, onStarted
-
-
-    startKernel: (kernelSpec, grammar, onStarted) ->
-        grammarLanguage = KernelManager.getGrammarLanguageFor grammar
-
-        kernelSpec.grammarLanguage = grammarLanguage
-
-        customKernelConnectionPath = path.join atom.project.rootDirectories[0].path, 'hydrogen', 'connection.json'
-
-        finishKernelStartup = (kernel) =>
-            @_runningKernels[grammarLanguage] = kernel
-
-            startupCode = Config.getJson('startupCode')[kernelSpec.display_name]
-            if startupCode?
-                console.log 'executing startup code'
-                startupCode = startupCode + ' \n'
-                kernel.execute startupCode
-
-            onStarted?(kernel)
-
-        try
-            data = fs.readFileSync customKernelConnectionPath, 'utf8'
-            config = JSON.parse data
-            console.log "Using custom kernel connection: ", customKernelConnectionPath
-            kernel = new Kernel kernelSpec, grammar, config, customKernelConnectionPath, true
-            finishKernelStartup kernel
-        catch e
-            if e.code != 'ENOENT'
-                trow e
-            console.log(e)
-            ConfigManager.writeConfigFile (filepath, config) ->
-                kernel = new Kernel kernelSpec, grammar, config, filepath, onlyConnect=false
-                finishKernelStartup kernel
-
-
-
-
-
-    destroyRunningKernel: (kernel) ->
-        delete @_runningKernels[kernel.kernelSpec.grammarLanguage]
-        kernel.destroy()
-
-
-    destroy: ->
-        _.forEach @_runningKernels, (kernel) -> kernel.destroy()
+        Config.setJson 'kernelMappings', mapping, true

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -102,7 +102,7 @@ module.exports = Hydrogen =
         unless grammar
             grammar = @editor.getGrammar()
         unless language
-            language = @kernelManager.getGrammarLanguageFor grammar
+            language = @kernelManager.getLanguageFor grammar
         unless kernel
             kernel = @kernelManager.getRunningKernelFor language
 
@@ -127,7 +127,7 @@ module.exports = Hydrogen =
 
     getCurrentKernel: ->
         grammar = @editor.getGrammar()
-        language = @kernelManager.getGrammarLanguageFor grammar
+        language = @kernelManager.getLanguageFor grammar
         kernel = @kernelManager.getRunningKernelFor language
 
         return {grammar, language, kernel}
@@ -346,7 +346,7 @@ module.exports = Hydrogen =
         unless @kernelPicker?
             @kernelPicker = new KernelPicker =>
                 grammar = @editor.getGrammar()
-                language = @kernelManager.getGrammarLanguageFor grammar
+                language = @kernelManager.getLanguageFor grammar
                 kernelSpecs = @kernelManager.getAllKernelSpecsFor language
                 return kernelSpecs
             @kernelPicker.onConfirmed = ({kernelSpec}) =>

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -2,30 +2,41 @@
 
 _ = require 'lodash'
 
+ResultView = require './result-view'
+SignalListView = require './signal-list-view'
+KernelPicker = require './kernel-picker'
+CellManager = require './cell-manager'
 
 Config = require './config'
 KernelManager = require './kernel-manager'
-ResultView = require './result-view'
-SignalListView = require './signal-list-view'
-WatchSidebar = require './watch-sidebar'
-KernelPicker = require './kernel-picker'
-AutocompleteProvider = require './autocomplete-provider'
 Inspector = require './inspector'
-CellManager = require './cell-manager'
+AutocompleteProvider = require './autocomplete-provider'
 
 module.exports = Hydrogen =
     config: Config.schema
-
     subscriptions: null
+
+    kernelManager: null
+    inspector: null
+
+    editor: null
+    markerBubbleMap: null
 
     statusBarElement: null
     statusBarTile: null
 
-    editor: null
-
-    markerBubbleMap: {}
-
     activate: (state) ->
+        @kernelManager = new KernelManager()
+        @inspector = new Inspector @kernelManager
+
+        @editor = atom.workspace.getActiveTextEditor()
+        @markerBubbleMap = {}
+
+        @statusBarElement = document.createElement('div')
+        @statusBarElement.classList.add('hydrogen')
+        @statusBarElement.classList.add('status-container')
+        @statusBarElement.onclick = @showKernelCommands.bind @
+
         @subscriptions = new CompositeDisposable
 
         @subscriptions.add atom.commands.add 'atom-text-editor',
@@ -40,8 +51,8 @@ module.exports = Hydrogen =
             'hydrogen:select-kernel': => @showKernelPicker()
             'hydrogen:add-watch': => @watchSidebar.addWatchFromEditor()
             'hydrogen:remove-watch': => @watchSidebar.removeWatch()
-            'hydrogen:update-kernels': -> KernelManager.updateKernelSpecs()
-            'hydrogen:inspect': -> Inspector.inspect()
+            'hydrogen:update-kernels': => @kernelManager.updateKernelSpecs()
+            'hydrogen:inspect': => @inspector.inspect()
             'hydrogen:interrupt-kernel': =>
                 @handleKernelCommand command: 'interrupt-kernel'
             'hydrogen:restart-kernel': =>
@@ -49,27 +60,21 @@ module.exports = Hydrogen =
 
         @subscriptions.add atom.commands.add 'atom-workspace',
             'hydrogen:clear-results': => @clearResultBubbles()
-            'hydrogen:toggle-inspector-size': -> Inspector.toggleInspectorSize()
-            'hydrogen:close-inspector': -> Inspector.closeInspector()
-
-        @statusBarElement = document.createElement('div')
-        @statusBarElement.classList.add('hydrogen')
-        @statusBarElement.classList.add('status-container')
-        @statusBarElement.onclick = @showKernelCommands.bind @
-
-        @editor = atom.workspace.getActiveTextEditor()
+            'hydrogen:toggle-inspector-size': =>
+                @inspector.toggleInspectorSize()
+            'hydrogen:close-inspector': => @inspector.closeInspector()
 
         @subscriptions.add atom.workspace.observeActivePaneItem (item) =>
             if item and item is atom.workspace.getActiveTextEditor()
                 @editor = item
                 @setStatusBarElement()
 
-        KernelManager.updateKernelSpecs()
+        @kernelManager.updateKernelSpecs()
 
 
     deactivate: ->
         @subscriptions.dispose()
-        KernelManager.destroy()
+        @kernelManager.destroy()
         @statusBarTile.destroy()
 
 
@@ -80,12 +85,12 @@ module.exports = Hydrogen =
 
     provide: ->
         if atom.config.get('Hydrogen.autocomplete') is true
-            return AutocompleteProvider
+            return AutocompleteProvider @kernelManager
 
 
     showKernelCommands: ->
         unless @signalListView?
-            @signalListView = new SignalListView()
+            @signalListView = new SignalListView @kernelManager
             @signalListView.onConfirmed = (kernelCommand) =>
                 @handleKernelCommand kernelCommand
         @signalListView.toggle()
@@ -97,33 +102,33 @@ module.exports = Hydrogen =
         unless grammar
             grammar = @editor.getGrammar()
         unless language
-            language = KernelManager.getGrammarLanguageFor grammar
+            language = @kernelManager.getGrammarLanguageFor grammar
         unless kernel
-            kernel = KernelManager.getRunningKernelFor language
+            kernel = @kernelManager.getRunningKernelFor language
 
         if command is 'interrupt-kernel'
             kernel.interrupt()
 
         else if command is 'restart-kernel'
-            KernelManager.destroyRunningKernel kernel
+            @kernelManager.destroyRunningKernel kernel
             @clearResultBubbles()
-            KernelManager.startKernelFor grammar, =>
+            @kernelManager.startKernelFor grammar, =>
                 @setStatusBarElement()
 
         else if command is 'switch-kernel'
-            kernel = KernelManager.getRunningKernelFor language
+            kernel = @kernelManager.getRunningKernelFor language
             if kernel
-                KernelManager.destroyRunningKernel kernel
+                @kernelManager.destroyRunningKernel kernel
             @clearResultBubbles()
-            KernelManager.setKernelMapping kernelSpec, grammar
-            KernelManager.startKernel kernelSpec, grammar, =>
+            @kernelManager.setKernelMapping kernelSpec, grammar
+            @kernelManager.startKernel kernelSpec, grammar, =>
                 @setStatusBarElement()
 
 
     getCurrentKernel: ->
         grammar = @editor.getGrammar()
-        language = KernelManager.getGrammarLanguageFor grammar
-        kernel = KernelManager.getRunningKernelFor language
+        language = @kernelManager.getGrammarLanguageFor grammar
+        kernel = @kernelManager.getRunningKernelFor language
 
         return {grammar, language, kernel}
 
@@ -135,7 +140,7 @@ module.exports = Hydrogen =
             @_createResultBubble kernel, code, row
             return
 
-        KernelManager.startKernelFor grammar, (kernel) =>
+        @kernelManager.startKernelFor grammar, (kernel) =>
             @setStatusBarElement()
             @_createResultBubble kernel, code, row
 
@@ -341,8 +346,9 @@ module.exports = Hydrogen =
         unless @kernelPicker?
             @kernelPicker = new KernelPicker =>
                 grammar = @editor.getGrammar()
-                language = KernelManager.getGrammarLanguageFor grammar
-                return KernelManager.getAllKernelSpecsFor language
+                language = @kernelManager.getGrammarLanguageFor grammar
+                kernelSpecs = @kernelManager.getAllKernelSpecsFor language
+                return kernelSpecs
             @kernelPicker.onConfirmed = ({kernelSpec}) =>
                 @handleKernelCommand
                     command: 'switch-kernel'
@@ -352,10 +358,18 @@ module.exports = Hydrogen =
 
     showWatchKernelPicker: ->
         unless @watchKernelPicker?
-            @watchKernelPicker = new KernelPicker ->
-                KernelManager.getAllRunningKernels()
+            @watchKernelPicker = new KernelPicker =>
+                kernels = @kernelManager.getAllRunningKernels()
+                kernelSpecs = _.map kernels, 'kernelSpec'
+                return kernelSpecs
             @watchKernelPicker.onConfirmed = (command) =>
-                @setWatchSidebar command.kernel.watchSidebar
+                kernelSpec = command.kernelSpec
+                kernels = _.filter @kernelManager.getAllRunningKernels(), (k) ->
+                    k.kernelSpec is kernelSpec
+                kernel = kernels[0]
+                if kernel
+                    @setWatchSidebar kernel.watchSidebar
+                    @watchSidebar.show()
         @watchKernelPicker.toggle()
 
     findCodeBlock: (runAllAbove = false) ->

--- a/lib/signal-list-view.coffee
+++ b/lib/signal-list-view.coffee
@@ -39,7 +39,7 @@ class SignalListView extends SelectListView
         @panel ?= atom.workspace.addModalPanel item: @
         @focusFilterEditor()
         grammar = @editor.getGrammar()
-        grammarLanguage = @kernelManager.getGrammarLanguageFor grammar
+        grammarLanguage = @kernelManager.getLanguageFor grammar
 
         # disable all commands if no kernel is running
         kernel = @kernelManager.getRunningKernelFor grammarLanguage

--- a/lib/signal-list-view.coffee
+++ b/lib/signal-list-view.coffee
@@ -1,12 +1,10 @@
 {SelectListView} = require 'atom-space-pen-views'
 _ = require 'lodash'
 
-KernelManager = require './kernel-manager'
-
 # View to display a list of grammars to apply to the current editor.
 module.exports =
 class SignalListView extends SelectListView
-    initialize: ->
+    initialize: (@kernelManager) ->
         super
 
         @basicCommands = [
@@ -41,10 +39,10 @@ class SignalListView extends SelectListView
         @panel ?= atom.workspace.addModalPanel item: @
         @focusFilterEditor()
         grammar = @editor.getGrammar()
-        grammarLanguage = KernelManager.getGrammarLanguageFor grammar
+        grammarLanguage = @kernelManager.getGrammarLanguageFor grammar
 
         # disable all commands if no kernel is running
-        kernel = KernelManager.getRunningKernelFor grammarLanguage
+        kernel = @kernelManager.getRunningKernelFor grammarLanguage
         unless kernel?
             return @setItems []
 
@@ -59,7 +57,7 @@ class SignalListView extends SelectListView
             }
 
         # add commands to switch to other kernels
-        kernelSpecs = KernelManager.getAllKernelSpecsFor grammarLanguage
+        kernelSpecs = @kernelManager.getAllKernelSpecsFor grammarLanguage
 
         switchCommands = kernelSpecs.map (spec) ->
             spec.grammarLanguage = grammarLanguage

--- a/lib/watch-sidebar.coffee
+++ b/lib/watch-sidebar.coffee
@@ -8,9 +8,6 @@ WatchesPicker = require './watches-picker'
 module.exports =
 class WatchSidebar
     constructor: (@kernel) ->
-        KernelManager = require './kernel-manager'
-        @language = KernelManager.getGrammarLanguageFor @kernel.grammar
-
         @element = document.createElement('div')
         @element.classList.add('hydrogen', 'watch-sidebar')
 
@@ -19,7 +16,7 @@ class WatchSidebar
 
         languageDisplay = document.createElement('button')
         languageDisplay.classList.add('btn', 'icon', 'icon-sync')
-        languageDisplay.innerText = "Watch: #{@language}"
+        languageDisplay.innerText = "Watch: #{@kernel.kernelSpec.display_name}"
         languageDisplay.onclick = ->
             editor = atom.workspace.getActiveTextEditor()
             editorView = atom.views.getView(editor)

--- a/spec/hydrogen-spec.coffee
+++ b/spec/hydrogen-spec.coffee
@@ -187,7 +187,7 @@ describe "Kernel manager", ->
 
     it "should read lower case name from grammar", ->
         grammar = atom.grammars.getGrammars()[0]
-        expect(KernelManager::getGrammarLanguageFor grammar).toEqual("null grammar")
+        expect(KernelManager::getLanguageFor grammar).toEqual("null grammar")
 
     it "should update kernelspecs", ->
         KernelManager::updateKernelSpecs()

--- a/spec/hydrogen-spec.coffee
+++ b/spec/hydrogen-spec.coffee
@@ -114,35 +114,35 @@ describe "Kernel manager", ->
         it "should parse kernelspecs from settings", ->
             atom.config.set "Hydrogen.kernelspec", firstKernelSpecString
 
-            parsed = KernelManager.parseKernelSpecSettings()
+            parsed = KernelManager::parseKernelSpecSettings()
 
             expect(parsed).toEqual(firstKernelSpec.kernelspecs)
 
         it "should return {} if no kernelspec is set", ->
-            expect(KernelManager.parseKernelSpecSettings()).toEqual({})
+            expect(KernelManager::parseKernelSpecSettings()).toEqual({})
 
         it "should return {} if invalid kernelspec is set", ->
             atom.config.set "Hydrogen.kernelspec", "invalid"
-            expect(KernelManager.parseKernelSpecSettings()).toEqual({})
+            expect(KernelManager::parseKernelSpecSettings()).toEqual({})
 
     describe "saveKernelSpecs", ->
         it "should not write invalid json strings to settings", ->
-            KernelManager.saveKernelSpecs("invalid")
+            KernelManager::saveKernelSpecs("invalid")
             expect(atom.config.get "Hydrogen.kernelspec").toEqual("")
 
         it "should not write invalid kernelspecs to json", ->
-            KernelManager.saveKernelSpecs('{"invalid": "kernel"}')
+            KernelManager::saveKernelSpecs('{"invalid": "kernel"}')
             expect(atom.config.get "Hydrogen.kernelspec").toEqual("")
 
         it "should save kernelspecs to settings", ->
-            KernelManager.saveKernelSpecs(firstKernelSpecString)
+            KernelManager::saveKernelSpecs(firstKernelSpecString)
 
             config = JSON.parse atom.config.get "Hydrogen.kernelspec"
             expect(config).toEqual(firstKernelSpec)
 
         it "should add kernelspecs to settings", ->
             atom.config.set "Hydrogen.kernelspec", firstKernelSpecString
-            KernelManager.saveKernelSpecs(secondKernelSpecString)
+            KernelManager::saveKernelSpecs(secondKernelSpecString)
             config = JSON.parse atom.config.get "Hydrogen.kernelspec"
 
             expect(config.kernelspecs.ijavascript).toEqual(firstKernelSpec.kernelspecs.ijavascript)
@@ -151,7 +151,7 @@ describe "Kernel manager", ->
     describe "getAllKernelSpecs", ->
         it "should return an array with specs", ->
             atom.config.set "Hydrogen.kernelspec", JSON.stringify kernelSpecs
-            allKernelSpecs = KernelManager.getAllKernelSpecs()
+            allKernelSpecs = KernelManager::getAllKernelSpecs()
 
             expect(allKernelSpecs.length).toEqual(2)
             expect(allKernelSpecs[0]).toEqual(kernelSpecs.kernelspecs.ijavascript.spec)
@@ -160,37 +160,37 @@ describe "Kernel manager", ->
     describe "getAllKernelSpecsFor", ->
         it "should return an array with specs for given language", ->
             atom.config.set "Hydrogen.kernelspec", JSON.stringify kernelSpecs
-            allKernelSpecsForPython = KernelManager.getAllKernelSpecsFor("python")
+            allKernelSpecsForPython = KernelManager::getAllKernelSpecsFor("python")
 
             expect(allKernelSpecsForPython.length).toEqual(1)
             expect(allKernelSpecsForPython[0]).toEqual(kernelSpecs.kernelspecs.python2.spec)
 
         it "should return an empty array", ->
             atom.config.set "Hydrogen.kernelspec", JSON.stringify kernelSpecs
-            allKernelSpecsForJulia = KernelManager.getAllKernelSpecsFor("julia")
+            allKernelSpecsForJulia = KernelManager::getAllKernelSpecsFor("julia")
 
             expect(allKernelSpecsForJulia).toEqual([])
 
     describe "getKernelSpecFor", ->
         it "should return spec for given language", ->
             atom.config.set "Hydrogen.kernelspec", JSON.stringify kernelSpecs
-            kernelSpecForPython = KernelManager.getKernelSpecFor("python")
+            kernelSpecForPython = KernelManager::getKernelSpecFor("python")
 
             console.log kernelSpecForPython
             expect(kernelSpecForPython).toEqual(kernelSpecs.kernelspecs.python2.spec)
 
         it "should return undefined", ->
             atom.config.set "Hydrogen.kernelspec", JSON.stringify kernelSpecs
-            kernelSpecForJulia = KernelManager.getKernelSpecFor("julia")
+            kernelSpecForJulia = KernelManager::getKernelSpecFor("julia")
 
             expect(kernelSpecForJulia).toBeUndefined()
 
     it "should read lower case name from grammar", ->
         grammar = atom.grammars.getGrammars()[0]
-        expect(KernelManager.getGrammarLanguageFor grammar).toEqual("null grammar")
+        expect(KernelManager::getGrammarLanguageFor grammar).toEqual("null grammar")
 
     it "should update kernelspecs", ->
-        KernelManager.updateKernelSpecs()
+        KernelManager::updateKernelSpecs()
 
         waits(3000)
         runs ->


### PR DESCRIPTION
Originally, `KernelManager` was implemented using a global plain object.

This PR refactors `KernelManager` as a class so that `coffeelint` can check the use of arrows more reliably.

This PR replaces the use of the global object `KernelManager` by an instance of `KernelManager`, which is passed to wherever this object was used. This means that:
- the function that creates `AutocompleteProvider` now takes an instance of `KernelManager` as an argument;
- `SignalListView` takes an instance of `KernelManager` in the constructor;
- `Inspector` had to be converted into a class with a constructor that takes an instance of `KernelManager`;
- ...

I've also taken this opportunity to simplify the naming in `KernelManager`. Now there is only one type of language: that obtained using `KernelManager::getLanguageFor(grammar)`.

I've also fixed a  bug in `hydrogen:select-watch-kernel`.

I've tested this PR running simultaneously multiple kernels and watches and haven't found any problems.

---

TODO for  another PR: 
- There are two files, `main.coffee` and `autocomplete-provide.coffee` that still use '@' with plain objects.
- Update spec to use an instance of `KernelManager` instead of the `KernelManager::` hack.