### PR TITLE
Don't save kernelspecs to settings

### DIFF
--- a/lib/kernel-manager.coffee
+++ b/lib/kernel-manager.coffee
@@ -165,6 +165,7 @@ class KernelManager
                     dismissable: true
                 atom.notifications.addError message, options
             else
+                err = null
                 message = 'Hydrogen Kernels updated:'
                 options =
                     detail: (_.map @_kernelSpecs, 'spec.display_name').join('\n')

--- a/lib/kernel-manager.coffee
+++ b/lib/kernel-manager.coffee
@@ -11,6 +11,7 @@ module.exports =
 class KernelManager
     constructor: ->
         @_runningKernels = {}
+        @_kernelSpecs = []
 
 
     destroy: ->
@@ -91,8 +92,7 @@ class KernelManager
 
 
     getAllKernelSpecs: ->
-        kernelSpecs = _.map @parseKernelSpecSettings(), 'spec'
-        return kernelSpecs
+        return _.clone @_kernelSpecs
 
 
     getAllKernelSpecsFor: (language) ->
@@ -162,10 +162,10 @@ class KernelManager
         kernelSpecs = @parseKernelSpecSettings()
         _.assign kernelSpecs, newKernelSpecs
 
-        Config.setJson 'kernelspec', kernelspecs: kernelSpecs
+        @_kernelSpecs = _.map kernelSpecs, 'spec'
 
         message = 'Hydrogen Kernels updated:'
-        options = detail: (_.map kernelSpecs, 'spec.display_name').join('\n')
+        options = detail: (_.map @_kernelSpecs, 'display_name').join('\n')
         atom.notifications.addInfo message, options
 
 

--- a/lib/kernel-manager.coffee
+++ b/lib/kernel-manager.coffee
@@ -24,10 +24,15 @@ class KernelManager
 
 
     startKernelFor: (grammar, onStarted) ->
+        if _.isEmpty @_kernelSpecs
+            @updateKernelSpecs =>
+                @_startKernelFor grammar, onStarted
+        else
+            @_startKernelFor grammar, onStarted
+
+
+    _startKernelFor: (grammar, onStarted) ->
         language = @getLanguageFor grammar
-
-        console.log 'startKernelFor:', language
-
         kernelSpec = @getKernelSpecFor language
 
         unless kernelSpec?
@@ -38,6 +43,7 @@ class KernelManager
             atom.notifications.addError message, options
             return
 
+        console.log 'startKernelFor:', language
         @startKernel kernelSpec, grammar, onStarted
 
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -69,8 +69,6 @@ module.exports = Hydrogen =
                 @editor = item
                 @setStatusBarElement()
 
-        @kernelManager.updateKernelSpecs()
-
 
     deactivate: ->
         @subscriptions.dispose()


### PR DESCRIPTION
As discussed in #272.

This PR updates specs to use an instance of `KernelManager` as introduced in #335.
