### PR TITLE
Remove watch kernel picker

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -54,7 +54,6 @@ module.exports = Hydrogen =
             'hydrogen:run-cell': => @runCell()
             'hydrogen:run-cell-and-move-down': => @runCell(true)
             'hydrogen:toggle-watches': => @toggleWatchSidebar()
-            'hydrogen:select-watch-kernel': => @showWatchKernelPicker()
             'hydrogen:select-kernel': => @showKernelPicker()
             'hydrogen:connect-to-remote-kernel': => @showWSKernelPicker()
             'hydrogen:add-watch': =>
@@ -358,25 +357,6 @@ module.exports = Hydrogen =
                     command: 'switch-kernel'
                     kernelSpec: kernelSpec
         @kernelPicker.toggle()
-
-
-    showWatchKernelPicker: ->
-        unless @watchSidebarIsVisible
-            @toggleWatchSidebar()
-
-        unless @watchKernelPicker?
-            @watchKernelPicker = new KernelPicker (callback) =>
-                kernels = @kernelManager.getAllRunningKernels()
-                kernelSpecs = _.map kernels, 'kernelSpec'
-                callback kernelSpecs
-            @watchKernelPicker.onConfirmed = (command) =>
-                kernelSpec = command.kernelSpec
-                kernels = _.filter @kernelManager.getAllRunningKernels(), (k) ->
-                    k.kernelSpec is kernelSpec
-                kernel = kernels[0]
-                if kernel
-                    @setWatchSidebar kernel
-        @watchKernelPicker.toggle()
 
 
     showWSKernelPicker: ->

--- a/lib/watch-sidebar.coffee
+++ b/lib/watch-sidebar.coffee
@@ -14,13 +14,9 @@ class WatchSidebar
         toolbar = document.createElement('div')
         toolbar.classList.add('toolbar', 'block')
 
-        languageDisplay = document.createElement('button')
-        languageDisplay.classList.add('btn', 'icon', 'icon-sync')
-        languageDisplay.innerText = "Watch: #{@kernel.kernelSpec.display_name}"
-        languageDisplay.onclick = ->
-            editor = atom.workspace.getActiveTextEditor()
-            editorView = atom.views.getView(editor)
-            atom.commands.dispatch(editorView, 'hydrogen:select-watch-kernel')
+        languageDisplay = document.createElement('div')
+        languageDisplay.classList.add('language', 'icon', 'icon-eye')
+        languageDisplay.innerText = @kernel.kernelSpec.display_name
 
         commands = document.createElement('div')
         commands.classList.add('btn-group')
@@ -36,12 +32,9 @@ class WatchSidebar
 
         tooltips = new CompositeDisposable()
         tooltips.add atom.tooltips.add toggleButton,
-            title: 'Toggle Watches'
-        tooltips.add atom.tooltips.add languageDisplay,
-            title: 'Change Watch Kernel'
+            title: 'Toggle Watch Sidebar'
         tooltips.add atom.tooltips.add removeButton,
             title: 'Remove Watch'
-
 
         @watchesContainer = document.createElement('div')
         _.forEach @watchViews, (watch) =>

--- a/styles/hydrogen.less
+++ b/styles/hydrogen.less
@@ -255,7 +255,11 @@
     border-left: 1px solid @base-border-color;
 
     .toolbar {
-        .btn-group{
+        .language {
+            display: inline-block;
+            padding: @component-icon-padding - 1px;
+        }
+        .btn-group {
             float: right;
         }
     }


### PR DESCRIPTION
This functionality is now provided by #366.

The sidebar will now look like this:
<img width="301" alt="watches" src="https://cloud.githubusercontent.com/assets/13285808/17368799/ecdce2cc-5995-11e6-968b-4e498fef933a.png">
