### PR TITLE
Fix #483

### DIFF
--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -7,7 +7,7 @@ module.exports = Config =
             return JSON.parse value
         catch error
             message = "Your Hydrogen config is broken: #{key}"
-            atom.notifications.addError message, description: error
+            atom.notifications.addError message, detail: error
         return _default
 
     schema:


### PR DESCRIPTION
The variable `error` is an error object, and not a string. The `description` flag expects markdown strings and passes them through a markdown parser, which then chokes on the object because it isn't what it expected. Rendering markdown makes no sense here, so I've switched back to using `detail`.