### PR TITLE
Improve documentation for remote kernels

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,12 +185,13 @@ To connect to a gateway server, you must first add the connection information to
 [{
     "name": "Remote notebook",
     "options": {
-            "baseUrl": "http://example.com:8888"
+            "baseUrl": "http://example.com:8888",
+            "token": "my_secret_token"
     }
 }]
 ```
 
-Each entry in the gateways list needs at minimum a `name` (for displaying in the UI), and a value for `options.baseUrl`. The `options` are passed directly to the [`@jupyterlab/services`](https://github.com/jupyterlab/services) npm package, which includes documentation for additional fields.
+Each entry in the gateways list needs at minimum a `name` (for displaying in the UI), and a value for `options.baseUrl`. The `options.token` should only be present if your server requires token authentication, in which case it should contain the specific token issued by your server. (Token authentication is enabled by default for Jupyter Notebook 4.3 or later). The `options` are passed directly to the [`@jupyterlab/services`](https://github.com/jupyterlab/services) npm package, which includes documentation for additional fields.
 
 After gateways have been configured, you can use the **"Hydrogen: Connect to Remote Kernel"** command. You will be prompted to select a gateway, and then given the choice to either create a new session or connect to an existing one.
 

--- a/README.md
+++ b/README.md
@@ -177,9 +177,9 @@ Hydrogen implements the [messaging protocol](http://jupyter-client.readthedocs.i
 
 ## Remote kernels via kernel gateways
 
-In addition to managing local kernels and connecting to them over ZeroMQ, Hydrogen is also able to connect to Jupyter Kernel Gateways and Jupyter Notebook servers. This is most useful for running code remotely (e.g. in the cloud).
+In addition to managing local kernels and connecting to them over ZeroMQ, Hydrogen is also able to connect to Jupyter Notebook (or Jupyter Kernel Gateway) servers. This is most useful for running code remotely (e.g. in the cloud).
 
-To connect to a gateway server, you must first add the connection information to the Hydrogen `gateways` setting. An example settings entry might be:
+To connect to a server, you must first add the connection information to the Hydrogen `gateways` setting. An example settings entry might be:
 
 ```json
 [{
@@ -197,25 +197,35 @@ After gateways have been configured, you can use the **"Hydrogen: Connect to Rem
 
 Unlike with local kernels, Hydrogen does not kill remote kernels when it disconnects from them. This allows sharing remote kernels between Hydrogen and the Notebook UI, as well as using them for long-running processes. To clean up unused kernels, you must explicitly call the **"Hydrogen: Shutdown Kernel"** command while connected to a kernel.
 
-**Note:** Unlike a notebook server, the jupyter kernel gateway by default disables listing already-running kernels. This means that once disconnected from a kernel, you will not be able to reconnect to it. You can set `c.KernelGatewayApp.list_kernels = True` in your kernel gateway configuration to change this behavior.
+### Example with notebook server
 
-### Example remote kernel gateway
+To set up a server on the remote machine, you could
 
-To create a remote kernel gateway you could
-
-- Install Jupyter Kernel Gateway:
+- Install Jupyter Notebook:
 
 ```bash
-pip install jupyter_kernel_gateway
+pip install jupyter
 ```
 
-- Run the kernel gateway with parameters specifying the IP address and port to listen to, e.g.:
+- Check to see if you have the notebook configuration file, `jupyter_notebook_config.py`. (By default, it is located in `~/jupyter`). If you don't already have one, create one by running the command:
 
 ```bash
-jupyter kernelgateway --ip=0.0.0.0 --port=8888
+jupyter notebook --generate-config
 ```
 
-**Note**: "`0.0.0.0`" means "listen to all IPs, including public IPs".
+- Edit `jupyter_notebook_config.py` and find the line that says `#c.NotebookApp.token = ''`. Change it to say `c.NotebookApp.token = 'my_secret_token'`, substituting your choice of token string. (If you skip this step, the token will change every time the notebook server restarts).
+
+- To run a server that listens on localhost, use the command:
+
+```bash
+jupyter notebook --port=8888
+```
+
+- To run a public server, consult the [official instructions](http://jupyter-notebook.readthedocs.io/en/latest/public_server.html) for setting up certificates. Skip the steps for setting up a password: hydrogen only supports token-based authentication. Also note that hydrogen does not support self-signed certificates -- we recommend that you use Let's Encrypt or consider alternatives such as listening on localhost followed by SSH port forwarding.
+
+### Example with kernel gateway server
+
+As of December 2016, we recommend that you use a notebook server (version 4.3 or greater) instead of the Jupyter Kernel Gateway. We expect this to change in the future, and will update this README when that occurs.
 
 ## Docker execution via kernel gateways
 


### PR DESCRIPTION
The first commit adds a few words describing the `token` option.

It the second commit, I make the recommendation that users install Jupyter Notebook (and not the kernel gateway), and document how to set it up locally and on the public internet.

I feel obliged to mention why I would personally recommend the notebook over the gateway server. When I first wrote the remote kernel feature, the kernel gateway server was a newly-added toplevel Jupyter project. It seemed very appealing to have the kernel management capabilities of the notebook without the web UI -- something that is still true today. Without doing much testing I assumed that the two would be roughly equivalent, and wrote all the docs to mention gateways.

As it turns out, however, the gateway server actually depends on the notebook and imports large chunks of its code (so it offers no savings in terms of install size). Moreover, the two servers have diverging sets of features. Notebook 4.3 now has a token implementation that enables security and interacts well with Hydrogen. Kernel Gateway + Notebook 4.2 also has tokens, but its implementation differs slightly in a way that breaks hydrogen (it can't use `?token=<>` URL parameters for websocket connections, meaning that you can't actually send code to be run). This could conceivably be fixed in a Kernel Gateway + Notebook 4.3 combination, but that one remains broken (I reported this bug a few days ago). In fact, I suspect that if you `pip install` the kernel gateway today on a clean system, you will get the broken combination that will fail 100% of the time.

In conclusion, these problems will probably take a few dev cycles to be resolved upstream. In the meantime, I would like to advise Hydrogen users to use a configuration that is known to be working and that encourages good security practices. (Ideally we would update the Docker docs as well, but I haven't touched those because I can't test anything docker-related)