### PR TITLE
Add coffeescope2 plugin to coffeelint config

### DIFF
--- a/coffeelint.json
+++ b/coffeelint.json
@@ -66,5 +66,38 @@
     "missing_fat_arrows": {
     "level": "error",
     "is_strict": false
+  },
+    "check_scope": {
+    "module": "coffeescope2",
+    "level": "warn",
+    "environments": ["es5", "es6", "browser", "node", "jasmine"],
+    "globals": {
+      "atom": true,
+      "afterEach": true,
+      "beforeEach": true,
+      "describe": true,
+      "fdescribe": true,
+      "xdescribe": true,
+      "expect": true,
+      "it": true,
+      "fit": true,
+      "xit": true,
+      "jasmine": true,
+      "runs": true,
+      "spyOn": true,
+      "waitsFor": true,
+      "waitsForPromise": true,
+      "indexedDB": true
+    },
+    "overwrite": false,
+    "shadow": false,
+    "shadow_builtins": false,
+    "shadow_exceptions": ["err", "next"],
+    "undefined": true,
+    "hoist_local": true,
+    "hoist_parent": true,
+    "unused_variables": false,
+    "unused_arguments": false,
+    "unused_classes": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     }
   },
   "devDependencies": {
-    "coffeelint": "^1.15.7"
+    "coffeelint": "^1.15.7",
+    "coffeescope2": "^0.4.2"
   }
 }


### PR DESCRIPTION
There are efforts to [upgrade coffeescript in atom](https://github.com/atom/atom/pull/12780). This is the `coffeelint` config recommended to ensure compatibility.
  
[`coffeescope`](https://github.com/za-creature/coffeescope) helps to detect
> - attempting to access an undefined variable
- overwriting or shadowing a variable from an outer scope
- unused variables and arguments