### PR TITLE
Coffeelint: Add missing_fat_arrows rule

### DIFF
--- a/coffeelint.json
+++ b/coffeelint.json
@@ -62,5 +62,9 @@
   },
   "arrow_spacing": {
     "level": "error"
+  },
+    "missing_fat_arrows": {
+    "level": "error",
+    "is_strict": false
   }
 }

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,3 +1,4 @@
+# coffeelint: disable = missing_fat_arrows
 {CompositeDisposable} = require 'atom'
 
 _ = require 'lodash'


### PR DESCRIPTION
This rule is deactivated for `main.coffee` because it gets confused because Hydrogen is not defined as a class.