### PR TITLE
Support multiple kernels per file (markdown, &c.)

### DIFF
--- a/lib/autocomplete-provider.js
+++ b/lib/autocomplete-provider.js
@@ -2,7 +2,7 @@
 
 import _ from 'lodash';
 
-import RobustGrammar from './robust-grammar';
+import getRobustGrammar from './robust-grammar';
 
 const iconHTML = `<img src='${__dirname}/../static/logo.svg' style='width: 100%;'>`;
 
@@ -31,7 +31,7 @@ export default function (kernelManager) {
 
     // Required: Return a promise, an array of suggestions, or null.
     getSuggestions({ editor, bufferPosition, prefix }) {
-      const grammar = RobustGrammar(editor);
+      const grammar = getRobustGrammar(editor);
       const language = kernelManager.getLanguageFor(grammar);
       const kernel = kernelManager.getRunningKernelFor(language);
       if (!kernel) {

--- a/lib/autocomplete-provider.js
+++ b/lib/autocomplete-provider.js
@@ -2,6 +2,8 @@
 
 import _ from 'lodash';
 
+import RobustGrammar from './robust-grammar';
+
 const iconHTML = `<img src='${__dirname}/../static/logo.svg' style='width: 100%;'>`;
 
 const regexes = {
@@ -29,7 +31,7 @@ export default function (kernelManager) {
 
     // Required: Return a promise, an array of suggestions, or null.
     getSuggestions({ editor, bufferPosition, prefix }) {
-      const grammar = editor.getGrammar();
+      const grammar = RobustGrammar(editor);
       const language = kernelManager.getLanguageFor(grammar);
       const kernel = kernelManager.getRunningKernelFor(language);
       if (!kernel) {

--- a/lib/inspector.js
+++ b/lib/inspector.js
@@ -3,6 +3,8 @@
 import { MessagePanelView, PlainMessageView } from 'atom-message-panel';
 import * as transformime from 'transformime';
 
+import RobustGrammar from './robust-grammar';
+
 const transform = transformime.createTransform();
 
 export default class Inspector {
@@ -13,8 +15,8 @@ export default class Inspector {
   }
 
   toggle() {
-    const editor = atom.workspace.getActiveTextEditor();
-    const grammar = editor.getGrammar();
+    const editor = atom.workspace.getActiveTextEditor()
+    const grammar = RobustGrammar(editor);
     const language = this.kernelManager.getLanguageFor(grammar);
     const kernel = this.kernelManager.getRunningKernelFor(language);
     if (!kernel) {

--- a/lib/inspector.js
+++ b/lib/inspector.js
@@ -15,7 +15,7 @@ export default class Inspector {
   }
 
   toggle() {
-    const editor = atom.workspace.getActiveTextEditor()
+    const editor = atom.workspace.getActiveTextEditor();
     const grammar = RobustGrammar(editor);
     const language = this.kernelManager.getLanguageFor(grammar);
     const kernel = this.kernelManager.getRunningKernelFor(language);

--- a/lib/inspector.js
+++ b/lib/inspector.js
@@ -3,7 +3,7 @@
 import { MessagePanelView, PlainMessageView } from 'atom-message-panel';
 import * as transformime from 'transformime';
 
-import RobustGrammar from './robust-grammar';
+import getRobustGrammar from './robust-grammar';
 
 const transform = transformime.createTransform();
 
@@ -16,7 +16,7 @@ export default class Inspector {
 
   toggle() {
     const editor = atom.workspace.getActiveTextEditor();
-    const grammar = RobustGrammar(editor);
+    const grammar = getRobustGrammar(editor);
     const language = this.kernelManager.getLanguageFor(grammar);
     const kernel = this.kernelManager.getRunningKernelFor(language);
     if (!kernel) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -16,7 +16,7 @@ import Inspector from './inspector';
 import AutocompleteProvider from './autocomplete-provider';
 
 import HydrogenProvider from './plugin-api/hydrogen-provider';
-import RobustGrammar from './robust-grammar';
+import getRobustGrammar from './robust-grammar';
 
 const Hydrogen = {
   config: Config.schema,
@@ -128,7 +128,7 @@ const Hydrogen = {
     this.editor = editor;
     let kernel;
     if (this.editor) {
-      const grammar = RobustGrammar(this.editor);
+      const grammar = getRobustGrammar(this.editor);
       const language = this.kernelManager.getLanguageFor(grammar);
       kernel = this.kernelManager.getRunningKernelFor(language);
       this.codeManager.editor = this.editor;
@@ -221,7 +221,7 @@ const Hydrogen = {
     console.log('handleKernelCommand:', arguments);
 
     if (!grammar) {
-      grammar = RobustGrammar(this.editor);
+      grammar = getRobustGrammar(this.editor);
     }
     if (!language) {
       language = this.kernelManager.getLanguageFor(grammar);
@@ -262,12 +262,12 @@ const Hydrogen = {
 
 
   createResultBubble(code, row) {
-    if (this.kernel && this.kernel.grammar === RobustGrammar(this.editor)) {
+    if (this.kernel && this.kernel.grammar === getRobustGrammar(this.editor)) {
       this._createResultBubble(this.kernel, code, row);
       return;
     }
 
-    this.kernelManager.startKernelFor(RobustGrammar(this.editor), (kernel) => {
+    this.kernelManager.startKernelFor(getRobustGrammar(this.editor), (kernel) => {
       this.onKernelChanged(kernel);
       this._createResultBubble(kernel, code, row);
     });
@@ -372,12 +372,12 @@ const Hydrogen = {
 
 
   runAll() {
-    if (this.kernel && this.kernel.grammar === RobustGrammar(this.editor)) {
+    if (this.kernel && this.kernel.grammar === getRobustGrammar(this.editor)) {
       this._runAll(this.kernel);
       return;
     }
 
-    this.kernelManager.startKernelFor(RobustGrammar(this.editor), (kernel) => {
+    this.kernelManager.startKernelFor(getRobustGrammar(this.editor), (kernel) => {
       this.onKernelChanged(kernel);
       this._runAll(kernel);
     });
@@ -424,7 +424,7 @@ const Hydrogen = {
   showKernelPicker() {
     if (!this.kernelPicker) {
       this.kernelPicker = new KernelPicker((callback) => {
-        const grammar = RobustGrammar(this.editor);
+        const grammar = getRobustGrammar(this.editor);
         const language = this.kernelManager.getLanguageFor(grammar);
         this.kernelManager.getAllKernelSpecsFor(language, kernelSpecs =>
           callback(kernelSpecs));
@@ -452,7 +452,7 @@ const Hydrogen = {
       });
     }
 
-    const grammar = RobustGrammar(this.editor);
+    const grammar = getRobustGrammar(this.editor);
     const language = this.kernelManager.getLanguageFor(grammar);
 
     this.wsKernelPicker.toggle(grammar, kernelSpec =>

--- a/lib/main.js
+++ b/lib/main.js
@@ -16,6 +16,7 @@ import Inspector from './inspector';
 import AutocompleteProvider from './autocomplete-provider';
 
 import HydrogenProvider from './plugin-api/hydrogen-provider';
+import RobustGrammar from './robust-grammar';
 
 const Hydrogen = {
   config: Config.schema,
@@ -127,7 +128,7 @@ const Hydrogen = {
     this.editor = editor;
     let kernel;
     if (this.editor) {
-      const grammar = this.editor.getGrammar();
+      const grammar = RobustGrammar(this.editor);
       const language = this.kernelManager.getLanguageFor(grammar);
       kernel = this.kernelManager.getRunningKernelFor(language);
       this.codeManager.editor = this.editor;
@@ -220,7 +221,7 @@ const Hydrogen = {
     console.log('handleKernelCommand:', arguments);
 
     if (!grammar) {
-      grammar = this.editor.getGrammar();
+      grammar = RobustGrammar(this.editor);
     }
     if (!language) {
       language = this.kernelManager.getLanguageFor(grammar);
@@ -261,12 +262,12 @@ const Hydrogen = {
 
 
   createResultBubble(code, row) {
-    if (this.kernel) {
+    if (this.kernel && this.kernel.grammar === RobustGrammar(this.editor)) {
       this._createResultBubble(this.kernel, code, row);
       return;
     }
 
-    this.kernelManager.startKernelFor(this.editor.getGrammar(), (kernel) => {
+    this.kernelManager.startKernelFor(RobustGrammar(this.editor), (kernel) => {
       this.onKernelChanged(kernel);
       this._createResultBubble(kernel, code, row);
     });
@@ -371,12 +372,12 @@ const Hydrogen = {
 
 
   runAll() {
-    if (this.kernel) {
+    if (this.kernel && this.kernel.grammar === RobustGrammar(this.editor)) {
       this._runAll(this.kernel);
       return;
     }
 
-    this.kernelManager.startKernelFor(this.editor.getGrammar(), (kernel) => {
+    this.kernelManager.startKernelFor(RobustGrammar(this.editor), (kernel) => {
       this.onKernelChanged(kernel);
       this._runAll(kernel);
     });
@@ -423,7 +424,7 @@ const Hydrogen = {
   showKernelPicker() {
     if (!this.kernelPicker) {
       this.kernelPicker = new KernelPicker((callback) => {
-        const grammar = this.editor.getGrammar();
+        const grammar = RobustGrammar(this.editor);
         const language = this.kernelManager.getLanguageFor(grammar);
         this.kernelManager.getAllKernelSpecsFor(language, kernelSpecs =>
           callback(kernelSpecs));
@@ -451,7 +452,7 @@ const Hydrogen = {
       });
     }
 
-    const grammar = this.editor.getGrammar();
+    const grammar = RobustGrammar(this.editor);
     const language = this.kernelManager.getLanguageFor(grammar);
 
     this.wsKernelPicker.toggle(grammar, kernelSpec =>

--- a/lib/robust-grammar.js
+++ b/lib/robust-grammar.js
@@ -1,7 +1,7 @@
 'use babel';
 
-export default function(editor) {
-  const markupGrammars = new Set([ 'source.asciidoc', 'source.gfm' ]);
+export default function (editor) {
+  const markupGrammars = new Set(['source.asciidoc', 'source.gfm']);
   if (typeof editor === 'undefined') {
     editor = atom.workspace.getActiveTextEditor();
   }

--- a/lib/robust-grammar.js
+++ b/lib/robust-grammar.js
@@ -1,0 +1,24 @@
+'use babel';
+
+export default function(editor) {
+  const markupGrammars = new Set([ 'source.asciidoc', 'source.gfm' ]);
+  if (typeof editor === 'undefined') {
+    editor = atom.workspace.getActiveTextEditor();
+  }
+  const topLevelGrammar = editor.getGrammar();
+  if (markupGrammars.has(topLevelGrammar.scopeName)) {
+    const allScopes = editor.scopeDescriptorForBufferPosition(
+        editor.getCursorBufferPosition());
+    const scopes =
+        allScopes.scopes.filter(s => s.indexOf('source.embedded.') === 0);
+
+    if (scopes.length === 0) {
+      return topLevelGrammar;
+    }
+    const scope = scopes[0].replace('.embedded', '');
+
+    return atom.grammars.grammarForScopeName(scope);
+  }
+
+  return topLevelGrammar;
+}

--- a/lib/signal-list-view.js
+++ b/lib/signal-list-view.js
@@ -4,7 +4,7 @@ import { SelectListView } from 'atom-space-pen-views';
 import _ from 'lodash';
 
 import WSKernel from './ws-kernel';
-import RobustGrammar from './robust-grammar';
+import getRobustGrammar from './robust-grammar';
 
 // View to display a list of grammars to apply to the current editor.
 export default class SignalListView extends SelectListView {
@@ -52,7 +52,7 @@ export default class SignalListView extends SelectListView {
     this.storeFocusedElement();
     if (!this.panel) { this.panel = atom.workspace.addModalPanel({ item: this }); }
     this.focusFilterEditor();
-    const grammar = RobustGrammar(this.editor);
+    const grammar = getRobustGrammar(this.editor);
     const language = this.kernelManager.getLanguageFor(grammar);
 
     // disable all commands if no kernel is running

--- a/lib/signal-list-view.js
+++ b/lib/signal-list-view.js
@@ -4,6 +4,7 @@ import { SelectListView } from 'atom-space-pen-views';
 import _ from 'lodash';
 
 import WSKernel from './ws-kernel';
+import RobustGrammar from './robust-grammar';
 
 // View to display a list of grammars to apply to the current editor.
 export default class SignalListView extends SelectListView {
@@ -51,7 +52,7 @@ export default class SignalListView extends SelectListView {
     this.storeFocusedElement();
     if (!this.panel) { this.panel = atom.workspace.addModalPanel({ item: this }); }
     this.focusFilterEditor();
-    const grammar = this.editor.getGrammar();
+    const grammar = RobustGrammar(this.editor);
     const language = this.kernelManager.getLanguageFor(grammar);
 
     // disable all commands if no kernel is running


### PR DESCRIPTION
This PR adds one module to Hydrogen, in `robust-grammar.js`, which seeks to generalize [`TextEditor.getGrammar()`](https://atom.io/docs/api/v1.12.7/TextEditor#instance-getGrammar). If the current editor is AsciiDoc or Github-Flavored Markdown, we check the cursor’s [scope](https://atom.io/docs/api/v1.12.7/TextEditor#instance-scopeDescriptorForBufferPosition) for an alternative grammar. This happens when editing fenced code blocks in GFM, e.g.

With this robust alternative to `getGrammar()`, Hydrogen just has to pick the correct kernel given the cursor position.

Hydrogen continues to work with stand-alone (non-Markdown) source files, as illustrated below (where `Hydrogen: Run` is invoked on the fenced code block around the cursor by a keyboard macro):

![gfm-support](https://cloud.githubusercontent.com/assets/37649/21524931/b3ed07b0-cce7-11e6-951c-10aae8dfadd4.gif)

The extra call to the robust grammar checker each time `createResultBubble()` is run *should* be negligible. If this PR is accepted, the doors will be open for multilingual literate programming documentation!

(Caveat—as in the screencap above, this depends on `language-gfm` to understand a particular fenced code block, and it doesn’t (yet) support Octave. This issue is tracked at atom/language-gfm/issues/170.)