### PR TITLE
Add command to copy path to connection file

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -70,6 +70,8 @@ module.exports = Hydrogen =
                 @handleKernelCommand command: 'interrupt-kernel'
             'hydrogen:restart-kernel': =>
                 @handleKernelCommand command: 'restart-kernel'
+            'hydrogen:copy-path-to-connection-file': =>
+                @copyPathToConnectionFile()
 
         @subscriptions.add atom.commands.add 'atom-workspace',
             'hydrogen:clear-results': => @clearResultBubbles()
@@ -358,3 +360,25 @@ module.exports = Hydrogen =
                 @onKernelChanged kernel
 
         @wsKernelPicker.toggle @editor.getGrammar()
+
+
+    copyPathToConnectionFile: ->
+        grammar = @editor.getGrammar()
+        language = @kernelManager.getLanguageFor grammar
+
+        unless @kernel?
+            message = "No running kernel for language `#{language}` found"
+            atom.notifications.addError message
+            return
+
+        connectionFile = @kernel.connectionFile
+        unless connectionFile?
+            atom.notifications.addError "No connection file for
+                #{@kernel.kernelSpec.display_name} kernel found"
+            return
+
+        atom.clipboard.write connectionFile
+        message = 'Path to connection file copied to clipboard.'
+        description = "Use `jupyter console --existing #{connectionFile}` to
+            connect to the running kernel."
+        atom.notifications.addSuccess message, description: description


### PR DESCRIPTION
This allows the user to easily connect to a ZMQKernel via a external console.

Related to #166, #365 and #403

