### PR TITLE
Don't move the cursor down if there is no following code to execute

### DIFF
--- a/lib/code-manager.coffee
+++ b/lib/code-manager.coffee
@@ -182,14 +182,12 @@ class CodeManager
     moveDown: (row) ->
         lastRow = @editor.getLastBufferRow()
 
-        if row >= lastRow
-            @editor.moveToBottom()
-            @editor.insertNewline()
-            return
-
         while row < lastRow
             row++
             break if not @isBlank(row)
+
+        unless row < lastRow
+            return
 
         @editor.setCursorBufferPosition
             row: row


### PR DESCRIPTION
This prevents the cursor skipping to the last line. Helpful if there are a lot of comments at the end of a file.

Brought up by @matthew-brett on [slack](https://nteract.slack.com/archives/general/p1472939771000014).