### PR TITLE
Document plugin API

### DIFF
--- a/PLUGIN_API.md
+++ b/PLUGIN_API.md
@@ -1,0 +1,58 @@
+
+
+<!-- Start lib/plugin-api/hydrogen-provider.coffee -->
+
+## HydrogenProvider
+
+Version: 0.0.3 
+
+The Plugin API allows you to make Hydrogen awesome.
+You will be able to interact with this class in your Hydrogen Plugin.
+
+Take a look at our [Example Plugin](https://github.com/lgeiger/hydrogen-example-plugin)
+and the [Atom Flight Manual](http://flight-manual.atom.io/hacking-atom/) for
+learning how to interact with Hydrogen in your own plugin.
+
+## onDidChangeKernel(Callback)
+
+Calls your callback when the kernel has changed.
+
+### Params:
+
+* **Function** *Callback* 
+
+## getActiveKernel()
+
+Get the `HydrogenKernel` of the currently active text editor.
+
+### Return:
+
+* **Class** `HydrogenKernel`
+
+<!-- End lib/plugin-api/hydrogen-provider.coffee -->
+
+<!-- Start lib/plugin-api/hydrogen-kernel.coffee -->
+
+## HydrogenKernel
+
+The `HydrogenKernel` class wraps Hydrogen's internal representation of kernels
+and exposes a small set of methods that should be usable by plugins.
+
+## onDidDestroy(Callback)
+
+Calls your callback when the kernel has been destroyed.
+
+### Params:
+
+* **Function** *Callback* 
+
+## getConnectionFile()
+
+Get the [connection file](http://jupyter-notebook.readthedocs.io/en/latest/examples/Notebook/Connecting%20with%20the%20Qt%20Console.html) of the kernel.
+
+### Return:
+
+* **String** Path to connection file.
+
+<!-- End lib/plugin-api/hydrogen-kernel.coffee -->
+

--- a/PLUGIN_API.md
+++ b/PLUGIN_API.md
@@ -4,10 +4,11 @@
 
 ## HydrogenProvider
 
-Version: 0.0.3 
+Version: 1.0.0
 
 The Plugin API allows you to make Hydrogen awesome.
-You will be able to interact with this class in your Hydrogen Plugin.
+You will be able to interact with this class in your Hydrogen Plugin using
+Atom's [Service API](http://blog.atom.io/2015/03/25/new-services-API.html).
 
 Take a look at our [Example Plugin](https://github.com/lgeiger/hydrogen-example-plugin)
 and the [Atom Flight Manual](http://flight-manual.atom.io/hacking-atom/) for
@@ -44,7 +45,7 @@ Calls your callback when the kernel has been destroyed.
 
 ### Params:
 
-* **Function** *Callback* 
+* **Function** *Callback*
 
 ## getConnectionFile()
 
@@ -55,4 +56,3 @@ Get the [connection file](http://jupyter-notebook.readthedocs.io/en/latest/examp
 * **String** Path to connection file.
 
 <!-- End lib/plugin-api/hydrogen-kernel.coffee -->
-

--- a/README.md
+++ b/README.md
@@ -213,6 +213,13 @@ You can also access these commands by clicking on the kernel status in the statu
 
 Additionally, if you have two or more kernels for a particular language (grammar), you can select which kernel to use with the "Switch to <kernel>" option in the Kernel Commands menu.
 
+## Plugins for Hydrogen
+
+Hydrogen has support for plugins. Feel free to add your own to the list:
+- [Hydrogen Launcher](https://github.com/lgeiger/hydrogen-launcher)
+
+If you are interested in building a plugin take a look at our [plugin API documentation](PLUGIN_API.md).
+
 ## How it works
 
 Hydrogen implements the [messaging protocol](http://jupyter-client.readthedocs.io/en/latest/messaging.html) for [Jupyter](https://jupyter.org/). Jupyter (formerly IPython) uses ZeroMQ to connect a client (like Hydrogen) to a running kernel (like IJulia or iTorch). The client sends code to be executed to the kernel, which runs it and sends back results.

--- a/lib/plugin-api/hydrogen-kernel.coffee
+++ b/lib/plugin-api/hydrogen-kernel.coffee
@@ -1,5 +1,8 @@
-# The HydrogenKernel class wraps hydrogen's internal representation of kernels
-# and exposes a small set of methods that should be usable by plugins.
+###
+* The `HydrogenKernel` class wraps Hydrogen's internal representation of kernels
+* and exposes a small set of methods that should be usable by plugins.
+* @class HydrogenKernel
+###
 
 module.exports =
 class HydrogenKernel
@@ -12,10 +15,18 @@ class HydrogenKernel
         if @destroyed
             throw new Error 'HydrogenKernel: operation not allowed because the kernel has been destroyed'
 
+    ###
+    * Calls your callback when the kernel has been destroyed.
+    * @param {Function} Callback
+    ###
     onDidDestroy: (callback) ->
         @_assertNotDestroyed()
         return @_kernel.emitter.on 'did-destroy', callback
 
+    ###
+    * Get the [connection file](http://jupyter-notebook.readthedocs.io/en/latest/examples/Notebook/Connecting%20with%20the%20Qt%20Console.html) of the kernel.
+    * @return {String} Path to connection file.
+    ###
     getConnectionFile: ->
         @_assertNotDestroyed()
         connectionFile = @_kernel.connectionFile

--- a/lib/plugin-api/hydrogen-provider.coffee
+++ b/lib/plugin-api/hydrogen-provider.coffee
@@ -1,8 +1,26 @@
+###*
+* @version 0.0.3
+*
+*
+* The Plugin API allows you to make Hydrogen awesome.
+* You will be able to interact with this class in your Hydrogen Plugin using
+* Atom's [Service API](http://blog.atom.io/2015/03/25/new-services-API.html).
+*
+* Take a look at our [Example Plugin](https://github.com/lgeiger/hydrogen-example-plugin)
+* and the [Atom Flight Manual](http://flight-manual.atom.io/hacking-atom/) for
+* learning how to interact with Hydrogen in your own plugin.
+*
+* @class HydrogenProvider
+###
 module.exports =
 class HydrogenProvider
     constructor: (@_hydrogen) ->
         @_happy = true
 
+    ###
+    * Calls your callback when the kernel has changed.
+    * @param {Function} Callback
+    ###
     onDidChangeKernel: (callback) ->
         @_hydrogen.emitter.on 'did-change-kernel', (kernel) ->
             if kernel?
@@ -10,6 +28,10 @@ class HydrogenProvider
             else
                 callback null
 
+    ###
+    * Get the `HydrogenKernel` of the currently active text editor.
+    * @return {Class} `HydrogenKernel`
+    ###
     getActiveKernel: ->
         unless @_hydrogen.kernel?
             grammar = @_hydrogen.editor.getGrammar()

--- a/lib/plugin-api/hydrogen-provider.coffee
+++ b/lib/plugin-api/hydrogen-provider.coffee
@@ -1,5 +1,5 @@
 ###*
-* @version 0.0.3
+* @version 1.0.0
 *
 *
 * The Plugin API allows you to make Hydrogen awesome.

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     ]
   },
   "scripts": {
-    "install": "npm rebuild --build-from-source"
+    "install": "npm rebuild --build-from-source",
+    "build:docs": "markdox lib/plugin-api/hydrogen-provider.coffee lib/plugin-api/hydrogen-kernel.coffee -o PLUGIN_API.md"
   },
   "repository": "https://github.com/nteract/hydrogen",
   "license": "MIT",
@@ -74,6 +75,7 @@
   },
   "devDependencies": {
     "coffeelint": "^1.15.7",
-    "coffeescope2": "^0.4.2"
+    "coffeescope2": "^0.4.2",
+    "markdox": "^0.1.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     },
     "hydrogen.provider": {
       "versions": {
-        "0.0.3": "provideHydrogen"
+        "1.0.0": "provideHydrogen"
       }
     }
   },


### PR DESCRIPTION
- Add docs for plugin API
- Bump API version to `1.0.0` in order to adhere to semver. This way we can bump the version to `1.1.0` if we add features and don't break plugins using `1.0.0`.