### PR TITLE
Remote kernels: filter sessions and kernels by language

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -373,7 +373,11 @@ module.exports = Hydrogen =
                 @kernelManager.setRunningKernelFor grammar, kernel
                 @onKernelChanged kernel
 
-        @wsKernelPicker.toggle @editor.getGrammar()
+        grammar = @editor.getGrammar()
+        language = @kernelManager.getLanguageFor grammar
+
+        @wsKernelPicker.toggle grammar, (kernelSpec) =>
+            @kernelManager.kernelSpecProvidesLanguage(kernelSpec, language)
 
 
     copyPathToConnectionFile: ->


### PR DESCRIPTION
When connecting to a remote gateway, only the existing sessions that match the current grammar are presented as options. If creating a new session, only the kernelspecs matching the current grammar are made available.

This makes remote kernels more closely match local kernels, as requested in #383 

(I have additionally renamed some variables in this PR, because the overuse of the word "spec" made the old code extremely hard to understand)