### PR TITLE
Remote kernels: add command to disconnect from WSKernel

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -206,6 +206,11 @@ module.exports = Hydrogen =
             @kernelManager.startKernel kernelSpec, grammar, (kernel) =>
                 @onKernelChanged kernel
 
+        else if command is 'disconnect-kernel'
+            @clearResultBubbles()
+            @kernelManager.destroyRunningKernelFor grammar
+            @onKernelChanged()
+
 
     createResultBubble: (code, row) ->
         if @kernel

--- a/lib/signal-list-view.coffee
+++ b/lib/signal-list-view.coffee
@@ -27,6 +27,14 @@ class SignalListView extends SelectListView
             },
         ]
 
+        @wsKernelCommands = [
+            {
+                name: 'Disconnect from'
+                value: 'disconnect-kernel'
+                language: null
+            }
+        ]
+
         @onConfirmed = null
         @addClass('kernel-signal-selector')
         @list.addClass('mark-active')
@@ -66,7 +74,17 @@ class SignalListView extends SelectListView
             }
 
         if kernel instanceof WSKernel
-            @setItems basicCommands
+            wsKernelCommands = @wsKernelCommands.map (command) ->
+                name =
+                    command.name + ' ' + kernel.kernelSpec.display_name + ' kernel'
+                return {
+                    name: name
+                    value: command.value
+                    grammar: grammar
+                    language: language
+                    kernel: kernel
+                }
+            @setItems _.union basicCommands, wsKernelCommands
         else
             # add commands to switch to other kernels
             @kernelManager.getAllKernelSpecsFor language, (kernelSpecs) =>


### PR DESCRIPTION
This is another request brought up in #383 

This command is accessible via the status bar whenever a WSKernel is active. I didn't add it to the global list of atom commands because calling this command when a ZMQKernel is active makes no sense.