### PR TITLE
Make keybindings consistent with nteract and jupyter notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ It's easiest to see these interactions visually:
 
 **"Hydrogen: Run And Move Down"** will run the the code as described above and move the cursor to the next executable line.
 
-If your code starts getting cluttered up with results, run **"Hydrogen: Clear Results"** to remove them all at once. You can also run this command with ⌘-⌥-⌫.
+If your code starts getting cluttered up with results, run **"Hydrogen: Clear Results"** to remove them all at once.
 
 ### "Hydrogen: Run Cell"
 A "code cell" is a block of lines to be executed at once. You can define them using inline comments. Hydrogen supports a
@@ -169,7 +169,7 @@ After you've run some code with Hydrogen, you can use the **"Hydrogen: Toggle Wa
 **IMPORTANT:** Be careful what you put in your watch expressions. If you write code that mutates state in a watch expression, that code will get run after every execute command and likely result in some _extremely confusing_ bugs.
 
 
-You can re-run the watch expressions by using the normal run shortcut (⌘-⌥-↩ by default) inside a watch expression's edit field.
+You can re-run the watch expressions by using the normal run shortcut (⌘-↩ by default) inside a watch expression's edit field.
 
 If you have multiple kernels running, you can switch between their watch expressions with the **"Hydrogen: Select Watch Kernel"** command (or just click on the "Kernel: <language>" text).
 

--- a/keymaps/hydrogen.cson
+++ b/keymaps/hydrogen.cson
@@ -24,8 +24,13 @@
     'cmd-enter': 'hydrogen:run'
     'cmd-ctrl-enter': 'hydrogen:run-all'
 
+# Override ctrl-enter and ctrl-backspace
+'.platform-win32 atom-text-editor:not([mini])':
+    'ctrl-enter': 'hydrogen:run'
+    'ctrl-backspace': 'hydrogen:clear-results'
+
 '.platform-win32 atom-text-editor, .platform-linux atom-text-editor':
-    'ctrl-alt-enter': 'hydrogen:run-cell-and-move-down'
+    'ctrl-alt-enter': 'hydrogen:run-cell'
     'ctrl-enter': 'hydrogen:run'
     'ctrl-shift-alt-enter': 'hydrogen:run-all'
 

--- a/keymaps/hydrogen.cson
+++ b/keymaps/hydrogen.cson
@@ -25,7 +25,7 @@
     'cmd-ctrl-enter': 'hydrogen:run-all'
 
 # Override ctrl-enter and ctrl-backspace
-'.platform-win32 atom-text-editor:not([mini])':
+'.platform-win32 atom-text-editor:not([mini]), .platform-linux atom-text-editor:not([mini])':
     'ctrl-enter': 'hydrogen:run'
     'ctrl-backspace': 'hydrogen:clear-results'
 

--- a/keymaps/hydrogen.cson
+++ b/keymaps/hydrogen.cson
@@ -7,18 +7,31 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/behind-atom-keymaps-in-depth
-'.platform-darwin atom-text-editor':
-  'cmd-alt-enter': 'hydrogen:run-and-move-down'
-  'shift-alt-enter': 'hydrogen:run'
-  'cmd-ctrl-enter': 'hydrogen:run-all'
 
-'.platform-darwin atom-workspace':
-  'cmd-alt-backspace': 'hydrogen:clear-results'
+# ---------- Editor --------------
+'atom-text-editor':
+    'shift-enter': 'hydrogen:run-and-move-down'
+    'shift-alt-enter': 'hydrogen:run-cell-and-move-down'
+    'alt-i': 'hydrogen:toggle-inspector'
+
+# Override shift-enter and cmd-enter
+'.platform-darwin atom-text-editor:not([mini])':
+    'shift-enter': 'hydrogen:run-and-move-down'
+    'cmd-enter': 'hydrogen:run'
+
+'.platform-darwin atom-text-editor':
+    'cmd-alt-enter': 'hydrogen:run-cell'
+    'cmd-enter': 'hydrogen:run'
+    'cmd-ctrl-enter': 'hydrogen:run-all'
 
 '.platform-win32 atom-text-editor, .platform-linux atom-text-editor':
-  'ctrl-alt-enter': 'hydrogen:run-and-move-down'
-  'shift-alt-enter': 'hydrogen:run'
-  'ctrl-shift-alt-enter': 'hydrogen:run-all'
+    'ctrl-alt-enter': 'hydrogen:run-cell-and-move-down'
+    'ctrl-enter': 'hydrogen:run'
+    'ctrl-shift-alt-enter': 'hydrogen:run-all'
+
+# ---------- Workspace -----------
+'.platform-darwin atom-workspace':
+    'cmd-alt-backspace': 'hydrogen:clear-results'
 
 '.platform-win32 atom-workspace, .platform-linux atom-workspace':
-  'ctrl-backspace': 'hydrogen:clear-results'
+    'ctrl-backspace': 'hydrogen:clear-results'


### PR DESCRIPTION
Since the zeromq install issues are solved. We're getting closer to `1.0.0`.
This is the right time to make the keybinding consistent with `nteract` and `jupyter notebook`.

Please try it and let me know what you think.
Closes #304 