### PR TITLE
Allow text/markdown code inspect results

### DIFF
--- a/lib/inspector.js
+++ b/lib/inspector.js
@@ -77,7 +77,7 @@ export default class Inspector {
 
         this._lastInspectionResult = message;
         return;
-      } else if (mimetype === 'text/html') {
+      } else if (mimetype === 'text/html' || mimetype === 'text/markdown') {
         const container = document.createElement('div');
         container.appendChild(el);
         const message = container.innerHTML;


### PR DESCRIPTION
One line change to inspect.js to allow mimetype text/markdown for IJulia and maybe others. 
#561.