### PR TITLE
Use passive event to improve scroll perf

### DIFF
--- a/lib/result-view.js
+++ b/lib/result-view.js
@@ -15,7 +15,7 @@ export default class ResultView {
 
     const outputContainer = document.createElement('div');
     outputContainer.classList.add('bubble-output-container');
-    outputContainer.onmousewheel = (event) => {
+    const onWheel = (event) => {
       const clientHeight = outputContainer.clientHeight;
       const scrollHeight = outputContainer.scrollHeight;
       const scrollTop = outputContainer.scrollTop;
@@ -26,6 +26,7 @@ export default class ResultView {
         event.stopPropagation();
       }
     };
+    outputContainer.addEventListener('wheel', onWheel, { passive: true });
     this.element.appendChild(outputContainer);
 
     this.resultContainer = document.createElement('div');


### PR DESCRIPTION
:racehorse: Use passive `wheel` event to improve scroll performance.

I discovered this thanks to a console warning.

For more infos see: https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md