### PR TITLE
Fix: Action panel is squashed if space is limited

### DIFF
--- a/styles/hydrogen.less
+++ b/styles/hydrogen.less
@@ -108,7 +108,7 @@
 
         display: inline-block;
         max-height: 250px;
-        max-width: 95%;
+        max-width: inherit;
         overflow: auto;
     }
 


### PR DESCRIPTION
Fixes this:
<img width="218" alt="bildschirmfoto 2016-12-10 um 03 41 11" src="https://cloud.githubusercontent.com/assets/13285808/21070686/fabc4fc2-be8a-11e6-9034-eef2da76d9ec.png">
