### PR TITLE
Remove kernelMapping setting and handle kernelspecs asynchronous

### DIFF
--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -10,23 +10,11 @@ module.exports = Config =
             atom.notifications.addError message, detail: error
         return _default
 
-    setJson: (key, value, merge=false) ->
-        value = _.merge Config.getJson(key), value if merge
-        atom.config.set "Hydrogen.#{key}", JSON.stringify value
-
     schema:
         autocomplete:
             title: 'Enable Autocomplete'
             type: 'boolean'
             default: true
-        kernelMappings:
-            title: 'Kernel Mappings'
-            description: 'This field is JSON string that maps grammar languages
-            to kernel display names. You can use it, for example, to specify
-            which Python kernel will be started to execute Python code, like
-            this: `{"python":"Python 3"}`'
-            type: 'string'
-            default: '{}'
         kernelNotifications:
             title: 'Enable Kernel Notifications'
             description: 'By default, kernel notifications are only displayed in

--- a/lib/kernel-picker.coffee
+++ b/lib/kernel-picker.coffee
@@ -8,7 +8,6 @@ class SignalListView extends SelectListView
         super
 
         @onConfirmed = null
-        @addClass('watch-language-picker')
         @list.addClass('mark-active')
 
 
@@ -38,13 +37,14 @@ class SignalListView extends SelectListView
         @panel ?= atom.workspace.addModalPanel(item: this)
         @focusFilterEditor()
 
-        @languageOptions = _.map @getKernelSpecs(), (kernelSpec) ->
-            return {
-                name: kernelSpec.display_name
-                kernelSpec: kernelSpec
-            }
+        @getKernelSpecs (kernelSpec) =>
+            @languageOptions = _.map kernelSpec, (kernelSpec) ->
+                return {
+                    name: kernelSpec.display_name
+                    kernelSpec: kernelSpec
+                }
 
-        @setItems(@languageOptions)
+            @setItems(@languageOptions)
 
     getEmptyMessage: ->
         'No running kernels found.'

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -105,9 +105,10 @@ module.exports = Hydrogen =
             kernel.interrupt()
 
         else if command is 'restart-kernel'
+            kernelSpec = kernel.kernelSpec
             @kernelManager.destroyRunningKernel kernel
             @clearResultBubbles()
-            @kernelManager.startKernelFor grammar, =>
+            @kernelManager.startKernel kernelSpec, grammar, =>
                 @setStatusBarElement()
 
         else if command is 'switch-kernel'
@@ -115,7 +116,6 @@ module.exports = Hydrogen =
             if kernel
                 @kernelManager.destroyRunningKernel kernel
             @clearResultBubbles()
-            @kernelManager.setKernelMapping kernelSpec, grammar
             @kernelManager.startKernel kernelSpec, grammar, =>
                 @setStatusBarElement()
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -101,10 +101,18 @@ module.exports = Hydrogen =
         unless kernel
             kernel = @kernelManager.getRunningKernelFor language
 
+        message = "No running kernel for language `#{language}` found"
+
         if command is 'interrupt-kernel'
+            unless kernel
+                atom.notifications.addError message
+                return
             kernel.interrupt()
 
         else if command is 'restart-kernel'
+            unless kernel
+                atom.notifications.addError message
+                return
             kernelSpec = kernel.kernelSpec
             @kernelManager.destroyRunningKernel kernel
             @clearResultBubbles()
@@ -112,7 +120,6 @@ module.exports = Hydrogen =
                 @setStatusBarElement()
 
         else if command is 'switch-kernel'
-            kernel = @kernelManager.getRunningKernelFor language
             if kernel
                 @kernelManager.destroyRunningKernel kernel
             @clearResultBubbles()
@@ -321,24 +328,24 @@ module.exports = Hydrogen =
 
     showKernelPicker: ->
         unless @kernelPicker?
-            @kernelPicker = new KernelPicker =>
+            @kernelPicker = new KernelPicker (callback) =>
                 grammar = @editor.getGrammar()
                 language = @kernelManager.getLanguageFor grammar
-                kernelSpecs = @kernelManager.getAllKernelSpecsFor language
-                return kernelSpecs
+                @kernelManager.getAllKernelSpecsFor language, (kernelSpecs) ->
+                    callback kernelSpecs
             @kernelPicker.onConfirmed = ({kernelSpec}) =>
                 @handleKernelCommand
                     command: 'switch-kernel'
                     kernelSpec: kernelSpec
-
         @kernelPicker.toggle()
+
 
     showWatchKernelPicker: ->
         unless @watchKernelPicker?
-            @watchKernelPicker = new KernelPicker =>
+            @watchKernelPicker = new KernelPicker (callback) =>
                 kernels = @kernelManager.getAllRunningKernels()
                 kernelSpecs = _.map kernels, 'kernelSpec'
-                return kernelSpecs
+                callback kernelSpecs
             @watchKernelPicker.onConfirmed = (command) =>
                 kernelSpec = command.kernelSpec
                 kernels = _.filter @kernelManager.getAllRunningKernels(), (k) ->

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -101,17 +101,17 @@ module.exports = Hydrogen =
         unless kernel
             kernel = @kernelManager.getRunningKernelFor language
 
-        message = "No running kernel for language `#{language}` found"
+        errorMessage = "No running kernel for language `#{language}` found"
 
         if command is 'interrupt-kernel'
             unless kernel
-                atom.notifications.addError message
+                atom.notifications.addError errorMessage
                 return
             kernel.interrupt()
 
         else if command is 'restart-kernel'
             unless kernel
-                atom.notifications.addError message
+                atom.notifications.addError errorMessage
                 return
             kernelSpec = kernel.kernelSpec
             @kernelManager.destroyRunningKernel kernel

