### PR TITLE
Add new button to insert result into document

### DIFF
--- a/lib/result-view.coffee
+++ b/lib/result-view.coffee
@@ -70,7 +70,9 @@ class ResultView
             bubbleText = @getAllText()
             editor = atom.workspace.getActiveTextEditor()
             editor.insertNewlineBelow()
-            editor.insertText('/* result: \n' + bubbleText + '\n*/')
+            editor.insertText('result: \n' + bubbleText + '\n',
+              select: true)
+            editor.toggleLineCommentsInSelection()
         actionPanel.appendChild(insertButton)
 
         @setMultiline false

--- a/lib/result-view.coffee
+++ b/lib/result-view.coffee
@@ -63,6 +63,16 @@ class ResultView
                 editor.insertText(bubbleText)
         actionPanel.appendChild(openButton)
 
+        insertButton = document.createElement('div')
+        insertButton.classList.add 'action-button',
+            'insert-button', 'icon', 'icon-triangle-down'
+        insertButton.onclick = =>
+            bubbleText = @getAllText()
+            editor = atom.workspace.getActiveTextEditor()
+            editor.insertNewlineBelow()
+            editor.insertText('/* result: \n' + bubbleText + '\n*/')
+        actionPanel.appendChild(insertButton)
+
         @setMultiline false
 
         @tooltips = new CompositeDisposable()
@@ -70,6 +80,8 @@ class ResultView
             title: 'Copy to clipboard'
         @tooltips.add atom.tooltips.add openButton,
             title: 'Open in new editor'
+        @tooltips.add atom.tooltips.add insertButton,
+            title: 'Insert below'
 
         @_hasResult = false
 


### PR DESCRIPTION
Hello wonderful Hydrogen developers!

This pull request currently works beautifully for me (working currently with JavaScript and ijs), but I’d love to get feedback on how to generalize it and get it into Hydrogen proper, if you think it’s worth it.

Here’s what it does:

![animation_with_pause](https://cloud.githubusercontent.com/assets/37649/18206386/744e8bc8-70f4-11e6-9385-65caba1cec7b.gif)

In words: the results box has an additional button that grabs the results and inserts them below the selection. It currently wraps the results in `/* result: <results> */`, which is very JavaScript-specific, I know, and which is currently hardcoded into the button’s callback.

I’m surprised how frequently I want to inject the results of evaluation back into my document—it’s enabling me to be much more literate in both my code (à la literate programming) and my Markdown files (now that I have the ability to tell Hydrogen to use ijs or jupyter while editing Markdown).

If you think this is more widely useful, I’m more than happy to think about how to generalize this to work for all Hydrogen users, by customizing the output to be language-aware (i.e., use `#` for Python, `/**/` for JS, etc.), etc.

If you’re only lukewarm on the entire idea, let me know and I can write a blog post about how I use this functionality with examples.

In any case, feedback is much-appreciated!