### PR TITLE
Use zmq-prebuilt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,25 +6,10 @@ notifications:
 
 script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh'
 
-os:
-  - osx
-
 env:
-  global:
-    - APM_TEST_PACKAGES=""
-
   matrix:
-    - ATOM_CHANNEL=stable
+    - ATOM_CHANNEL=beta
 
 before_install:
-  - brew update
-  - brew outdated pkg-config || brew upgrade pkg-config
-  - brew install zeromq
-  - wget https://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh -O miniconda.sh;
-  - bash miniconda.sh -b -p $HOME/miniconda
-  - export PATH="$HOME/miniconda/bin:$PATH"
-  - hash -r
-  - conda config --set always_yes yes --set changeps1 no
-  - conda update -q conda
-  - conda info -a
-  - conda install jupyter
+  - python -m pip install ipykernel --user
+  - python -m ipykernel install --user

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,11 @@
 sudo: false
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - gcc-4.9
+    - g++-4.9
 notifications:
   email:
     on_success: never
@@ -7,6 +14,9 @@ notifications:
 script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh'
 
 env:
+  global:
+    - CXX=g++-4.9
+    - CC=gcc-4.9
   matrix:
     - ATOM_CHANNEL=beta
 

--- a/README.md
+++ b/README.md
@@ -26,43 +26,37 @@ Hydrogen was inspired by Bret Victor's ideas about the power of instantaneous fe
 For all systems, you'll need
 
 - [Atom](https://atom.io/) `1.6.0+`
-- [ZeroMQ](http://zeromq.org/intro:get-the-software)
-- [Jupyter notebook](http://jupyter.org): `pip install jupyter`
+- [Jupyter notebook](http://jupyter.org): If you have Python and pip setup, install the notebook directly with `pip install jupyter`
 - Python 2 for builds (you can still run Python 3 code)
 
-Each operating system has their own instruction set. Please read on down to save yourself time.
-
-#### OS X
-
-##### homebrew on OS X
-
-- [`pkg-config`](https://www.freedesktop.org/wiki/Software/pkg-config/): `brew install pkg-config`
-- [ZeroMQ](http://zeromq.org/intro:get-the-software): `brew install zeromq`
-- [Jupyter notebook](http://jupyter.org) (needs to be installed and on your `$PATH`): `pip install jupyter`
-
-#### Windows
-
-- You'll need a compiler! [Visual Studio 2013 Community Edition](https://www.visualstudio.com/en-us/downloads/download-visual-studio-vs.aspx) is required to build zmq.node.
-- Python (tread on your own or install [Anaconda](https://www.continuum.io/downloads))
-- [Jupyter notebook](http://jupyter.org) (if you installed Anaconda, you're already done)
-
-After these are installed, you'll likely need to restart your machine (especially after Visual Studio).
+You likely have them installed already installed. You can check your installation with `apm install --check`.
 
 #### Linux
 
-For **Debian/Ubuntu** based variants, you'll need `libzmq3-dev` (preferred) or alternatively `libzmq-dev`.
+- `python` (`v2.7` recommended, `v3.x.x` is not supported)
+- `make`
+- A proper C/C++ compiler toolchain, like [GCC](https://gcc.gnu.org/)
 
-For **RedHat/CentOS/Fedora/openSUSE** based variants, you'll need `zeromq` and `zeromq-devel`.
+Use your distribution's package manager to install.
 
-For **Arch** Linux based variants, you'll need `zeromq` or `zeromq3` (which has to be built from the <abbr title="Arch User Repository">AUR</abbr>).
+#### macOS
 
-For **Gentoo** Linux based variants, you'll need `net-libs/zeromq`.
+- `python` (`v2.7` recommended, `v3.x.x` is not supported): already installed on Mac OS X
+- `Xcode Command Line Tools`: Can be installed with `xcode-select --install`
 
-If you have Python and pip setup, install the notebook directly, via running (as root):
+#### Windows
 
-```
-pip install jupyter
-```
+- **Option 1:** Install all the required tools and configurations using Microsoft's [windows-build-tools](https://github.com/felixrieseberg/windows-build-tools) by running `npm install -g windows-build-tools` from an elevated PowerShell (run as Administrator).
+- **Option 2:** Install dependencies and configuration manually
+   * Visual C++ Build Environment:
+     * **Option 1:** Install [Visual C++ Build Tools](http://go.microsoft.com/fwlink/?LinkId=691126) using the *Default Install* option.
+     * **Option 2:** Install [Visual Studio 2015](https://www.visualstudio.com/products/visual-studio-community-vs) (or modify an existing installation) and select *Common Tools for Visual C++* during setup.  
+
+    > :bulb: [Windows Vista / 7 only] requires [.NET Framework 4.5.1](http://www.microsoft.com/en-us/download/details.aspx?id=40773)
+
+  * Install [Python 2.7](https://www.python.org/downloads/) or [Miniconda 2.7](http://conda.pydata.org/miniconda.html) (`v3.x.x` is not supported)
+
+- Finally run `apm config set msvs_version 2015` and `apm config set python python2.7` to complete the setup.
 
 ## Installation
 
@@ -87,7 +81,7 @@ But it _should_ work with any [kernel](https://github.com/ipython/ipython/wiki/I
 
 <img src="https://cloud.githubusercontent.com/assets/13285808/16931386/048f056e-4d41-11e6-8563-3baa8ed84371.png">
 
-Note that if you install a new kernel, you'll need to reload Atom (search in the Command Palette for "reload") for Hydrogen to find it. For performance reasons, Hydrogen only looks for available kernels when it first starts.
+Note that if you install a new kernel, you'll need to run **Hydrogen: Update Kernels** for Hydrogen to find it. For performance reasons, Hydrogen only looks for available kernels when it first starts.
 
 #### Debian 8 and Ubuntu 16.04 LTS
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,102 +1,38 @@
 ### Hydrogen installation fails reporting an error running `node-gyp`
 
-**For Windows (Tested with Windows 10)**
-If you have a `node-gyp` error, before you read through the troubleshooting
-section below, I suggest you repeat my latest steps here as many of the information
-in the following troubleshooting section may be out of date.
-
-- Install Git (Bash) and restore all settings (.gitconfig)
-- [Optional] Install Git Credential Winstore (for remembering git username and password)
-- [Optional] Install Cmder and restore all settings (cmder_exinit.sh in C:\Program Files\Git\etc\profile.d\, and user-profile.sh in D:\Cmder\config) (for a nice customisable terminal)
-- Install Anaconda 3
-- Run -> `conda update conda`
-- Run -> `conda update Anaconda`
-- Install packages -> `pip install -r requirements.txt`
-- Install Anaconda 2 in virtual environment -> `conda create -n python2 python=2.7 anaconda`
-- [Optional] ***For Python installer user:***
-  `virtualenv -p <path/to/your/python2> <envname>` (you'll need to install Jupyter via `pip install jupyter` if you choose this option)
-- Install packages in virtual environment python2 -> `source activate python2` -> `pip install -r requirements.txt` -> `source deactivate`
-- Install Node.js and restore .npmrc (latest 6.7.0 is fine!)
-- Install Visuall C++ compiler -> `npm install --global --production windows-build-tools` (including C++ components and Python 2)
-- ***If somehow you failed installing your compiler before, and your visual studio
-  version can't be recognised by `apm -v`, use
-  [Visual Studio Uninstaller](https://github.com/Microsoft/VisualStudioUninstaller/releases)
-  here to cleanup/scorch, and cleanup remaining items and registry for fresh start
-  (this process can take hours, but worth it) as traditional uninstallation
-  may not solve the issue due to remaining registry and package cache there.***
-- Update node-gyp -> `npm install -g node-gyp`
-- Install ZeroMQ.node -> `npm -g install zmq`
-- Make sure npm's version is matched between local and global (if you have local npm installed. Unmatched npm version will give you `MSBuild error failed with exit code: 1`) -> `npm -g install npm@latest`
-- [Optional] Install IJavacript Kernel -> `npm -g install ijavascript`
-- [Optional] Register IJavascript globally -> `ijs --ijs-install=global` -> `ijs`
-- [Optional] Install JP-Babel Kernel globally-> `npm install -g jp-babel`
-- [Optional] Register JP-Babel -> `jp-babel --jp-install=global` -> `jp-babel`
-- Install Atom (Run installer as adminstrator) and restore .atom/.apmrc
-- Set python 2 for npm -> `npm config edit` and add in:
-```
-python=D:\Anaconda3\envs\python2\python.exe (or whatever your python2 is)
-msvs_version=2015
-GYP_MSVS_VERSION=2015
-```
-- Set Python 2 for apm -> `apm config edit` and add in the same parameters above
-
-
-- At this stage, all of the dependencies we need should all be installed.
-  Run `apm -v` to check if they are all recognised. You should see something
-  like this:
-```
-apm  1.12.5
-npm  3.10.5
-node 4.4.5
-python 2.7.12
-git 2.10.0.windows.1
-visual studio 2015 (VS 2015 is fine!)
-```
-- [Optional if you have backup for Atom] Assuming you followed exactly the steps above, you can now `apm install hydrogen`
-  or search for "hydrogen" in the Install pane of the Atom settings.
-- If you have everything backed up in atom, just install sync-settings in Atom, and restore all settings via your Personal Access Token and Gist ID (restart Atom several times until no error pops up, installed theme requires at least restarts twice)
-- Change the grammar settings in Hydrogen to cope with jp-babel kernel -> `{ "babel": "babel es6 javascript", "python": "python django" }` (otherwise hydrogen won't be able to recognise babel files and python django files)
-- Now you have a perfectly functioning Hydrogen with Python 2, Python 3, IJavascript and Babel kernel, running at their full potential. ENJOY!
-
-
-***
-***For previous troubleshooting section, please continue reading***
-
 There are a number of possible causes and solutions:
 
-- Atom is installed in a path that contains spaces (see issues
-  [#318](https://github.com/nteract/hydrogen/issues/318) and
-  [#292](https://github.com/nteract/hydrogen/issues/292)).
-
-- Missing `pkg-config` in OS X. Please, ensure you've installed `pkg-config` by
-  running `brew install pkg-config`.
-
 - Missing Visual Studio in Windows. `node-gyp` requires a compiler. See
-  [here](https://github.com/nodejs/node-gyp#installation) for installation
+  [here](https://github.com/nteract/hydrogen#windows) for installation
   instructions.
 
-- Atom uses incorrect version of Visual Studio (on Windows). Installing hydrogen
-  on windows works best with Visual Studio 2013, but Atom may see a different
+- Atom uses incorrect version of Visual Studio (on Windows). Installing Hydrogen
+  on Windows only works with Visual Studio 2015, but Atom may see a different
   version. You can check this by running `apm --version`, if it looks like this:
-  
+
   ```
   apm  1.12.5
   npm  3.10.5
   node 4.4.5
   python 2.7.12
   git 2.8.1.windows.1
-  visual studio 2015
+  visual studio 2013
   ```
-  
-  then it means Atom is seeing visual studio 2015, not 2013.
+
+  then it means Atom is seeing Visual Studio 2013, not 2015.
   These commands should help:
   ```
-  apm config set msvs_version 2013 -g
-  set GYP_MSVS_VERSION=2013
+  apm config set msvs_version 2015 -g
+  set GYP_MSVS_VERSION=2015
+  ```
+  Or if you are using git bash
+  ```
+  apm config set msvs_version 2015 -g
+  export GYP_MSVS_VERSION=2015
   ```
 
 - Atom is unable to use your installation of Python 2 (see issues
-  [#301](https://github.com/nteract/hydrogen/issues/301) and 
+  [#301](https://github.com/nteract/hydrogen/issues/301) and
   [#358](https://github.com/nteract/hydrogen/issues/358)). To confirm this is
   the cause, please, run `apm --version`. Here's an example for the case when
   Atom cannot find any installation of Python, the output could look like this:
@@ -107,7 +43,7 @@ There are a number of possible causes and solutions:
   node 0.10.40
   python
   git 2.8.1.windows.1
-  visual studio 2013
+  visual studio 2015
   ```
 
   And here, when Atom finds the installation of Python 3 instead of Python 2:
@@ -118,7 +54,7 @@ There are a number of possible causes and solutions:
   node 0.10.40
   python 3.5.1
   git
-  visual studio
+  visual studio 2015
   ```
 
   To fix this problem, you need to locate the executable for Python 2. Running
@@ -165,7 +101,7 @@ Again, there are a number of possible causes and solutions:
     comment](https://github.com/nteract/hydrogen/issues/88#issuecomment-136761769) );
 
 - If Hydrogen doesn't output any results (see issue
-  [#326](https://github.com/nteract/hydrogen/issues/326)), check that you haven't disabled 
+  [#326](https://github.com/nteract/hydrogen/issues/326)), check that you haven't disabled
   `Use Shadow DOM` under `Settings > Editor`. This option should be enabled.
 
 - If the spinner in the result bubble never stops (see issue

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
       "hydrogen:run-cell-and-move-down"
     ]
   },
-  "scripts": {},
+  "scripts": {
+    "install": "npm rebuild --build-from-source"
+  },
   "repository": "https://github.com/nteract/hydrogen",
   "license": "MIT",
   "engines": {
@@ -39,7 +41,7 @@
     "atom-message-panel": "^1.2.4",
     "atom-space-pen-views": "^2.0.5",
     "escape-string-regexp": "^1.0.5",
-    "jmp": "0.4.x",
+    "jmp": "0.6.x",
     "jupyter-js-services": "^0.18.1",
     "lodash": "^4.14.0",
     "requirejs": "^2.2.0",
@@ -64,10 +66,10 @@
         "2.0.0": "provide"
       }
     },
-    "hydrogen.provider" : {
-        "versions": {
-            "0.0.2": "provideHydrogen"
-        }
+    "hydrogen.provider": {
+      "versions": {
+        "0.0.2": "provideHydrogen"
+      }
     }
   },
   "devDependencies": {


### PR DESCRIPTION
This will bump `jmp` and switch to `zmq-prebuilt`. Any help with testing is really appreciated. The prerequisites can be found [here](https://github.com/lgeiger/hydrogen/blob/15fd7836371a024299290a2778a0180c12ce0c5c/README.md#dependencies).

**TODO:**
- Tested on:
  - [x] OS X: Atom beta
  - [x] OS X: Atom stable
  - [x] Windows 10 (64-bit): Atom stable
  - [x] Ubuntu 16.04 (64-bit): Atom stable
- Docs:
  - [x] Update README
  - [x] Update TROUBLESHOOTING
- Travis:
  - [x] Remove unnecessary dependencies
  - [x] Move to Linux for faster builds