### PR TITLE
Upgrade to @jupyterlab/services 0.34.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ To connect to a gateway server, you must first add the connection information to
 }]
 ```
 
-Each entry in the gateways list needs at minimum a `name` (for displaying in the UI), and a value for `options.baseUrl`. The `options` are passed directly to the `jupyter-js-services` npm package, which includes documentation for additional fields.
+Each entry in the gateways list needs at minimum a `name` (for displaying in the UI), and a value for `options.baseUrl`. The `options` are passed directly to the [`@jupyterlab/services`](https://github.com/jupyterlab/services) npm package, which includes documentation for additional fields.
 
 After gateways have been configured, you can use the **"Hydrogen: Connect to Remote Kernel"** command. You will be prompted to select a gateway, and then given the choice to either create a new session or connect to an existing one.
 

--- a/lib/jupyter-js-services-shim.js
+++ b/lib/jupyter-js-services-shim.js
@@ -1,7 +1,7 @@
 'use babel';
 
-// jupyter-js-services apparently require overriding globals, as explained in its
-// README: https://github.com/jupyter/jupyter-js-services
+// @jupyterlab/services apparently require overriding globals, as explained in its
+// README: https://github.com/jupyterlab/services
 // Otherwise, any requests it sends are blocked due to CORS issues
 //
 // This file exists to
@@ -17,4 +17,4 @@ global.requirejs = requirejs;
 global.XMLHttpRequest = xhr.XMLHttpRequest;
 global.WebSocket = ws;
 
-export * from 'jupyter-js-services';
+export * from '@jupyterlab/services';

--- a/lib/ws-kernel-picker.js
+++ b/lib/ws-kernel-picker.js
@@ -73,10 +73,10 @@ export default class WSKernelPicker {
   }
 
   onGateway(gatewayInfo) {
-    services.getKernelSpecs(gatewayInfo.options)
+    services.Kernel.getSpecs(gatewayInfo.options)
       .then((specModels) => {
-        const kernelSpecs = _.filter(specModels.kernelspecs, specModel =>
-          this._kernelSpecFilter(specModel.spec));
+        const kernelSpecs = _.filter(specModels.kernelspecs, spec =>
+          this._kernelSpecFilter(spec));
 
         const kernelNames = _.map(kernelSpecs, specModel => specModel.name);
 
@@ -84,7 +84,7 @@ export default class WSKernelPicker {
         sessionListing.previouslyFocusedElement = this.previouslyFocusedElement;
         sessionListing.setLoading('Loading sessions...');
 
-        services.listRunningSessions(gatewayInfo.options)
+        services.Session.listRunning(gatewayInfo.options)
           .then((sessionModels) => {
             sessionModels = sessionModels.filter((model) => {
               const name = (model.kernel) ? model.kernel.name : null;
@@ -130,12 +130,12 @@ export default class WSKernelPicker {
       const kernelListing = new CustomListView('No kernel specs available', this.startSession.bind(this));
       kernelListing.previouslyFocusedElement = this.previouslyFocusedElement;
 
-      const items = _.map(sessionInfo.kernelSpecs, (specModel) => {
+      const items = _.map(sessionInfo.kernelSpecs, (spec) => {
         const options = Object.assign({}, sessionInfo.options);
-        options.kernelName = specModel.name;
+        options.kernelName = spec.name;
         options.path = this._path;
         return {
-          name: specModel.spec.display_name,
+          name: spec.display_name,
           options,
         };
       });
@@ -144,18 +144,18 @@ export default class WSKernelPicker {
         kernelListing.setError('This gateway does not support listing sessions');
       }
     } else {
-      services.connectToSession(sessionInfo.model.id, sessionInfo.options)
+      services.Session.connectTo(sessionInfo.model.id, sessionInfo.options)
         .then(this.onSessionChosen.bind(this));
     }
   }
 
   startSession(sessionInfo) {
-    services.startNewSession(sessionInfo.options)
+    services.Session.startNew(sessionInfo.options)
       .then(this.onSessionChosen.bind(this));
   }
 
   onSessionChosen(session) {
-    session.kernel.getKernelSpec().then((kernelSpec) => {
+    session.kernel.getSpec().then((kernelSpec) => {
       const kernel = new WSKernel(kernelSpec, this._grammar, session);
       this._onChosen(kernel);
     });

--- a/lib/ws-kernel.js
+++ b/lib/ws-kernel.js
@@ -29,7 +29,7 @@ export default class WSKernel extends Kernel {
   }
 
   _execute(code, callWatches, onResults) {
-    const future = this.session.kernel.execute({ code });
+    const future = this.session.kernel.requestExecute({ code });
 
     future.onIOPub = (message) => {
       if (callWatches &&
@@ -81,7 +81,7 @@ export default class WSKernel extends Kernel {
   }
 
   complete(code, onResults) {
-    this.session.kernel.complete({
+    this.session.kernel.requestComplete({
       code,
       cursor_pos: code.length,
     })
@@ -89,7 +89,7 @@ export default class WSKernel extends Kernel {
   }
 
   inspect(code, cursorPos, onResults) {
-    this.session.kernel.inspect({
+    this.session.kernel.requestInspect({
       code,
       cursor_pos: cursorPos,
       detail_level: 0,

--- a/package.json
+++ b/package.json
@@ -40,11 +40,11 @@
     "atom": ">=1.6.0 <2.0.0"
   },
   "dependencies": {
+    "@jupyterlab/services": "^0.34.2",
     "atom-message-panel": "^1.2.4",
     "atom-space-pen-views": "^2.0.5",
     "escape-string-regexp": "^1.0.5",
     "jmp": "^0.7.5",
-    "jupyter-js-services": "^0.18.1",
     "lodash": "^4.14.0",
     "requirejs": "^2.2.0",
     "spawnteract": "^2.1.1",


### PR DESCRIPTION
This updates to the latest APIs, and changes all mentions of `jupyter-js-services` to `@jupyterlab/services`.

This allows token-based authentication for notebooks, starting with notebook version 4.3. However there's something funny going on with gateways (see https://github.com/jupyter/kernel_gateway/issues/204), so we might have to hold off on merging this until the cause of the gateway issue is determined.