### PR TITLE
Remove unnecessary postinstall step

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     ]
   },
   "scripts": {
-    "postinstall": "npm rebuild zeromq --build-from-source",
     "lint": "eslint .",
     "fix": "eslint . --fix",
     "build:docs": "markdox lib/plugin-api/hydrogen-provider.js lib/plugin-api/hydrogen-kernel.js -o PLUGIN_API.md"


### PR DESCRIPTION
`prebuild` 4.5.0 is here 🚀 

https://github.com/mafintosh/prebuild/pull/135 makes the postinstall step unnecessary which means `apm rebuild` will work now.
We should ship 1.1.0 after this.

Fixes #518 and may help with #507 