### PR TITLE
Fix onDidChangeKernel in plugin API

### DIFF
--- a/lib/plugin-api/hydrogen-provider.coffee
+++ b/lib/plugin-api/hydrogen-provider.coffee
@@ -5,7 +5,10 @@ class HydrogenProvider
 
     onDidChangeKernel: (callback) ->
         @_hydrogen.emitter.on 'did-change-kernel', (kernel) ->
-            return kernel.getPluginWrapper()
+            if kernel?
+                callback kernel.getPluginWrapper()
+            else
+                callback null
 
     getActiveKernel: ->
         unless @_hydrogen.kernel


### PR DESCRIPTION
Apparently I didn't test if this method actually worked, because the code currently there is just plain wrong.