### PR TITLE
Remote kernels: support shutdown (plus shutdown menu item)

### DIFF
--- a/lib/kernel.coffee
+++ b/lib/kernel.coffee
@@ -31,7 +31,7 @@ class Kernel
         throw new Error 'Kernel: interrupt method not implemented'
 
 
-    shutdown: (restart) ->
+    shutdown: ->
         throw new Error 'Kernel: shutdown method not implemented'
 
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -70,6 +70,8 @@ module.exports = Hydrogen =
                 @handleKernelCommand command: 'interrupt-kernel'
             'hydrogen:restart-kernel': =>
                 @handleKernelCommand command: 'restart-kernel'
+            'hydrogen:shutdown-kernel': =>
+                @handleKernelCommand command: 'shutdown-kernel'
             'hydrogen:copy-path-to-connection-file': =>
                 @copyPathToConnectionFile()
 
@@ -190,6 +192,13 @@ module.exports = Hydrogen =
             @clearResultBubbles()
             @kernelManager.restartRunningKernelFor grammar, (kernel) =>
                 @onKernelChanged kernel
+
+        else if command is 'shutdown-kernel'
+            @clearResultBubbles()
+            # Note that destroy alone does not shut down a WSKernel
+            kernel.shutdown()
+            @kernelManager.destroyRunningKernelFor grammar
+            @onKernelChanged()
 
         else if command is 'switch-kernel'
             @clearResultBubbles()

--- a/lib/signal-list-view.coffee
+++ b/lib/signal-list-view.coffee
@@ -20,6 +20,11 @@ class SignalListView extends SelectListView
                 value: 'restart-kernel'
                 language: null
             },
+            {
+                name: 'Shut Down'
+                value: 'shutdown-kernel'
+                language: null
+            },
         ]
 
         @onConfirmed = null

--- a/lib/ws-kernel.coffee
+++ b/lib/ws-kernel.coffee
@@ -19,8 +19,11 @@ class WSKernel extends Kernel
     interrupt: ->
         @session.kernel.interrupt()
 
+    shutdown: ->
+        return @session.kernel.shutdown()
+
     restart: ->
-        @session.kernel.restart()
+        return @session.kernel.restart()
 
     _onStatusChange: ->
         @statusView.setStatus @session.status


### PR DESCRIPTION
Continuing with the issues listed in #383, this is another (disjoint) set of changes.

The first commit implements the "shut down" method for remote kernels.

The second adds "shut down" to the list of available kernel commands. It's accessible via both the status bar and the atom command list. This is especially useful for remote kernels, because they don't shut down automatically through any other code path (as intended).