### PR TITLE
KernelManager: Don't throw error if existing kernel cannot be started

### DIFF
--- a/lib/kernel-manager.coffee
+++ b/lib/kernel-manager.coffee
@@ -69,7 +69,7 @@ class KernelManager
 
         catch e
             unless e.code is 'ENOENT'
-                throw e
+                console.log 'KernelManager: Cannot start existing kernel:\n', e
 
         language = @getLanguageFor grammar
         @getKernelSpecFor language, (kernelSpec) =>


### PR DESCRIPTION
Fixes #413