### PR TITLE
@showKernelPicker: Update kernelspecs if necessary

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -319,7 +319,7 @@ module.exports = Hydrogen =
         else
             @watchSidebar = sidebar
 
-    showKernelPicker: ->
+    _showKernelPicker: ->
         unless @kernelPicker?
             @kernelPicker = new KernelPicker =>
                 grammar = @editor.getGrammar()
@@ -330,8 +330,16 @@ module.exports = Hydrogen =
                 @handleKernelCommand
                     command: 'switch-kernel'
                     kernelSpec: kernelSpec
-
         @kernelPicker.toggle()
+
+
+    showKernelPicker: ->
+        if @kernelManager.getAllKernelSpecs().length is 0
+            @kernelManager.updateKernelSpecs =>
+                @_showKernelPicker()
+        else
+            @_showKernelPicker()
+
 
     showWatchKernelPicker: ->
         unless @watchKernelPicker?


### PR DESCRIPTION
In the future we should make the `getKernelSpecs` functions async as proposed in #330.

But for now I think it's ok to update the kernel specs if an activation command is triggered.