### PR TITLE
Kernel Connection docs in README improvements

### DIFF
--- a/KERNEL_CONNECTION.md
+++ b/KERNEL_CONNECTION.md
@@ -1,0 +1,128 @@
+# Custom kernel connection example (inside Docker)
+
+**Note**: Hydrogen now supports using kernel gateways ([see the instructions in the main page](https://github.com/nteract/hydrogen/blob/master/README.md)). Using that option might be simpler and will allow you to use the functionality in Windows or Mac very easily.
+
+You can use a custom kernel connection file to connect to a previously created kernel.
+
+For example, you can run a kernel inside a Docker container and make Hydrogen connect to it automatically.
+
+Hydrogen will look for a kernel JSON connection file under `./hydrogen/connection.json` inside your project. If that file exists, Hydrogen will try to connect to the kernel specified by that connection file.
+
+Here's a simple recipe for doing and testing that with Python:
+
+* In your project directory, create a `Dockerfile` with:
+
+```
+FROM python:2.7
+
+RUN pip install markdown # Delete this line after testing
+
+RUN pip install ipykernel
+RUN echo "alias hydrokernel='python -m ipykernel "'--ip=$(hostname -I)'" -f /tmp/hydrogen/connection.json'" >> /etc/bash.bashrc
+```
+
+You will test using the Python package `markdown` from inside the Docker container in your local Atom editor, with autocompletion, etc.
+
+The last two lines are the only (temporary) addition to your `Dockerfile` that will allow you to develop locally using the remote Python kernel. If you already have a Python project with a `Dockerfile` you only need to copy those 2 lines and add them to it:
+
+```
+RUN pip install ipykernel
+RUN echo "alias hydrokernel='python -m ipykernel "'--ip=$(hostname -I)'" -f /tmp/hydrogen/connection.json'" >> /etc/bash.bashrc
+```
+
+The first of those two lines will install the Python package `ipykernel`, which is the only requisite to run the remote Python kernel.
+
+The second line creates a handy shortcut named `hydrokernel` to run a Python kernel that listens on the container's IP address and writes the connection file to `/tmp/hydrogen/connection.json`.
+
+* Run your container mounting a volume that maps `./hydrogen/` in your local project directory to `/tmp/hydrogen/` in your container. That's the trick that will allow Hydrogen to connect to the kernel running inside your container automatically. It's probably better to run it with the command `bash` and start the kernel manually, so that you can restart it if you need to (or if it dies).
+
+### Running using docker build
+
+* Build your container with:
+
+```
+docker build -t python-docker .
+```
+
+```
+docker run -it --name python-docker -v $(pwd)/hydrogen:/tmp/hydrogen python-docker bash
+```
+
+* Next, you just have to call the alias command we created in the `Dockerfile`, that will start the kernel with all the parameters needed:
+
+```
+hydrokernel
+```
+Please see below for information to do after your container has started running.
+
+### Running using docker-compose
+
+If you try to use `docker-compose` with the Dockerfile as above you might not be able to connect to hydrokernel. This is because the ports have been not forwarded and cannot be accessed from outside of the new docker-compose sub-network. You need to forward these ports manually in the `docker-compose.yml` file.
+
+To ensure the ports used by hydrokernel are the same each time it loads you must specify them on the command line. Do not try and use/modify connection.json as it is overwritten on startup.
+```
+python -m ipykernel --stdin=45323 --iopub=43223 --shell=41454 --control=44186 --hb=40772 --ip=0.0.0.0 -f /tmp/hydrogen/connection.json
+```
+You may notice that the IP address given is different, `0.0.0.0` binds to all possible interfaces.
+
+Create `docker-compose.yml` and paste the following:
+```
+version: '2'
+services:
+  hydrokernel:
+    build: .
+    ports: #FROM connection.json
+      - "45323:45323"
+      - "44186:44186"
+      - "40772:40772"
+      - "41454:41454"
+      - "43223:43223"
+    volumes:
+      - ./hydrogen:/tmp/hydrogen #hydrogen connection info
+    command: python -m ipykernel --stdin=45323 --iopub=43223 --shell=41454 --control=44186 --hb=40772 --ip=0.0.0.0 -f /tmp/hydrogen/connection.json
+```
+Key points:
+* Ensure `docker-compose.yml` is in the same directory as your `Dockerfile`. If you have put your Dockerfile in a subfolder then modify the `build` entry for the hydrokernel service in the `docker-compose.yml` file to point to the Dockerfile.
+
+* Ensure that the ports that are forwarded are exactly the same on the host machine as the container i.e. port 45323 should be forwarded to 45253. Reason being, Hydrogen will attempt to connect using the ports in the connection.json file which will be described as the container sees them, not the host.
+
+* You could also run the command in the Dockerfile as a `CMD` entry but this way it's crystal clear what ports we're forwarding, there are quite a few so switching between files to get them is a headache!
+
+You can then use `docker-compose up` in the same directory as docker-compose.yml to start it up.
+
+Please see below for information to do after your container has started running.
+
+### When your container is running
+* You will see an output similar to:
+
+```
+root@24ae5d04ef3c:/# hydrokernel
+NOTE: When using the `ipython kernel` entry point, Ctrl-C will not work.
+
+To exit, you will have to explicitly quit this process, by either sending
+"quit" from a client, or using Ctrl-\ in UNIX-like environments.
+
+To read more about this, see https://github.com/ipython/ipython/issues/2049
+
+
+To connect another client to this kernel, use:
+    --existing /tmp/hydrogen/connection.json
+```
+
+* And you will see that a file was created in `./hydrogen/connection.json` inside your project directory.
+
+* Now you can create a file `test.py` with:
+
+```
+import markdown
+markdown.version
+```
+
+* Select the contents and run them with Hydrogen ("`cmd-shift-P`" and "`Hydrogen: run`").
+
+* You will see the inline execution and output that just ran from your kernel, even if you don't have the Python package `markdown` installed locally, because it's running inside your container.
+
+```
+import markdown [✓]
+markdown.version ['2.6.6']
+```

--- a/KERNEL_CONNECTION.md
+++ b/KERNEL_CONNECTION.md
@@ -1,6 +1,6 @@
 # Custom kernel connection example (inside Docker)
 
-**Note**: Hydrogen now supports using kernel gateways ([see the instructions in the main page](https://github.com/nteract/hydrogen/blob/master/README.md)). Using that option might be simpler and will allow you to use the functionality in Windows or Mac very easily.
+**Note**: Hydrogen now supports using kernel gateways ([see the instructions in the main page](https://github.com/nteract/hydrogen/blob/master/README.md)). Using that option might be simpler in most of the use cases. For example, it will allow you to use the functionality from a Docker virtual machine in Windows or Mac as easily as if it was Linux.
 
 You can use a custom kernel connection file to connect to a previously created kernel.
 

--- a/README.md
+++ b/README.md
@@ -511,9 +511,9 @@ exit
 
 ## Custom kernel connection
 
-**Hydrogen** also supports using a custom kernel connection file for each project. It could be used to connect to "remote" environments as Docker, a remote computer, etc. But the method described above using [**kernel gateways**](remote-kernels-via-kernel-gateways) is less error prone and simpler to apply in more cases.
+**Hydrogen** also supports using a custom kernel connection file for each project. It could be used to connect to "remote" environments as Docker, a remote computer, etc. But the method described above using [**kernel gateways**](#remote-kernels-via-kernel-gateways) is less error prone and simpler to apply in more cases.
 
-The recommended way of connecting to remote kernels is now using [**kernel gateways** as described above](remote-kernels-via-kernel-gateways). But if you still need to use a custom kernel connection file you can [read the **Custom kernel connection** guide here](https://github.com/nteract/hydrogen/blob/master/KERNEL_CONNECTION.md).
+The recommended way of connecting to remote kernels is now using [**kernel gateways** as described above](#remote-kernels-via-kernel-gateways). But if you still need to use a custom kernel connection file you can [read the **Custom kernel connection** guide here](https://github.com/nteract/hydrogen/blob/master/KERNEL_CONNECTION.md).
 
 
 ## Why "Hydrogen"?

--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ docker-compose ps
 
 #### Connect Atom
 
-Now you need to connect Atom to your setup. Follow the section [**Connect Atom**](#connect-atom) below.
+Now you need to connect Atom to your setup. Follow the section [**Connect Atom**](#connect-atom-1) below.
 
 ### Example Docker kernel gateway
 

--- a/README.md
+++ b/README.md
@@ -233,11 +233,91 @@ As of December 2016, we recommend that you use a notebook server (version 4.3 or
 
 You can use the same technique to create a kernel gateway in a Docker container. That would allow you to develop from Atom but with all the dependencies, autocompletion, environment, etc. of a Docker container.
 
-But, due to the way that the kernel gateway creates sub-processes for each kernel, you have to use it in a special way, you can't run the `jupyter kernelgateway` directly in your `Dockerfile` `CMD` section. You need to call it with an init manager such as [tini](https://github.com/krallin/tini) or run it from an interactive console.
+**Note**: due to the way that the kernel gateway creates sub-processes for each kernel, you have to use it in a special way, you can't run the `jupyter kernelgateway` directly in your `Dockerfile` `CMD` section. You need to call it with an init manager such as [tini](https://github.com/krallin/tini) or run it from an interactive console.
 
-Here's an example of how to setup a Docker execution environment with Hydrogen running the kernel gateway from an interactive console:
+If all you need is a Docker Python environment to execute your code, you can read the section [**Example Jupyter Docker Stack kernel gateway**](#example-jupyter-docker-stack-kernel-gateway) (this method uses **tini** under the hood).
+
+If you want to add a temporal Kernel Gateway (for development) to your current Docker images or need to modify an existing image to add the Kernel Gateway functionality, read the section [**Example Docker kernel gateway**](#example-docker-kernel-gateway) (this method runs the kernel gateway from an interactive console).
+
+### Example Jupyter Docker Stack kernel gateway
+
+Follow this if you only need to have a simple environment to run commands inside a Docker container and nothing more.
+
+If you need to customize a Docker image (e.g. for web development) follow the section below: [**Example Docker kernel gateway**](#example-docker-kernel-gateway).
+
+#### Dockerfile
+
+- Create a `Dockerfile` based on one of the [Jupyter Docker Stacks](https://github.com/jupyter/docker-stacks).
+- Install `jupyter_kernel_gateway` in your `Dockerfile`
+- Expose the gateway port, in this example it will be `8888`
+- Make the command to run be the Kernel Gateway:
+
+```Dockerfile
+FROM jupyter/minimal-notebook
+
+RUN pip install jupyter_kernel_gateway
+
+EXPOSE 8888
+CMD ["jupyter", "kernelgateway", "--KernelGatewayApp.ip=0.0.0.0", "--KernelGatewayApp.port=8888"]
+```
+
+#### Run Docker Container with Docker commands
+
+**Note**: alternatively, see below for `docker-compose` instructions.
+
+- Build your container:
+
+```bash
+docker build -t hydro-kernel-gateway .
+```
+
+- Run your container mapping the port of the gateway
+- Give your container a name
+
+```bash
+docker run -it --rm --name hydro-kernel-gateway -p 8888:8888 hydro-kernel-gateway
+```
+
+**Note**: you will only be able to run one container using that port mapping. So, if you had another container using that port, you will have to stop that one first. Or alternatively, you can create a mapping to a new port and add that configuration in the Hydrogen settings (see below).
+
+#### Run Docker Container with Docker Compose
+
+- Create a `docker-compose.yml` file with something like:
+
+```yml
+version: '2'
+services:
+  hydro-kernel-gateway:
+    build: .
+    ports:
+      - "8888:8888"
+```
+
+- The `docker-compose.yml` file has a port mapping using the port exposed in the `Dockerfile` and used in the `jupyter kernelgateway` command
+
+**Note**: you will only be able to run one container using that port mapping. So, if you had another container using that port, you will have to stop that one first. Or alternatively, you can create a mapping to a new port and add that configuration in the Hydrogen settings (see below).
+
+- Now start (and build) your container with `docker-compose`:
+
+```bash
+docker-compose up -d
+```
+
+- Check the name of your running container with:
+
+```bash
+docker-compose ps
+```
+
+#### Connect Atom
+
+Now you need to connect Atom to your setup. Follow the section [**Connect Atom**](#connect-atom) below.
 
 ### Example Docker kernel gateway
+
+Follow this if you need to customize a Docker image you already have. For example, for a web project.
+
+If you only need a simple environment in where to run Python commands with Hydrogen inside a Docker container, follow the section above: [**Example Jupyter Docker Stack kernel gateway**](#example-jupyter-docker-stack-kernel-gateway).
 
 #### Dockerfile
 
@@ -332,7 +412,7 @@ docker exec -it myproject_hydro_1 bash
 jupyter kernelgateway --ip=0.0.0.0 --port=8888
 ```
 
-#### Connect Atom
+### Connect Atom
 
 - Go to the settings in Atom with: `ctrl-shift-p` and type `Settings View: Open`
 - Go to the "Packages" section
@@ -351,11 +431,11 @@ jupyter kernelgateway --ip=0.0.0.0 --port=8888
 - In Atom, open a Python file, e.g. `main.py`
 - Connect to the kernel you just configured: `ctrl-shift-p` and type: `Hydrogen: Connect To Remote Kernel`
 - Select the kernel gateway you configured, e.g. `Docker Toolbox`
-- Select the "type of kernel" to run, there will just be the option `Python 2`
+- Select the "type of kernel" to run, there will just be the option `Python 2` or `Python 3`
 - Then select the line or block of code that you want to execute inside of your container
 - Run the code with: `ctrl-shift-p` and type: `Hydrogen: Run`
 
-#### Testing it
+### Testing it
 
 You can test that it is actually working by installing a package in your container that you don't have locally and using it inside your container (from your Atom editor).
 
@@ -369,6 +449,12 @@ RUN pip install markdown
 # Remove in production
 RUN pip install jupyter_kernel_gateway
 EXPOSE 8888
+```
+
+**Note**: If you followed the [**Example Jupyter Docker Stack kernel gateway**](#example-jupyter-docker-stack-kernel-gateway) section, your `Dockerfile` will look different. Just make sure you add a line with:
+
+```Dockerfile
+RUN pip install markdown
 ```
 
 - Follow all the instructions above, and use a Python file that has:
@@ -385,11 +471,13 @@ import markdown [✓]
 markdown.version ['2.6.6']
 ```
 
-#### Terminate the connection and container
+### Terminate the connection and container
 
 - To terminate a running kernel gateway you can "kill" it as any Linux process with `ctrl-c`
 
-But because of the way Jupyter Kernel Gateway creates sub-processes and due to the fact that you are running in a Docker container, the actual kernel process will still be running.
+- If you followed the section [**Example Jupyter Docker Stack kernel gateway**](#example-jupyter-docker-stack-kernel-gateway), it will just work.
+
+But, if you are using the general instructions (for a custom Docker image), because of the way Jupyter Kernel Gateway creates sub-processes and due to the fact that you are running in a Docker container, the actual kernel process will still be running.
 
 - Before exiting the terminal, find the still running (Python) kernel process with:
 
@@ -421,135 +509,11 @@ pkill python
 exit
 ```
 
-## Custom kernel connection (inside Docker)
+## Custom kernel connection
 
-**Note**: Hydrogen now supports using kernel gateways (see the instructions above). Using that option might be simpler and will allow you to use the functionality in Windows or Mac very easily.
+**Hydrogen** also supports using a custom kernel connection file for each project. It could be used to connect to "remote" environments as Docker, a remote computer, etc. But the method described above using **kernel gateways** is less error prone and simpler to apply in more cases.
 
-You can use a custom kernel connection file to connect to a previously created kernel.
-
-For example, you can run a kernel inside a Docker container and make Hydrogen connect to it automatically.
-
-Hydrogen will look for a kernel JSON connection file under `./hydrogen/connection.json` inside your project. If that file exists, Hydrogen will try to connect to the kernel specified by that connection file.
-
-Here's a simple recipe for doing and testing that with Python:
-
-* In your project directory, create a `Dockerfile` with:
-
-```
-FROM python:2.7
-
-RUN pip install markdown # Delete this line after testing
-
-RUN pip install ipykernel
-RUN echo "alias hydrokernel='python -m ipykernel "'--ip=$(hostname -I)'" -f /tmp/hydrogen/connection.json'" >> /etc/bash.bashrc
-```
-
-You will test using the Python package `markdown` from inside the Docker container in your local Atom editor, with autocompletion, etc.
-
-The last two lines are the only (temporary) addition to your `Dockerfile` that will allow you to develop locally using the remote Python kernel. If you already have a Python project with a `Dockerfile` you only need to copy those 2 lines and add them to it:
-
-```
-RUN pip install ipykernel
-RUN echo "alias hydrokernel='python -m ipykernel "'--ip=$(hostname -I)'" -f /tmp/hydrogen/connection.json'" >> /etc/bash.bashrc
-```
-
-The first of those two lines will install the Python package `ipykernel`, which is the only requisite to run the remote Python kernel.
-
-The second line creates a handy shortcut named `hydrokernel` to run a Python kernel that listens on the container's IP address and writes the connection file to `/tmp/hydrogen/connection.json`.
-
-* Run your container mounting a volume that maps `./hydrogen/` in your local project directory to `/tmp/hydrogen/` in your container. That's the trick that will allow Hydrogen to connect to the kernel running inside your container automatically. It's probably better to run it with the command `bash` and start the kernel manually, so that you can restart it if you need to (or if it dies).
-
-### Running using docker build
-
-* Build your container with:
-
-```
-docker build -t python-docker .
-```
-
-```
-docker run -it --name python-docker -v $(pwd)/hydrogen:/tmp/hydrogen python-docker bash
-```
-
-* Next, you just have to call the alias command we created in the `Dockerfile`, that will start the kernel with all the parameters needed:
-
-```
-hydrokernel
-```
-Please see below for information to do after your container has started running.
-
-### Running using docker-compose
-
-If you try to use `docker-compose` with the Dockerfile as above you might not be able to connect to hydrokernel. This is because the ports have been not forwarded and cannot be accessed from outside of the new docker-compose sub-network. You need to forward these ports manually in the `docker-compose.yml` file.
-
-To ensure the ports used by hydrokernel are the same each time it loads you must specify them on the command line. Do not try and use/modify connection.json as it is overwritten on startup.
-```
-python -m ipykernel --stdin=45323 --iopub=43223 --shell=41454 --control=44186 --hb=40772 --ip=0.0.0.0 -f /tmp/hydrogen/connection.json
-```
-You may notice that the IP address given is different, `0.0.0.0` binds to all possible interfaces.
-
-Create `docker-compose.yml` and paste the following:
-```
-version: '2'
-services:
-  hydrokernel:
-    build: .
-    ports: #FROM connection.json
-      - "45323:45323"
-      - "44186:44186"
-      - "40772:40772"
-      - "41454:41454"
-      - "43223:43223"
-    volumes:
-      - ./hydrogen:/tmp/hydrogen #hydrogen connection info
-    command: python -m ipykernel --stdin=45323 --iopub=43223 --shell=41454 --control=44186 --hb=40772 --ip=0.0.0.0 -f /tmp/hydrogen/connection.json
-```
-Key points:
-* Ensure `docker-compose.yml` is in the same directory as your `Dockerfile`. If you have put your Dockerfile in a subfolder then modify the `build` entry for the hydrokernel service in the `docker-compose.yml` file to point to the Dockerfile.
-
-* Ensure that the ports that are forwarded are exactly the same on the host machine as the container i.e. port 45323 should be forwarded to 45253. Reason being, Hydrogen will attempt to connect using the ports in the connection.json file which will be described as the container sees them, not the host.
-
-* You could also run the command in the Dockerfile as a `CMD` entry but this way it's crystal clear what ports we're forwarding, there are quite a few so switching between files to get them is a headache!
-
-You can then use `docker-compose up` in the same directory as docker-compose.yml to start it up.
-
-Please see below for information to do after your container has started running.
-
-### When your container is running
-* You will see an output similar to:
-
-```
-root@24ae5d04ef3c:/# hydrokernel
-NOTE: When using the `ipython kernel` entry point, Ctrl-C will not work.
-
-To exit, you will have to explicitly quit this process, by either sending
-"quit" from a client, or using Ctrl-\ in UNIX-like environments.
-
-To read more about this, see https://github.com/ipython/ipython/issues/2049
-
-
-To connect another client to this kernel, use:
-    --existing /tmp/hydrogen/connection.json
-```
-
-* And you will see that a file was created in `./hydrogen/connection.json` inside your project directory.
-
-* Now you can create a file `test.py` with:
-
-```
-import markdown
-markdown.version
-```
-
-* Select the contents and run them with Hydrogen ("`cmd-shift-P`" and "`Hydrogen: run`").
-
-* You will see the inline execution and output that just ran from your kernel, even if you don't have the Python package `markdown` installed locally, because it's running inside your container.
-
-```
-import markdown [✓]
-markdown.version ['2.6.6']
-```
-
+The recommended way of connecting to remote kernels is now using **kernel gateways** as described above. But if you still need to use a custom kernel connection file you can [read the **Custom kernel connection** guide here](https://github.com/nteract/hydrogen/blob/master/KERNEL_CONNECTION.md).
 
 
 ## Why "Hydrogen"?

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ As of December 2016, we recommend that you use a notebook server (version 4.3 or
 
 You can use the same technique to create a kernel gateway in a Docker container. That would allow you to develop from Atom but with all the dependencies, autocompletion, environment, etc. of a Docker container.
 
-**Note**: due to the way that the kernel gateway creates sub-processes for each kernel, you have to use it in a special way, you can't run the `jupyter kernelgateway` directly in your `Dockerfile` `CMD` section. You need to call it with an init manager such as [tini](https://github.com/krallin/tini) or run it from an interactive console.
+**Note**: due to the way that the kernel gateway creates sub-processes for each kernel, you have to use it in a special way, you can't run the `jupyter kernelgateway` directly in your `Dockerfile` `CMD` section. You need to call it with an init manager such as [**tini**](https://github.com/krallin/tini) or run it from an interactive console.
 
 If all you need is a Docker Python environment to execute your code, you can read the section [**Example Jupyter Docker Stack kernel gateway**](#example-jupyter-docker-stack-kernel-gateway) (this method uses **tini** under the hood).
 
@@ -475,7 +475,7 @@ markdown.version ['2.6.6']
 
 - To terminate a running kernel gateway you can "kill" it as any Linux process with `ctrl-c`
 
-- If you followed the section [**Example Jupyter Docker Stack kernel gateway**](#example-jupyter-docker-stack-kernel-gateway), it will just work.
+- If you followed the [**Example Jupyter Docker Stack kernel gateway**](#example-jupyter-docker-stack-kernel-gateway) section, it will just work.
 
 But, if you are using the general instructions (for a custom Docker image), because of the way Jupyter Kernel Gateway creates sub-processes and due to the fact that you are running in a Docker container, the actual kernel process will still be running.
 
@@ -511,9 +511,9 @@ exit
 
 ## Custom kernel connection
 
-**Hydrogen** also supports using a custom kernel connection file for each project. It could be used to connect to "remote" environments as Docker, a remote computer, etc. But the method described above using **kernel gateways** is less error prone and simpler to apply in more cases.
+**Hydrogen** also supports using a custom kernel connection file for each project. It could be used to connect to "remote" environments as Docker, a remote computer, etc. But the method described above using [**kernel gateways**](remote-kernels-via-kernel-gateways) is less error prone and simpler to apply in more cases.
 
-The recommended way of connecting to remote kernels is now using **kernel gateways** as described above. But if you still need to use a custom kernel connection file you can [read the **Custom kernel connection** guide here](https://github.com/nteract/hydrogen/blob/master/KERNEL_CONNECTION.md).
+The recommended way of connecting to remote kernels is now using [**kernel gateways** as described above](remote-kernels-via-kernel-gateways). But if you still need to use a custom kernel connection file you can [read the **Custom kernel connection** guide here](https://github.com/nteract/hydrogen/blob/master/KERNEL_CONNECTION.md).
 
 
 ## Why "Hydrogen"?


### PR DESCRIPTION
As discussed in https://github.com/nteract/hydrogen/issues/528:

* Put the section for custom Kernel Connection files in an external file (not in the README).
* Add a section in the README with instructions to set up a Docker kernel gateway based on a Jupyter Docker Stack.
* Adjust other sections to account for the new section.

I tested all the instructions in a local "demo" project to make sure they worked as expected.

I guess @MaximilianR and @lgeiger can check it. :smiley: 

I'm sorry for the delay creating this PR, I got very busy with end-of-year project deliveries and I wanted to have the time to test all the instructions and make sure everything worked.