### PR TITLE
WSKernelPicker: Tildify session path

### DIFF
--- a/lib/ws-kernel-picker.coffee
+++ b/lib/ws-kernel-picker.coffee
@@ -1,5 +1,6 @@
 {SelectListView} = require 'atom-space-pen-views'
 _ = require 'lodash'
+tildify = require 'tildify'
 
 Config = require './config'
 services = require './jupyter-js-services-shim'
@@ -79,7 +80,7 @@ class WSKernelPicker
                         return true
                 items = sessionModels.map (model) ->
                     if model.notebook?.path?
-                        name = model.notebook.path
+                        name = tildify model.notebook.path
                     else
                         name = "Session #{model.id}"
                     return {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "lodash": "^4.14.0",
     "requirejs": "^2.2.0",
     "spawnteract": "^2.1.1",
+    "tildify": "^1.2.0",
     "transformime": "^3.1.0",
     "transformime-marked": "0.0.1",
     "uuid": "^2.0.1",


### PR DESCRIPTION
PR:
<img width="573" alt="bildschirmfoto 2016-08-29 um 23 24 36" src="https://cloud.githubusercontent.com/assets/13285808/18069606/2f2b4a4c-6e40-11e6-90f6-6672f950f5a6.png">
Master:
<img width="569" alt="bildschirmfoto 2016-08-29 um 23 27 01" src="https://cloud.githubusercontent.com/assets/13285808/18069607/2f2bdffc-6e40-11e6-9737-62c7c66b2967.png">


I still don't like the `uuid` at the end. Is there a better possibility of uniquely identifying a session? Maybe the time of creation?