### PR TITLE
Service providing results of last Hydrogen run

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -223,14 +223,47 @@ module.exports = Hydrogen =
             @_createResultBubble kernel, code, row
 
 
+    mostRecentResult:
+      row: -1
+      texts: []
+
+
+    mostRecentResultProvider: ->
+      obj = @mostRecentResult
+      ->
+        return obj
+    mostRecentResultProvider3: ->
+      return () ->
+        return "whee"
+
+
+    resetMostRecentResult: ->
+      @mostRecentResult.row = -1
+      @mostRecentResult.texts = []
+
+
+    appendMostRecentResult: (row, text) ->
+      obj = @mostRecentResult
+      if (obj.row != row)
+        @resetMostRecentResult()
+        obj = @mostRecentResult
+        obj.row = row
+      obj.texts.push(text)
+
+
     _createResultBubble: (kernel, code, row) ->
         if @watchSidebar.element.contains document.activeElement
             @watchSidebar.run()
             return
 
         @clearBubblesOnRow row
+        @resetMostRecentResult()
         view = @insertResultBubble row
+        appender = (result) ->
+          @appendMostRecentResult(row, result)
+        appenderBound = appender.bind(@)
         kernel.execute code, (result) ->
+            appenderBound(result)
             view.spin false
             view.addResult result
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -244,10 +244,10 @@ module.exports = Hydrogen =
 
 
     resetMostRecentResult: ->
-      @mostRecentResult.row = -1
-      @mostRecentResult.texts = []
       if (@mostRecentResult.resolveFn)
         @mostRecentResolver()
+      @mostRecentResult.row = -1
+      @mostRecentResult.texts = []
       most = @mostRecentResult
       @mostRecentResult.promise = new Promise((resolve, reject) ->
         most.resolveFn = resolve
@@ -255,11 +255,9 @@ module.exports = Hydrogen =
 
 
     appendMostRecentResult: (row, text) ->
+      console.log("ROWWW", row, text)
       obj = @mostRecentResult
-      if (obj.row != row)
-        @resetMostRecentResult()
-        obj = @mostRecentResult
-        obj.row = row
+      obj.row = row
       obj.texts.push(text)
       if (text.stream=='error' || text.stream=='status')
         @mostRecentResolver()

--- a/package.json
+++ b/package.json
@@ -58,6 +58,11 @@
     }
   },
   "providedServices": {
+    "hydrogen.most-recent-result.provider": {
+      "versions": {
+        "1.0.0": "mostRecentResultProvider"
+      }
+    },
     "autocomplete.provider": {
       "versions": {
         "2.0.0": "provide"


### PR DESCRIPTION
This is a very rough proof-of-concept of an Atom service that Hydrogen provides for other plugins to get the results of the most recent “Run” in Hydrogen. (In case it helps, my unusual use-case is described in nteract/hydrogen/pull/428.)
# Hydrogen (provider) side

The way it works: `Hydrogen.main` has a new property `mostRecentResult`. This internal state is reset when a new results bubble is created, and it’s populated with the results Jupyter sends over. The service provider’s API is just a single function that grabs this property and returns it to the service consumer.

(See diff for details.)
# Consumer plugin side

The consumer plugin’s `package.json` includes:

``` json
  "consumedServices": {
    "hydrogen.most-recent-result.provider": {
      "versions": {
        "1.0.0": "hydrogenConsumer"
      }
    }
  }
```

That name `hydrogen.most-recent-result.provider` is the same as the one in Hydrogen’s `package.json` (see this pull request‘s diff). The consumer gets the following properties (note how `hydrogenConsumer` above matches the method below):

``` coffee
  hydrogenCallback: null

  hydrogenConsumer: (hydrogenProvider) ->
    console.log("Getting Hydrogen provider", hydrogenProvider)
    @hydrogenCallback = hydrogenProvider

  hydrogenCallbackWrapper: ->
    console.log('Hydrogen said:', @hydrogenCallback())
```

The first time I run a Hydrogen command, Atom logs `Getting Hydrogen provider`, meaning that Atom has established the provider–consumer bridge. Then, I can invoke the consumer plugin’s `hydrogenCallbackWrapper` to talk to Hydrogen.
# Example

Hydrogen evaluates the following JavaScript snippet:

``` js
console.log('sup');
console.log('zzz');
```

I then call my consumer plugin’s `hydrogenCallbackWrapper` method, which logs the Hydrogen service’s response, which, in JSON, is:

``` json
 {"row":20,"texts":[
                    {"data":{"text/plain":"sup"},"type":"text","stream":"stdout"},
                    {"data":{"text/plain":"zzz"},"type":"text","stream":"stdout"},
                    {"data":{"text/plain":"undefined"},"type":"text","stream":"pyout"},
                    {"data":"ok","type":"text","stream":"status"}]}
```

This is exactly what’s expected, because the Hydrogen results bubble contains

```
sup
zzz
undefined
```

Stupid `console.log`’s return value is `undefined`, hence that last line. And the fourth element in the service payload seems to be an `"ok"` from Jupyter telling Hydrogen it’s done (or something like that?).

Emphasis is on the fact that this output was obtained from the consumer plugin.

(It appears that I have to first run a Hydrogen command for Atom to link the provider and the consumer plugins. If I try to call `hydrogenCallbackWrapper` from the consumer plugin before running anything Hydrogen-wise, Atom complains that `this.hydrogenCallback is not a function`.)

**Caveat** That meme where the dog wearing the tie at a computer and a caption “I don’t know what I’m doing”—that’s me right here. I’m sure there are architectural and stylistic improvements that could be made here. 
