### PR TITLE
Remove copyPathToConnectionFile

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -76,8 +76,6 @@ module.exports = Hydrogen =
                 @handleKernelCommand command: 'restart-kernel'
             'hydrogen:shutdown-kernel': =>
                 @handleKernelCommand command: 'shutdown-kernel'
-            'hydrogen:copy-path-to-connection-file': =>
-                @copyPathToConnectionFile()
 
         @subscriptions.add atom.commands.add 'atom-workspace',
             'hydrogen:clear-results': => @clearResultBubbles()
@@ -392,25 +390,3 @@ module.exports = Hydrogen =
 
         @wsKernelPicker.toggle grammar, (kernelSpec) =>
             @kernelManager.kernelSpecProvidesLanguage(kernelSpec, language)
-
-
-    copyPathToConnectionFile: ->
-        grammar = @editor.getGrammar()
-        language = @kernelManager.getLanguageFor grammar
-
-        unless @kernel?
-            message = "No running kernel for language `#{language}` found"
-            atom.notifications.addError message
-            return
-
-        connectionFile = @kernel.connectionFile
-        unless connectionFile?
-            atom.notifications.addError "No connection file for
-                #{@kernel.kernelSpec.display_name} kernel found"
-            return
-
-        atom.clipboard.write connectionFile
-        message = 'Path to connection file copied to clipboard.'
-        description = "Use `jupyter console --existing #{connectionFile}` to
-            connect to the running kernel."
-        atom.notifications.addSuccess message, description: description

--- a/lib/plugin-api/hydrogen-kernel.coffee
+++ b/lib/plugin-api/hydrogen-kernel.coffee
@@ -20,7 +20,6 @@ class HydrogenKernel
         @_assertNotDestroyed()
         connectionFile = @_kernel.connectionFile
         unless connectionFile?
-            atom.notifications.addError "No connection file for
-                #{@_kernel.kernelSpec.display_name} kernel found"
+            throw new Error "No connection file for #{@_kernel.kernelSpec.display_name} kernel found"
             return null
         return connectionFile

--- a/lib/plugin-api/hydrogen-kernel.coffee
+++ b/lib/plugin-api/hydrogen-kernel.coffee
@@ -21,5 +21,5 @@ class HydrogenKernel
         connectionFile = @_kernel.connectionFile
         unless connectionFile?
             throw new Error "No connection file for #{@_kernel.kernelSpec.display_name} kernel found"
-            return null
+
         return connectionFile

--- a/lib/plugin-api/hydrogen-kernel.coffee
+++ b/lib/plugin-api/hydrogen-kernel.coffee
@@ -20,7 +20,7 @@ class HydrogenKernel
         @_assertNotDestroyed()
         connectionFile = @_kernel.connectionFile
         unless connectionFile?
-            # Standardize on returning null if there is no connection file
-            # (e.g. for WSKernel)
+            atom.notifications.addError "No connection file for
+                #{@_kernel.kernelSpec.display_name} kernel found"
             return null
         return connectionFile

--- a/lib/plugin-api/hydrogen-provider.coffee
+++ b/lib/plugin-api/hydrogen-provider.coffee
@@ -14,8 +14,7 @@ class HydrogenProvider
         unless @_hydrogen.kernel?
             grammar = @_hydrogen.editor.getGrammar()
             language = @_hydrogen.kernelManager.getLanguageFor grammar
-            message = "No running kernel for language `#{language}` found"
-            atom.notifications.addError message
+            throw new Error "No running kernel for language `#{language}` found"
             return null
 
         return @_hydrogen.kernel.getPluginWrapper()

--- a/lib/plugin-api/hydrogen-provider.coffee
+++ b/lib/plugin-api/hydrogen-provider.coffee
@@ -15,6 +15,5 @@ class HydrogenProvider
             grammar = @_hydrogen.editor.getGrammar()
             language = @_hydrogen.kernelManager.getLanguageFor grammar
             throw new Error "No running kernel for language `#{language}` found"
-            return null
 
         return @_hydrogen.kernel.getPluginWrapper()

--- a/lib/plugin-api/hydrogen-provider.coffee
+++ b/lib/plugin-api/hydrogen-provider.coffee
@@ -11,7 +11,11 @@ class HydrogenProvider
                 callback null
 
     getActiveKernel: ->
-        unless @_hydrogen.kernel
+        unless @_hydrogen.kernel?
+            grammar = @_hydrogen.editor.getGrammar()
+            language = @_hydrogen.kernelManager.getLanguageFor grammar
+            message = "No running kernel for language `#{language}` found"
+            atom.notifications.addError message
             return null
 
         return @_hydrogen.kernel.getPluginWrapper()

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     },
     "hydrogen.provider": {
       "versions": {
-        "0.0.2": "provideHydrogen"
+        "0.0.3": "provideHydrogen"
       }
     }
   },


### PR DESCRIPTION
This removes `@copyPathToConnectionFile()` because the functionality is now provided by [Hydrogen Launcher](https://github.com/lgeiger/hydrogen-launcher).

The error handling was moved to the plugin provider.