### PR TITLE
Wrapper-based plugin API

### DIFF
--- a/lib/kernel.coffee
+++ b/lib/kernel.coffee
@@ -1,3 +1,5 @@
+{Emitter} = require 'atom'
+
 child_process = require 'child_process'
 path = require 'path'
 
@@ -5,11 +7,9 @@ _ = require 'lodash'
 jmp = require 'jmp'
 uuid = require 'uuid'
 zmq = jmp.zmq
-{Emitter} = require 'event-kit'
 
 StatusView = require './status-view'
 WatchSidebar = require './watch-sidebar'
-
 HydrogenKernel = require './plugin-api/hydrogen-kernel'
 
 module.exports =

--- a/lib/kernel.coffee
+++ b/lib/kernel.coffee
@@ -26,7 +26,7 @@ class Kernel
 
     getPluginWrapper: ->
         unless @pluginWrapper?
-            @pluginWrapper = HydrogenKernel(this)
+            @pluginWrapper = new HydrogenKernel(this)
 
         return @pluginWrapper
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,5 +1,6 @@
 # coffeelint: disable = missing_fat_arrows
 {CompositeDisposable} = require 'atom'
+{Emitter} = require 'event-kit'
 
 _ = require 'lodash'
 
@@ -13,6 +14,8 @@ Config = require './config'
 KernelManager = require './kernel-manager'
 Inspector = require './inspector'
 AutocompleteProvider = require './autocomplete-provider'
+
+HydrogenProvider = require './plugin-api/hydrogen-provider'
 
 module.exports = Hydrogen =
     config: Config.schema
@@ -32,6 +35,7 @@ module.exports = Hydrogen =
     watchSidebarIsVisible: false
 
     activate: (state) ->
+        @emitter = new Emitter()
         @kernelManager = new KernelManager()
         @inspector = new Inspector @kernelManager
         @codeManager = new CodeManager()
@@ -83,11 +87,19 @@ module.exports = Hydrogen =
             if item and item is atom.workspace.getActiveTextEditor()
                 @onEditorChanged item
 
+        @hydrogenProvider = null
+
 
     deactivate: ->
         @subscriptions.dispose()
         @kernelManager.destroy()
         @statusBarTile.destroy()
+
+    provideHydrogen: ->
+        unless @hydrogenProvider?
+            @hydrogenProvider = new HydrogenProvider(this)
+
+        return @hydrogenProvider
 
 
     consumeStatusBar: (statusBar) ->
@@ -114,6 +126,7 @@ module.exports = Hydrogen =
     onKernelChanged: (@kernel) ->
         @setStatusBar()
         @setWatchSidebar @kernel
+        @emitter.emit 'did-change-kernel', @kernel
 
 
     setStatusBar: ->

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,6 +1,5 @@
 # coffeelint: disable = missing_fat_arrows
-{CompositeDisposable} = require 'atom'
-{Emitter} = require 'event-kit'
+{CompositeDisposable, Emitter} = require 'atom'
 
 _ = require 'lodash'
 

--- a/lib/plugin-api/hydrogen-kernel.coffee
+++ b/lib/plugin-api/hydrogen-kernel.coffee
@@ -1,0 +1,26 @@
+# The HydrogenKernel class wraps hydrogen's internal representation of kernels
+# and exposes a small set of methods that should be usable by plugins.
+
+module.exports =
+class HydrogenKernel
+    constructor: (@_kernel) ->
+        @destroyed = false
+
+    _assertNotDestroyed: ->
+        # Internal: plugins might hold references to long-destroyed kernels, so
+        # all API calls should guard against this case
+        if @destroyed
+            throw new Error 'HydrogenKernel: operation not allowed because the kernel has been destroyed'
+
+    onDidDestroy: (callback) ->
+        @_assertNotDestroyed()
+        return @_kernel.emitter.on 'did-destroy', callback
+
+    getConnectionFile: ->
+        @_assertNotDestroyed()
+        connectionFile = @_kernel.connectionFile
+        unless connectionFile?
+            # Standardize on returning null if there is no connection file
+            # (e.g. for WSKernel)
+            return null
+        return connectionFile

--- a/lib/plugin-api/hydrogen-provider.coffee
+++ b/lib/plugin-api/hydrogen-provider.coffee
@@ -1,0 +1,14 @@
+module.exports =
+class HydrogenProvider
+    constructor: (@_hydrogen) ->
+        @_happy = true
+
+    onDidChangeKernel: (callback) ->
+        @_hydrogen.emitter.on 'did-change-kernel', (kernel) ->
+            return kernel.getPluginWrapper()
+
+    getActiveKernel: ->
+        unless @_hydrogen.kernel
+            return null
+
+        return @_hydrogen.kernel.getPluginWrapper()

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "atom-message-panel": "^1.2.4",
     "atom-space-pen-views": "^2.0.5",
     "escape-string-regexp": "^1.0.5",
-    "event-kit": "^2.1.0",
     "jmp": "0.4.x",
     "jupyter-js-services": "^0.18.1",
     "lodash": "^4.14.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "atom-message-panel": "^1.2.4",
     "atom-space-pen-views": "^2.0.5",
     "escape-string-regexp": "^1.0.5",
+    "event-kit": "^2.1.0",
     "jmp": "0.4.x",
     "jupyter-js-services": "^0.18.1",
     "lodash": "^4.14.0",
@@ -63,6 +64,11 @@
       "versions": {
         "2.0.0": "provide"
       }
+    },
+    "hydrogen.provider" : {
+        "versions": {
+            "0.0.2": "provideHydrogen"
+        }
     }
   },
   "devDependencies": {


### PR DESCRIPTION
Here is my take on a possible way to implement a plugin API for hydrogen.

Thanks to @lgeiger and @fasiha for looking into plugin solutions beforehand! 

This PR is influenced by my experience extending hydrogen (where extend=fork because at the time I didn't know about how providers/consumers work in atom). The idea is to have wrapper classes that add a layer of indirection for plugins. This leads to slightly more complex code on hydrogen's end, but it formalizes the API commitments that Hydrogen is willing to make to plugin developers.

The code here is a sketch of the general idea I have, and I certainly don't want to suggest that this be merged without prior discussion of the direction the project wants to take with respect to plugins.

I've also added a few `emitter` objects throughout hydrogen, which to the best of my knowledge are the canonical way to implement events in atom. The idea is to demonstrate how the API can expand to allow plugins to subscribe to events. (For example, one of my own use-cases involves being able to detect when some code is about to be executed in a kernel, and react to that event)