### PR TITLE
Use commonmark instead of marked

### DIFF
--- a/lib/result-view.js
+++ b/lib/result-view.js
@@ -2,10 +2,9 @@
 
 import { CompositeDisposable } from 'atom';
 
-import * as transformime from 'transformime';
-import MarkdownTransform from 'transformime-marked';
+import { createTransform } from 'transformime';
 
-const transform = transformime.createTransform([MarkdownTransform]);
+const transform = createTransform();
 
 export default class ResultView {
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "spawnteract": "^2.1.1",
     "tildify": "^1.2.0",
     "transformime": "^3.2.0",
-    "transformime-marked": "0.0.1",
     "uuid": "^3.0.1",
     "ws": "^1.1.1",
     "xmlhttprequest": "^1.8.0"


### PR DESCRIPTION
[`marked`](https://github.com/chjj/marked) isn't actively maintained anymore and has a few bugs.

This PR will make it consistent with nteract and use [`commonmark`](https://github.com/jgm/commonmark.js) as a markdown renderer. If anyone feels strongly against `commonmark` we can also consider using [`markdown-it`](https://github.com/markdown-it/markdown-it).

As an added bonus this reduces our dependencies.