### PR TITLE
Remote kernels: support watches

### DIFF
--- a/lib/kernel.coffee
+++ b/lib/kernel.coffee
@@ -22,6 +22,11 @@ class Kernel
         @watchCallbacks.push(watchCallback)
 
 
+    _callWatchCallbacks: ->
+        @watchCallbacks.forEach (watchCallback) ->
+            watchCallback()
+
+
     interrupt: ->
         throw new Error 'Kernel: interrupt method not implemented'
 

--- a/lib/kernel.coffee
+++ b/lib/kernel.coffee
@@ -11,7 +11,7 @@ WatchSidebar = require './watch-sidebar'
 
 module.exports =
 class Kernel
-    constructor: (@kernelSpec) ->
+    constructor: (@kernelSpec, @grammar) ->
         @watchCallbacks = []
 
         @watchSidebar = new WatchSidebar this

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -351,10 +351,10 @@ module.exports = Hydrogen =
             @wsKernelPicker = new WSKernelPicker (kernel) =>
                 @clearResultBubbles()
 
-                grammar = @editor.getGrammar()
+                grammar = kernel.grammar
                 @kernelManager.destroyRunningKernelFor grammar
 
                 @kernelManager.setRunningKernelFor grammar, kernel
                 @onKernelChanged kernel
 
-        @wsKernelPicker.toggle()
+        @wsKernelPicker.toggle @editor.getGrammar()

--- a/lib/ws-kernel-picker.coffee
+++ b/lib/ws-kernel-picker.coffee
@@ -41,7 +41,8 @@ class WSKernelPicker
     constructor: (onChosen) ->
         @_onChosen = onChosen
 
-    toggle: ->
+    toggle: (grammar) ->
+        @_grammar = grammar
         @_path = atom.workspace.getActiveTextEditor().getPath() + '-' + uuid.v4()
         gatewayListing = new CustomListView('No gateways available', @onGateway.bind this)
         @previouslyFocusedElement = gatewayListing.previouslyFocusedElement
@@ -115,5 +116,5 @@ class WSKernelPicker
 
     onSessionChosen: (session) ->
         session.kernel.getKernelSpec().then (kernelSpec) =>
-            kernel = new WSKernel(kernelSpec, session)
+            kernel = new WSKernel(kernelSpec, @_grammar, session)
             @_onChosen(kernel)

--- a/lib/ws-kernel.coffee
+++ b/lib/ws-kernel.coffee
@@ -9,8 +9,8 @@ Kernel = require './kernel'
 
 module.exports =
 class WSKernel extends Kernel
-    constructor: (kernelSpec, @session) ->
-        super kernelSpec
+    constructor: (kernelSpec, grammar, @session) ->
+        super kernelSpec, grammar
 
         @session.statusChanged.connect => @_onStatusChange()
         @_onStatusChange() # Set initial status correctly

--- a/lib/zmq-kernel.coffee
+++ b/lib/zmq-kernel.coffee
@@ -12,8 +12,8 @@ InputView = require './input-view'
 
 module.exports =
 class ZMQKernel extends Kernel
-    constructor: (kernelSpec, @grammar, @connection, @connectionFile, @kernelProcess) ->
-        super kernelSpec
+    constructor: (kernelSpec, grammar, @connection, @connectionFile, @kernelProcess) ->
+        super kernelSpec, grammar
 
         @executionCallbacks = {}
 

--- a/lib/zmq-kernel.coffee
+++ b/lib/zmq-kernel.coffee
@@ -271,8 +271,7 @@ class ZMQKernel extends Kernel
 
             msg_id = message.parent_header?.msg_id
             if status is 'idle' and msg_id?.startsWith 'execute'
-                @watchCallbacks.forEach (watchCallback) ->
-                    watchCallback()
+                @_callWatchCallbacks()
 
         msg_id = message.parent_header.msg_id
         if msg_id?


### PR DESCRIPTION
Now that I'm back from vacation, it's time to address the backlog of issues in #383 

This PR adds watch support to WSKernel. `kernel.grammar` changes are also here because `WatchView` expects this property to be present.