### PR TITLE
Increase maximum output height

### DIFF
--- a/styles/hydrogen.less
+++ b/styles/hydrogen.less
@@ -107,7 +107,7 @@
         border-radius: 3px;
 
         display: inline-block;
-        max-height: 250px;
+        max-height: 400px;
         max-width: inherit;
         overflow: auto;
     }


### PR DESCRIPTION
Since #536 we can safely increase the maximum output height of the result bubbles.