### PR TITLE
Only log to console if atom is in dev mode

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -13,7 +13,7 @@ settings:
   import/core-modules: [ atom ]
 
 rules:
-  no-console: [0]
+  no-console: [2, { allow: ["warn", "error"] }]
   no-param-reassign: [0]
   no-underscore-dangle: [0]
   no-useless-escape: [0]

--- a/lib/autocomplete-provider.js
+++ b/lib/autocomplete-provider.js
@@ -1,6 +1,7 @@
 'use babel';
 
 import _ from 'lodash';
+import log from './log';
 
 const iconHTML = `<img src='${__dirname}/../static/logo.svg' style='width: 100%;'>`;
 
@@ -57,7 +58,7 @@ export default function (kernelManager) {
         return null;
       }
 
-      console.log('autocompleteProvider: request:',
+      log('autocompleteProvider: request:',
         line, bufferPosition, prefix);
 
       return new Promise(resolve =>

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -3,6 +3,8 @@
 import escapeStringRegexp from 'escape-string-regexp';
 import _ from 'lodash';
 
+import log from './log';
+
 export default class CodeManager {
   constructor() {
     this.editor = atom.workspace.getActiveTextEditor();
@@ -25,7 +27,7 @@ export default class CodeManager {
     const cursor = this.editor.getLastCursor();
 
     const row = cursor.getBufferRow();
-    console.log('findCodeBlock:', row);
+    log('findCodeBlock:', row);
 
     const indentLevel = cursor.getIndentLevel();
 
@@ -102,7 +104,7 @@ export default class CodeManager {
       this.getRow(range[1] + 1) === 'end') {
       range[1] += 1;
     }
-    console.log('getFoldRange:', range);
+    log('getFoldRange:', range);
     return range;
   }
 
@@ -165,7 +167,7 @@ export default class CodeManager {
       end = range.start;
     });
 
-    console.log('CellManager: Cell [start, end]:', [start, end],
+    log('CellManager: Cell [start, end]:', [start, end],
       'cursor:', cursor);
 
     return [start, end];
@@ -184,7 +186,7 @@ export default class CodeManager {
 
     breakpoints.push(buffer.getEndPosition());
 
-    console.log('CellManager: Breakpoints:', breakpoints);
+    log('CellManager: Breakpoints:', breakpoints);
 
     return breakpoints;
   }
@@ -196,7 +198,7 @@ export default class CodeManager {
     const { commentStartString } = this.getCommentStrings(scope);
 
     if (!commentStartString) {
-      console.log('CellManager: No comment string defined in root scope');
+      log('CellManager: No comment string defined in root scope');
       return null;
     }
 

--- a/lib/inspector.js
+++ b/lib/inspector.js
@@ -3,6 +3,8 @@
 import { MessagePanelView, PlainMessageView } from 'atom-message-panel';
 import * as transformime from 'transformime';
 
+import log from './log';
+
 const transform = transformime.createTransform();
 
 export default class Inspector {
@@ -42,7 +44,7 @@ export default class Inspector {
 
 
   showInspectionResult(result) {
-    console.log('Inspector: Result:', result);
+    log('Inspector: Result:', result);
 
     if (!result.found) {
       atom.notifications.addInfo('No introspection available!');

--- a/lib/kernel-manager.js
+++ b/lib/kernel-manager.js
@@ -10,6 +10,7 @@ import Config from './config';
 import WSKernel from './ws-kernel';
 import ZMQKernel from './zmq-kernel';
 import KernelPicker from './kernel-picker';
+import log from './log';
 
 export default class KernelManager {
   constructor() {
@@ -58,7 +59,7 @@ export default class KernelManager {
       return;
     }
 
-    console.log('KernelManager: restartRunningKernelFor: ignored', kernel);
+    log('KernelManager: restartRunningKernelFor: ignored', kernel);
     atom.notifications.addWarning('Cannot restart this kernel');
     if (onRestarted) onRestarted(kernel);
   }
@@ -99,7 +100,7 @@ export default class KernelManager {
   startExistingKernel(grammar, connection, connectionFile, onStarted) {
     const language = this.getLanguageFor(grammar);
 
-    console.log('KernelManager: startExistingKernel: Assuming', language);
+    log('KernelManager: startExistingKernel: Assuming', language);
 
     const kernelSpec = {
       display_name: 'Existing Kernel',
@@ -121,7 +122,7 @@ export default class KernelManager {
   startKernel(kernelSpec, grammar, onStarted) {
     const language = this.getLanguageFor(grammar);
 
-    console.log('KernelManager: startKernelFor:', language);
+    log('KernelManager: startKernelFor:', language);
 
     const projectPath = path.dirname(
       atom.workspace.getActiveTextEditor().getPath(),
@@ -147,7 +148,7 @@ export default class KernelManager {
     const displayName = kernel.kernelSpec.display_name;
     let startupCode = Config.getJson('startupCode')[displayName];
     if (startupCode) {
-      console.log('KernelManager: Executing startup code:', startupCode);
+      log('KernelManager: Executing startup code:', startupCode);
       startupCode = `${startupCode} \n`;
       kernel.execute(startupCode);
     }
@@ -296,7 +297,7 @@ export default class KernelManager {
           kernelSpecs = JSON.parse(stdout).kernelspecs;
         } catch (error) {
           err = error;
-          console.log('Could not parse kernelspecs:', err);
+          log('Could not parse kernelspecs:', err);
         }
       }
 

--- a/lib/kernel-picker.js
+++ b/lib/kernel-picker.js
@@ -3,6 +3,8 @@
 import { SelectListView } from 'atom-space-pen-views';
 import _ from 'lodash';
 
+import log from './log';
+
 // View to display a list of grammars to apply to the current editor.
 export default class SignalListView extends SelectListView {
   initialize(getKernelSpecs) {
@@ -35,7 +37,7 @@ export default class SignalListView extends SelectListView {
   }
 
   confirmed(item) {
-    console.log('Selected command:', item);
+    log('Selected command:', item);
     if (this.onConfirmed) this.onConfirmed(item);
     this.cancel();
   }

--- a/lib/kernel.js
+++ b/lib/kernel.js
@@ -5,6 +5,7 @@ import { Emitter } from 'atom';
 import StatusView from './status-view';
 import WatchSidebar from './watch-sidebar';
 import HydrogenKernel from './plugin-api/hydrogen-kernel';
+import log from './log';
 
 export default class Kernel {
   constructor(kernelSpec, grammar) {
@@ -258,7 +259,7 @@ export default class Kernel {
   }
 
   destroy() {
-    console.log('Kernel: Destroying base kernel');
+    log('Kernel: Destroying base kernel');
     if (this.pluginWrapper) {
       this.pluginWrapper.destroyed = true;
     }

--- a/lib/log.js
+++ b/lib/log.js
@@ -1,0 +1,8 @@
+'use babel';
+
+/* eslint-disable no-console */
+export default function log(...message) {
+  if (atom.inDevMode() === true) {
+    console.debug('Hydrogen', ...message);
+  }
+}

--- a/lib/main.js
+++ b/lib/main.js
@@ -14,8 +14,8 @@ import Config from './config';
 import KernelManager from './kernel-manager';
 import Inspector from './inspector';
 import AutocompleteProvider from './autocomplete-provider';
-
 import HydrogenProvider from './plugin-api/hydrogen-provider';
+import log from './log';
 
 const Hydrogen = {
   config: Config.schema,
@@ -174,7 +174,7 @@ const Hydrogen = {
 
 
   setWatchSidebar(kernel) {
-    console.log('setWatchSidebar:', kernel);
+    log('setWatchSidebar:', kernel);
 
     const sidebar = (kernel) ? kernel.watchSidebar : null;
     if (this.watchSidebar === sidebar) {
@@ -195,11 +195,11 @@ const Hydrogen = {
 
   toggleWatchSidebar() {
     if (this.watchSidebarIsVisible) {
-      console.log('toggleWatchSidebar: hiding sidebar');
+      log('toggleWatchSidebar: hiding sidebar');
       this.watchSidebarIsVisible = false;
       if (this.watchSidebar) this.watchSidebar.hide();
     } else {
-      console.log('toggleWatchSidebar: showing sidebar');
+      log('toggleWatchSidebar: showing sidebar');
       this.watchSidebarIsVisible = true;
       if (this.watchSidebar) this.watchSidebar.show();
     }
@@ -217,7 +217,7 @@ const Hydrogen = {
 
 
   handleKernelCommand({ kernel, command, grammar, language, kernelSpec }) {
-    console.log('handleKernelCommand:', arguments);
+    log('handleKernelCommand:', arguments);
 
     if (!grammar) {
       grammar = this.editor.getGrammar();
@@ -318,7 +318,7 @@ const Hydrogen = {
 
     this.markerBubbleMap[marker.id] = view;
     marker.onDidChange((event) => {
-      console.log('marker.onDidChange:', marker);
+      log('marker.onDidChange:', marker);
       if (!event.isValid) {
         view.destroy();
         marker.destroy();
@@ -341,12 +341,12 @@ const Hydrogen = {
 
 
   clearBubblesOnRow(row) {
-    console.log('clearBubblesOnRow:', row);
+    log('clearBubblesOnRow:', row);
     _.forEach(this.markerBubbleMap, (bubble) => {
       const { marker } = bubble;
       const range = marker.getBufferRange();
       if (range.start.row <= row && row <= range.end.row) {
-        console.log('clearBubblesOnRow:', row, bubble);
+        log('clearBubblesOnRow:', row, bubble);
         bubble.destroy();
         delete this.markerBubbleMap[marker.id];
       }

--- a/lib/result-view.js
+++ b/lib/result-view.js
@@ -1,8 +1,9 @@
 'use babel';
 
 import { CompositeDisposable } from 'atom';
-
 import { createTransform } from 'transformime';
+
+import log from './log';
 
 const transform = createTransform();
 
@@ -117,13 +118,13 @@ export default class ResultView {
 
     if (result.stream === 'status') {
       if (!this._hasResult && result.data === 'ok') {
-        console.log('ResultView: Show status container');
+        log('ResultView: Show status container');
         this.statusContainer.classList.add('icon', 'icon-check');
       }
       return;
     }
 
-    console.log('ResultView: Add result', result);
+    log('ResultView: Add result', result);
 
     if (result.stream === 'stderr') {
       container = this.errorContainer;
@@ -136,7 +137,7 @@ export default class ResultView {
     }
 
     const onSuccess = ({ mimetype, el }) => {
-      console.log('ResultView: Hide status container');
+      log('ResultView: Hide status container');
       this._hasResult = true;
       this.statusContainer.classList.add('hidden');
 
@@ -172,8 +173,8 @@ export default class ResultView {
         htmlElement = webview;
       }
 
-      console.log('ResultView: Rendering as MIME ', mimeType);
-      console.log('ResultView: Rendering as ', htmlElement);
+      log('ResultView: Rendering as MIME ', mimeType);
+      log('ResultView: Rendering as ', htmlElement);
       // this.getAllText must be called after appending the htmlElement
       // in order to obtain innerText
       container.appendChild(htmlElement);

--- a/lib/signal-list-view.js
+++ b/lib/signal-list-view.js
@@ -4,6 +4,7 @@ import { SelectListView } from 'atom-space-pen-views';
 import _ from 'lodash';
 
 import WSKernel from './ws-kernel';
+import log from './log';
 
 // View to display a list of grammars to apply to the current editor.
 export default class SignalListView extends SelectListView {
@@ -103,7 +104,7 @@ export default class SignalListView extends SelectListView {
 
 
   confirmed(item) {
-    console.log('Selected command:', item);
+    log('Selected command:', item);
     if (this.onConfirmed) this.onConfirmed(item);
     this.cancel();
   }

--- a/lib/watch-view.js
+++ b/lib/watch-view.js
@@ -3,6 +3,7 @@
 import { TextEditorView } from 'atom-space-pen-views';
 
 import ResultView from './result-view';
+import log from './log';
 
 export default class WatchView {
 
@@ -101,10 +102,10 @@ export default class WatchView {
   run() {
     const code = this.getCode();
     this.clearResults();
-    console.log('watchview running:', code);
+    log('watchview running:', code);
     if (code && code.length && code.length > 0) {
       this.kernel.executeWatch(code, (result) => {
-        console.log('watchview got result:', result);
+        log('watchview got result:', result);
         this.resultView.addResult(result);
         this.addToHistory(result);
       });

--- a/lib/watches-picker.js
+++ b/lib/watches-picker.js
@@ -2,6 +2,8 @@
 
 import { SelectListView } from 'atom-space-pen-views';
 
+import log from './log';
+
 class SignalListView extends SelectListView {
   initialize() {
     super.initialize(...arguments);
@@ -30,7 +32,7 @@ class SignalListView extends SelectListView {
   }
 
   confirmed(item) {
-    console.log('Selected command:', item);
+    log('Selected command:', item);
 
     if (this.onConfirmed) {
       this.onConfirmed(item);

--- a/lib/ws-kernel.js
+++ b/lib/ws-kernel.js
@@ -2,6 +2,7 @@
 
 import Kernel from './kernel';
 import InputView from './input-view';
+import log from './log';
 
 export default class WSKernel extends Kernel {
   constructor(kernelSpec, grammar, session) {
@@ -39,7 +40,7 @@ export default class WSKernel extends Kernel {
       }
 
       if (onResults) {
-        console.log('WSKernel: _execute:', message);
+        log('WSKernel: _execute:', message);
         const result = this._parseIOMessage(message);
         if (result) onResults(result);
       }
@@ -115,7 +116,7 @@ export default class WSKernel extends Kernel {
   }
 
   destroy() {
-    console.log('WSKernel: destroying jupyter-js-services Session');
+    log('WSKernel: destroying jupyter-js-services Session');
     this.session.dispose();
     super.destroy(...arguments);
   }

--- a/lib/zmq-kernel.js
+++ b/lib/zmq-kernel.js
@@ -6,6 +6,7 @@ import v4 from 'uuid/v4';
 
 import Kernel from './kernel';
 import InputView from './input-view';
+import log from './log';
 
 export default class ZMQKernel extends Kernel {
   constructor(kernelSpec, grammar, connection, connectionFile, kernelProcess) {
@@ -19,7 +20,7 @@ export default class ZMQKernel extends Kernel {
     this._connect();
 
     if (this.kernelProcess) {
-      console.log('ZMQKernel: @kernelProcess:', this.kernelProcess);
+      log('ZMQKernel: @kernelProcess:', this.kernelProcess);
 
       const getKernelNotificationsRegExp = () => {
         try {
@@ -34,7 +35,7 @@ export default class ZMQKernel extends Kernel {
       this.kernelProcess.stdout.on('data', (data) => {
         data = data.toString();
 
-        console.log('ZMQKernel: stdout:', data);
+        log('ZMQKernel: stdout:', data);
 
         const regexp = getKernelNotificationsRegExp();
         if (regexp && regexp.test(data)) {
@@ -48,7 +49,7 @@ export default class ZMQKernel extends Kernel {
       this.kernelProcess.stderr.on('data', (data) => {
         data = data.toString();
 
-        console.log('ZMQKernel: stderr:', data);
+        log('ZMQKernel: stderr:', data);
 
         const regexp = getKernelNotificationsRegExp();
         if (regexp && regexp.test(data)) {
@@ -59,7 +60,7 @@ export default class ZMQKernel extends Kernel {
         }
       });
     } else {
-      console.log('ZMQKernel: connectionFile:', this.connectionFile);
+      log('ZMQKernel: connectionFile:', this.connectionFile);
       atom.notifications.addInfo('Using an existing kernel connection');
     }
   }
@@ -91,10 +92,10 @@ export default class ZMQKernel extends Kernel {
     this.ioSocket.on('message', this.onIOMessage.bind(this));
     this.stdinSocket.on('message', this.onStdinMessage.bind(this));
 
-    this.shellSocket.on('connect', () => console.log('shellSocket connected'));
-    this.controlSocket.on('connect', () => console.log('controlSocket connected'));
-    this.ioSocket.on('connect', () => console.log('ioSocket connected'));
-    this.stdinSocket.on('connect', () => console.log('stdinSocket connected'));
+    this.shellSocket.on('connect', () => log('shellSocket connected'));
+    this.controlSocket.on('connect', () => log('controlSocket connected'));
+    this.ioSocket.on('connect', () => log('ioSocket connected'));
+    this.stdinSocket.on('connect', () => log('stdinSocket connected'));
 
     try {
       this.shellSocket.monitor();
@@ -109,10 +110,10 @@ export default class ZMQKernel extends Kernel {
 
   interrupt() {
     if (this.kernelProcess) {
-      console.log('ZMQKernel: sending SIGINT');
+      log('ZMQKernel: sending SIGINT');
       this.kernelProcess.kill('SIGINT');
     } else {
-      console.log('ZMQKernel: cannot interrupt an existing kernel');
+      log('ZMQKernel: cannot interrupt an existing kernel');
       atom.notifications.addWarning('Cannot interrupt this kernel');
     }
   }
@@ -120,10 +121,10 @@ export default class ZMQKernel extends Kernel {
 
   _kill() {
     if (this.kernelProcess) {
-      console.log('ZMQKernel: sending SIGKILL');
+      log('ZMQKernel: sending SIGKILL');
       this.kernelProcess.kill('SIGKILL');
     } else {
-      console.log('ZMQKernel: cannot kill an existing kernel');
+      log('ZMQKernel: cannot kill an existing kernel');
       atom.notifications.addWarning('Cannot kill this kernel');
     }
   }
@@ -159,7 +160,7 @@ export default class ZMQKernel extends Kernel {
 
 
   execute(code, onResults) {
-    console.log('Kernel.execute:', code);
+    log('Kernel.execute:', code);
 
     const requestId = `execute_${v4()}`;
     this._execute(code, requestId, onResults);
@@ -167,7 +168,7 @@ export default class ZMQKernel extends Kernel {
 
 
   executeWatch(code, onResults) {
-    console.log('Kernel.executeWatch:', code);
+    log('Kernel.executeWatch:', code);
 
     const requestId = `watch_${v4()}`;
     this._execute(code, requestId, onResults);
@@ -175,7 +176,7 @@ export default class ZMQKernel extends Kernel {
 
 
   complete(code, onResults) {
-    console.log('Kernel.complete:', code);
+    log('Kernel.complete:', code);
 
     const requestId = `complete_${v4()}`;
 
@@ -195,7 +196,7 @@ export default class ZMQKernel extends Kernel {
 
 
   inspect(code, cursorPos, onResults) {
-    console.log('Kernel.inspect:', code, cursorPos);
+    log('Kernel.inspect:', code, cursorPos);
 
     const requestId = `inspect_${v4()}`;
 
@@ -224,7 +225,7 @@ export default class ZMQKernel extends Kernel {
 
   /* eslint-disable camelcase*/
   onShellMessage(message) {
-    console.log('shell message:', message);
+    log('shell message:', message);
 
     if (!this._isValidMessage(message)) {
       return;
@@ -274,7 +275,7 @@ export default class ZMQKernel extends Kernel {
 
 
   onStdinMessage(message) {
-    console.log('stdin message:', message);
+    log('stdin message:', message);
 
     if (!this._isValidMessage(message)) {
       return;
@@ -293,7 +294,7 @@ export default class ZMQKernel extends Kernel {
 
 
   onIOMessage(message) {
-    console.log('IO message:', message);
+    log('IO message:', message);
 
     if (!this._isValidMessage(message)) {
       return;
@@ -332,48 +333,48 @@ export default class ZMQKernel extends Kernel {
 
   _isValidMessage(message) {
     if (!message) {
-      console.log('Invalid message: null');
+      log('Invalid message: null');
       return false;
     }
 
     if (!message.content) {
-      console.log('Invalid message: Missing content');
+      log('Invalid message: Missing content');
       return false;
     }
 
     if (message.content.execution_state === 'starting') {
       // Kernels send a starting status message with an empty parent_header
-      console.log('Dropped starting status IO message');
+      log('Dropped starting status IO message');
       return false;
     }
 
     if (!message.parent_header) {
-      console.log('Invalid message: Missing parent_header');
+      log('Invalid message: Missing parent_header');
       return false;
     }
 
     if (!message.parent_header.msg_id) {
-      console.log('Invalid message: Missing parent_header.msg_id');
+      log('Invalid message: Missing parent_header.msg_id');
       return false;
     }
 
     if (!message.parent_header.msg_type) {
-      console.log('Invalid message: Missing parent_header.msg_type');
+      log('Invalid message: Missing parent_header.msg_type');
       return false;
     }
 
     if (!message.header) {
-      console.log('Invalid message: Missing header');
+      log('Invalid message: Missing header');
       return false;
     }
 
     if (!message.header.msg_id) {
-      console.log('Invalid message: Missing header.msg_id');
+      log('Invalid message: Missing header.msg_id');
       return false;
     }
 
     if (!message.header.msg_type) {
-      console.log('Invalid message: Missing header.msg_type');
+      log('Invalid message: Missing header.msg_type');
       return false;
     }
 
@@ -382,7 +383,7 @@ export default class ZMQKernel extends Kernel {
 
 
   destroy() {
-    console.log('ZMQKernel: destroy:', this);
+    log('ZMQKernel: destroy:', this);
 
     this.shutdown();
 


### PR DESCRIPTION
This will add a extra step for users to see the debugging logs, but won't clutter the dev console during normal usage.