--- a/lib/signal-list-view.coffee
+++ b/lib/signal-list-view.coffee
@@ -59,18 +59,17 @@ class SignalListView extends SelectListView
             }
 
         # add commands to switch to other kernels
-        kernelSpecs = @kernelManager.getAllKernelSpecsFor language
+        @kernelManager.getAllKernelSpecsFor language, (kernelSpecs) =>
+            switchCommands = kernelSpecs.map (spec) ->
+                return {
+                    name: 'Switch to ' + spec.display_name
+                    value: 'switch-kernel'
+                    grammar: grammar
+                    language: language
+                    kernelSpec: spec
+                }
 
-        switchCommands = kernelSpecs.map (spec) ->
-            return {
-                name: 'Switch to ' + spec.display_name
-                value: 'switch-kernel'
-                grammar: grammar
-                language: language
-                kernelSpec: spec
-            }
-
-        @setItems _.union basicCommands, switchCommands
+            @setItems _.union basicCommands, switchCommands
 
 
     confirmed: (item) ->

--- a/spec/hydrogen-spec.coffee
+++ b/spec/hydrogen-spec.coffee
@@ -7,10 +7,6 @@ path = require 'path'
 fs = require 'fs'
 
 describe 'Atom config', ->
-    it 'should set config value', ->
-        Config.setJson 'set', 'foo'
-        expect(JSON.parse atom.config.get 'Hydrogen.set').toEqual('foo')
-
     it 'should read config values', ->
         atom.config.set 'Hydrogen.read', JSON.stringify 'bar'
         expect(Config.getJson 'read').toEqual('bar')
@@ -159,17 +155,17 @@ describe 'Kernel manager', ->
             expect(allKernelSpecsForJulia).toEqual([])
 
     describe 'getKernelSpecFor', ->
-        it 'should return spec for given language', ->
+        it 'should return spec for given language', (done) ->
             @kernelManager._kernelSpecs = kernelSpecs.kernelspecs
-            kernelSpecForPython = @kernelManager.getKernelSpecFor('python')
+            @kernelManager.getKernelSpecFor 'python', (kernelSpecForPython) ->
+                expect(kernelSpecForPython).toEqual(kernelSpecs.kernelspecs.python2.spec)
+                done
 
-            expect(kernelSpecForPython).toEqual(kernelSpecs.kernelspecs.python2.spec)
-
-        it 'should return undefined', ->
+        it 'should return undefined', (done) ->
             @kernelManager._kernelSpecs = kernelSpecs.kernelspecs
-            kernelSpecForJulia = @kernelManager.getKernelSpecFor('julia')
-
-            expect(kernelSpecForJulia).toBeUndefined()
+            @kernelManager.getKernelSpecFor 'julia', (kernelSpecForJulia) ->
+                expect(kernelSpecForJulia).toBeUndefined()
+                done
 
     it 'should read lower case name from grammar', ->
         grammar = atom.grammars.getGrammars()[0]

--- a/spec/hydrogen-spec.coffee
+++ b/spec/hydrogen-spec.coffee
@@ -132,27 +132,27 @@ describe 'Kernel manager', ->
             expect(specs).toEqual(kernelSpecs.kernelspecs)
 
     describe 'getAllKernelSpecs', ->
-        it 'should return an array with specs', ->
+        it 'should return an array with specs', (done) ->
             @kernelManager._kernelSpecs = kernelSpecs.kernelspecs
-            specs = @kernelManager.getAllKernelSpecs()
-
-            expect(specs.length).toEqual(2)
-            expect(specs[0]).toEqual(kernelSpecs.kernelspecs.ijavascript.spec)
-            expect(specs[1]).toEqual(kernelSpecs.kernelspecs.python2.spec)
+            @kernelManager.getAllKernelSpecs (specs) ->
+                expect(specs.length).toEqual(2)
+                expect(specs[0]).toEqual(kernelSpecs.kernelspecs.ijavascript.spec)
+                expect(specs[1]).toEqual(kernelSpecs.kernelspecs.python2.spec)
+                done
 
     describe 'getAllKernelSpecsFor', ->
-        it 'should return an array with specs for given language', ->
+        it 'should return an array with specs for given language', (done) ->
             @kernelManager._kernelSpecs = kernelSpecs.kernelspecs
-            allKernelSpecsForPython = @kernelManager.getAllKernelSpecsFor('python')
+            @kernelManager.getAllKernelSpecsFor 'python', (specs) ->
+                expect(specs.length).toEqual(1)
+                expect(specs[0]).toEqual(kernelSpecs.kernelspecs.python2.spec)
+                done
 
-            expect(allKernelSpecsForPython.length).toEqual(1)
-            expect(allKernelSpecsForPython[0]).toEqual(kernelSpecs.kernelspecs.python2.spec)
-
-        it 'should return an empty array', ->
+        it 'should return an empty array', (done) ->
             @kernelManager._kernelSpecs = kernelSpecs.kernelspecs
-            allKernelSpecsForJulia = @kernelManager.getAllKernelSpecsFor('julia')
-
-            expect(allKernelSpecsForJulia).toEqual([])
+            @kernelManager.getAllKernelSpecsFor 'julia', (specs) ->
+                expect(specs).toEqual([])
+                done
 
     describe 'getKernelSpecFor', ->
         it 'should return spec for given language', (done) ->


### PR DESCRIPTION
The first commit removes the `kernelMapping` setting. Instead the user is asked to chose a kernel to start.

The second commit introduces callbacks for all kernel specs handling. In order to update the kernel specs if necessary.

It probably makes sense to review each commit on its own.