### PR TITLE
Remote kernels: add rename command

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -206,6 +206,9 @@ module.exports = Hydrogen =
             @kernelManager.startKernel kernelSpec, grammar, (kernel) =>
                 @onKernelChanged kernel
 
+        else if command is 'rename-kernel'
+            kernel.promptRename?()
+
         else if command is 'disconnect-kernel'
             @clearResultBubbles()
             @kernelManager.destroyRunningKernelFor grammar

--- a/lib/rename-view.coffee
+++ b/lib/rename-view.coffee
@@ -1,0 +1,40 @@
+{$, TextEditorView, View} = require 'atom-space-pen-views'
+
+module.exports =
+class RenameView extends View
+    @content: (@prompt) ->
+        @div =>
+            @label @prompt, class: 'icon icon-arrow-right', outlet: 'promptText'
+            @subview 'miniEditor', new TextEditorView(mini: true)
+
+    initialize: (@prompt, @default, @onConfirmed) ->
+        atom.commands.add @element,
+            'core:confirm': @confirm
+            'core:cancel': @cancel
+
+        @miniEditor.on 'blur', (e) =>
+            @cancel() unless not document.hasFocus()
+
+        @miniEditor.setText(@default)
+
+    storeFocusedElement: ->
+        @previouslyFocusedElement = $(document.activeElement)
+
+    restoreFocus: ->
+        @previouslyFocusedElement?.focus()
+
+    confirm: =>
+        text = @miniEditor.getText()
+        @onConfirmed?(text)
+        @cancel()
+
+    cancel: =>
+        @panel?.destroy()
+        @panel = null
+        @restoreFocus()
+
+    attach: ->
+        @storeFocusedElement()
+        @panel = atom.workspace.addModalPanel(item: @element)
+        @miniEditor.focus()
+        @miniEditor.getModel().scrollToCursorPosition()

--- a/lib/signal-list-view.coffee
+++ b/lib/signal-list-view.coffee
@@ -29,6 +29,11 @@ class SignalListView extends SelectListView
 
         @wsKernelCommands = [
             {
+                name: 'Rename'
+                value: 'rename-kernel'
+                language: null
+            },
+            {
                 name: 'Disconnect from'
                 value: 'disconnect-kernel'
                 language: null

--- a/lib/ws-kernel.coffee
+++ b/lib/ws-kernel.coffee
@@ -7,6 +7,7 @@ services = require('./jupyter-js-services-shim')
 
 Kernel = require './kernel'
 InputView = require './input-view'
+RenameView = require './rename-view'
 
 module.exports =
 class WSKernel extends Kernel
@@ -91,6 +92,12 @@ class WSKernel extends Kernel
                 data: message.content.data
                 found: message.content.found
             )
+
+    promptRename: ->
+        view = new RenameView 'Name your current session', @session.path, (input) =>
+            @session.rename(input)
+
+        view.attach()
 
     destroy: ->
         console.log 'WSKernel: destroying jupyter-js-services Session'

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "atom-space-pen-views": "^2.0.5",
     "escape-string-regexp": "^1.0.5",
     "jmp": "0.4.x",
-    "jupyter-js-services": "^0.18.0",
+    "jupyter-js-services": "^0.18.1",
     "lodash": "^4.14.0",
     "requirejs": "^2.2.0",
     "spawnteract": "^2.1.1",


### PR DESCRIPTION
This adds a command for renaming remote sessions.

The names were originally intended to be paths to notebook files, but in the case of Hydrogen they can really be anything. The only consequence of picking a non-path name is that the notebook web UI can't be used to talk to that kernel.

I had to add a new text input view, because I wanted it to be cancellable by pressing esc. The InputView doesn't do this, which is probably a good thing in the case of input.