### PR TITLE
hydrogen projects

### DIFF
--- a/hydrogen.cson
+++ b/hydrogen.cson
@@ -1,0 +1,14 @@
+javascript:
+  code: 'a=1'
+  
+python:
+  kernel: 'Python 3'
+  code: '''
+  qwe=123
+  '''
+  files: [
+    './py.py'
+    './py2.py'
+  ]
+    
+  

--- a/lib/config.js
+++ b/lib/config.js
@@ -43,7 +43,7 @@ const Config = {
       type: 'string',
       default: '{}',
     }
-  },
+  }
 };
 
 export default Config;

--- a/lib/config.js
+++ b/lib/config.js
@@ -43,6 +43,12 @@ const Config = {
       type: 'string',
       default: '{}',
     },
+    startupCode: {
+      title: 'Startup Code',
+      description: 'This code will be executed on kernel startup. Format: `{"kernel": "your code \\nmore code"}`. Example: `{"Python 2": "%matplotlib inline"}`',
+      type: 'string',
+      default: '{}',
+    },
   },
 };
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -42,8 +42,8 @@ const Config = {
       description: 'Some kernels may use a non-standard language name (e.g. jupyter-scala sets the language name to `scala211`). That leaves Hydrogen unable to figure out what kernel for your code. This field should be a valid JSON mapping from a kernel language name to Atom\'s lower-cased grammar name, e.g. ``` { "scala211": "scala", "Elixir": "elixir" } ```',
       type: 'string',
       default: '{}',
-    }
-  }
+    },
+  },
 };
 
 export default Config;

--- a/lib/config.js
+++ b/lib/config.js
@@ -42,13 +42,7 @@ const Config = {
       description: 'Some kernels may use a non-standard language name (e.g. jupyter-scala sets the language name to `scala211`). That leaves Hydrogen unable to figure out what kernel for your code. This field should be a valid JSON mapping from a kernel language name to Atom\'s lower-cased grammar name, e.g. ``` { "scala211": "scala", "Elixir": "elixir" } ```',
       type: 'string',
       default: '{}',
-    },
-    startupCode: {
-      title: 'Startup Code',
-      description: 'This code will be executed on kernel startup. Format: `{"kernel": "your code \\nmore code"}`. Example: `{"Python 2": "%matplotlib inline"}`',
-      type: 'string',
-      default: '{}',
-    },
+    }
   },
 };
 

--- a/lib/kernel-init.js
+++ b/lib/kernel-init.js
@@ -6,8 +6,13 @@ import path from 'path';
 import CSONParser from 'cson-parser';
 
 import log from './log';
+import Config from './config';
 
 const PROJECT_CONFIG_FILE = 'hydrogen.cson';
+const DEFAULT_KERNEL_INIT = {
+  files: [],
+  code: '',
+};
 
 function execInitFiles(kernel, files) {
   if (_.isEmpty(files)) return;
@@ -24,37 +29,31 @@ function execInitFiles(kernel, files) {
   });
 }
 
-function kernelInit(kernel) {
-  _.map(getInitConfig(), (initConfig) => {
-    const init = initConfig[kernel.kernelSpec.language];
-    if (!init) return;
-    if (init.code) {
-      kernel.execute(init.code, () => execInitFiles(kernel, init.files));
-    } else {
-      execInitFiles(kernel, init.files);
-    }
-  });
-}
-
-function _getInitConfig() {
-  return _.map(atom.project.getPaths(), (projectRoot) => {
+function getInitConfig() {
+  return _.filter(_.map(atom.project.getPaths(), (projectRoot) => {
     try {
       const init = CSONParser.parse(fs.readFileSync(projectRoot + path.sep + PROJECT_CONFIG_FILE));
-      return _.map(init, (kernelInit) => {
-        kernelInit.files = _.map(_.defaultTo(kernelInit.files, []),
-         f => projectRoot + path.sep + f);
-         
-        return kernelInit
+      return _.mapValues(init, (kernelInit) => {
+        kernelInit = _.assign(DEFAULT_KERNEL_INIT, kernelInit);
+        kernelInit.files = _.map(kernelInit.files, f => projectRoot + path.sep + f);
+
+        return kernelInit;
       });
     } catch (e) {
       log(e);
     }
-    return ''; //Satisfy eslint rules :(
+    return '';// Satisfy eslint rules :(
+  }));
+}
+
+function initKernel(kernel) {
+  const displayName = kernel.kernelSpec.display_name;
+  const startupCode = Config.getJson('startupCode')[displayName];
+
+  _.map(getInitConfig(), (initConfig) => {
+    const init = initConfig[kernel.kernelSpec.language];
+    kernel.execute([startupCode, init.code].join('\n'), () => execInitFiles(kernel, init.files));
   });
 }
 
-function getInitConfig() {
-  return _.filter(_getInitConfig())
-}
-
-export default { kernelInit, getInitConfig }
+export default { initKernel, getInitConfig };

--- a/lib/kernel-init.js
+++ b/lib/kernel-init.js
@@ -26,20 +26,20 @@ function execInitFiles(kernel, files) {
 
 export default function kernelInit(kernel) {
   _.map(atom.project.getPaths(), (projectRoot) => {
-    let config;
+    let projectInit;
     try {
-      config = CSONParser.parse(fs.readFileSync(projectRoot + path.sep + PROJECT_CONFIG_FILE));
+      projectInit = CSONParser.parse(fs.readFileSync(projectRoot + path.sep + PROJECT_CONFIG_FILE));
     } catch (e) {
       log(e);
       return;
     }
-    const cfg = config.init[kernel.kernelSpec.display_name]
-    cfg.files = _.map(cfg.files, f => projectRoot + path.sep + f);
-    const { files, code } = config.init[kernel.kernelSpec.display_name];
-    if (code) {
-      kernel.execute(code, () => execInitFiles(kernel, files));
+    if (!projectInit.init) return;
+    const init = projectInit.init[kernel.kernelSpec.display_name];
+    init.files = _.map(_.defaultTo(init.files, []), f => projectRoot + path.sep + f);
+    if (init.code) {
+      kernel.execute(init.code, () => execInitFiles(kernel, init.files));
     } else {
-      execInitFiles(kernel, files);
+      execInitFiles(kernel, init.files);
     }
   });
 }

--- a/lib/kernel-init.js
+++ b/lib/kernel-init.js
@@ -24,18 +24,10 @@ function execInitFiles(kernel, files) {
   });
 }
 
-export default function kernelInit(kernel) {
-  _.map(atom.project.getPaths(), (projectRoot) => {
-    let projectInit;
-    try {
-      projectInit = CSONParser.parse(fs.readFileSync(projectRoot + path.sep + PROJECT_CONFIG_FILE));
-    } catch (e) {
-      log(e);
-      return;
-    }
-    if (!projectInit.init) return;
-    const init = projectInit.init[kernel.kernelSpec.display_name];
-    init.files = _.map(_.defaultTo(init.files, []), f => projectRoot + path.sep + f);
+function kernelInit(kernel) {
+  _.map(getInitConfig(), (initConfig) => {
+    const init = initConfig[kernel.kernelSpec.language];
+    if (!init) return;
     if (init.code) {
       kernel.execute(init.code, () => execInitFiles(kernel, init.files));
     } else {
@@ -43,3 +35,26 @@ export default function kernelInit(kernel) {
     }
   });
 }
+
+function _getInitConfig() {
+  return _.map(atom.project.getPaths(), (projectRoot) => {
+    try {
+      const init = CSONParser.parse(fs.readFileSync(projectRoot + path.sep + PROJECT_CONFIG_FILE));
+      return _.map(init, (kernelInit) => {
+        kernelInit.files = _.map(_.defaultTo(kernelInit.files, []),
+         f => projectRoot + path.sep + f);
+         
+        return kernelInit
+      });
+    } catch (e) {
+      log(e);
+    }
+    return ''; //Satisfy eslint rules :(
+  });
+}
+
+function getInitConfig() {
+  return _.filter(_getInitConfig())
+}
+
+export default { kernelInit, getInitConfig }

--- a/lib/kernel-init.js
+++ b/lib/kernel-init.js
@@ -7,7 +7,7 @@ import CSONParser from 'cson-parser';
 
 import log from './log';
 
-const PROJECT_CONFIG_FILE = 'hydrogen.cson'
+const PROJECT_CONFIG_FILE = 'hydrogen.cson';
 
 function execInitFiles(kernel, files) {
   if (_.isEmpty(files)) return;
@@ -15,13 +15,13 @@ function execInitFiles(kernel, files) {
   const file = files.shift();
   fs.readFile(file, 'utf8', (e, code) => {
     if (e) log('init: error:', e);
-    if (!code || e) return
+    if (!code || e) return;
 
     kernel.execute(code, (result) => {
       log('init: result', result);
       execInitFiles(kernel, files);
-    })
-  })
+    });
+  });
 }
 
 export default function kernelInit(kernel) {
@@ -30,15 +30,16 @@ export default function kernelInit(kernel) {
     try {
       config = CSONParser.parse(fs.readFileSync(projectRoot + path.sep + PROJECT_CONFIG_FILE));
     } catch (e) {
-      log(e)
-      return
+      log(e);
+      return;
     }
-    let { files, code } = config.init[kernel.kernelSpec.display_name];
-    files = _.map(files, f => projectRoot + path.sep + f);
+    const cfg = config.init[kernel.kernelSpec.display_name]
+    cfg.files = _.map(cfg.files, f => projectRoot + path.sep + f);
+    const { files, code } = config.init[kernel.kernelSpec.display_name];
     if (code) {
-      kernel.execute(code, result => execInitFiles(kernel, files));
+      kernel.execute(code, () => execInitFiles(kernel, files));
     } else {
       execInitFiles(kernel, files);
     }
-  })
+  });
 }

--- a/lib/kernel-init.js
+++ b/lib/kernel-init.js
@@ -1,0 +1,44 @@
+'use babel';
+
+import _ from 'lodash';
+import fs from 'fs';
+import path from 'path';
+import CSONParser from 'cson-parser';
+
+import log from './log';
+
+const PROJECT_CONFIG_FILE = 'hydrogen.cson'
+
+function execInitFiles(kernel, files) {
+  if (_.isEmpty(files)) return;
+
+  const file = files.shift();
+  fs.readFile(file, 'utf8', (e, code) => {
+    if (e) log('init: error:', e);
+    if (!code || e) return
+
+    kernel.execute(code, (result) => {
+      log('init: result', result);
+      execInitFiles(kernel, files);
+    })
+  })
+}
+
+export default function kernelInit(kernel) {
+  _.map(atom.project.getPaths(), (projectRoot) => {
+    let config;
+    try {
+      config = CSONParser.parse(fs.readFileSync(projectRoot + path.sep + PROJECT_CONFIG_FILE));
+    } catch (e) {
+      log(e)
+      return
+    }
+    let { files, code } = config.init[kernel.kernelSpec.display_name];
+    files = _.map(files, f => projectRoot + path.sep + f);
+    if (code) {
+      kernel.execute(code, result => execInitFiles(kernel, files));
+    } else {
+      execInitFiles(kernel, files);
+    }
+  })
+}

--- a/lib/kernel-manager.js
+++ b/lib/kernel-manager.js
@@ -11,6 +11,7 @@ import WSKernel from './ws-kernel';
 import ZMQKernel from './zmq-kernel';
 import KernelPicker from './kernel-picker';
 import log from './log';
+import kernelInit from './kernel-init'
 
 export default class KernelManager {
   constructor() {
@@ -124,9 +125,7 @@ export default class KernelManager {
 
     log('KernelManager: startKernelFor:', language);
 
-    const projectPath = path.dirname(
-      atom.workspace.getActiveTextEditor().getPath(),
-    );
+    const projectPath = atom.project.getPaths()[0]
     const spawnOptions = { cwd: projectPath };
     launchSpec(kernelSpec, spawnOptions)
     .then(({ config, connectionFile, spawn }) => {
@@ -137,12 +136,11 @@ export default class KernelManager {
       );
       this.setRunningKernelFor(grammar, kernel);
 
-      this._executeStartupCode(kernel);
+      kernelInit(kernel)
 
       if (onStarted) onStarted(kernel);
     });
   }
-
 
   _executeStartupCode(kernel) {
     const displayName = kernel.kernelSpec.display_name;
@@ -153,7 +151,6 @@ export default class KernelManager {
       kernel.execute(startupCode);
     }
   }
-
 
   getAllRunningKernels() {
     return _.clone(this._runningKernels);

--- a/lib/kernel-manager.js
+++ b/lib/kernel-manager.js
@@ -11,7 +11,7 @@ import WSKernel from './ws-kernel';
 import ZMQKernel from './zmq-kernel';
 import KernelPicker from './kernel-picker';
 import log from './log';
-import { kernelInit, getInitConfig} from './kernel-init';
+import { initKernel, getInitConfig } from './kernel-init';
 
 export default class KernelManager {
   constructor() {
@@ -114,7 +114,7 @@ export default class KernelManager {
 
     this.setRunningKernelFor(grammar, kernel);
 
-    kernelInit(kernel);
+    initKernel(kernel);
 
     if (onStarted) onStarted(kernel);
   }
@@ -136,7 +136,7 @@ export default class KernelManager {
       );
       this.setRunningKernelFor(grammar, kernel);
 
-      kernelInit(kernel);
+      initKernel(kernel);
 
       if (onStarted) onStarted(kernel);
     });
@@ -186,12 +186,10 @@ export default class KernelManager {
         callback(kernelSpecs[0]);
         return;
       }
-      
-      a = getInitConfig()
-      debugger
-      if(getInitConfig()[0].kernel) {
-          callback(_.find(kernelSpecs, {display_name: getInitConfig()[0].kernel}));
-          return;
+      const { kernel } = getInitConfig()[0][language];
+      if (kernel) {
+        callback(_.find(kernelSpecs, { display_name: kernel }));
+        return;
       }
 
       if (!this.kernelPicker) {

--- a/lib/kernel-manager.js
+++ b/lib/kernel-manager.js
@@ -11,7 +11,7 @@ import WSKernel from './ws-kernel';
 import ZMQKernel from './zmq-kernel';
 import KernelPicker from './kernel-picker';
 import log from './log';
-import kernelInit from './kernel-init'
+import kernelInit from './kernel-init';
 
 export default class KernelManager {
   constructor() {
@@ -125,7 +125,7 @@ export default class KernelManager {
 
     log('KernelManager: startKernelFor:', language);
 
-    const projectPath = atom.project.getPaths()[0]
+    const projectPath = atom.project.getPaths()[0];
     const spawnOptions = { cwd: projectPath };
     launchSpec(kernelSpec, spawnOptions)
     .then(({ config, connectionFile, spawn }) => {
@@ -136,7 +136,7 @@ export default class KernelManager {
       );
       this.setRunningKernelFor(grammar, kernel);
 
-      kernelInit(kernel)
+      kernelInit(kernel);
 
       if (onStarted) onStarted(kernel);
     });

--- a/lib/kernel-manager.js
+++ b/lib/kernel-manager.js
@@ -11,7 +11,7 @@ import WSKernel from './ws-kernel';
 import ZMQKernel from './zmq-kernel';
 import KernelPicker from './kernel-picker';
 import log from './log';
-import kernelInit from './kernel-init';
+import { kernelInit, getInitConfig} from './kernel-init';
 
 export default class KernelManager {
   constructor() {
@@ -114,7 +114,7 @@ export default class KernelManager {
 
     this.setRunningKernelFor(grammar, kernel);
 
-    this._executeStartupCode(kernel);
+    kernelInit(kernel);
 
     if (onStarted) onStarted(kernel);
   }
@@ -142,20 +142,9 @@ export default class KernelManager {
     });
   }
 
-  _executeStartupCode(kernel) {
-    const displayName = kernel.kernelSpec.display_name;
-    let startupCode = Config.getJson('startupCode')[displayName];
-    if (startupCode) {
-      log('KernelManager: Executing startup code:', startupCode);
-      startupCode = `${startupCode} \n`;
-      kernel.execute(startupCode);
-    }
-  }
-
   getAllRunningKernels() {
     return _.clone(this._runningKernels);
   }
-
 
   getRunningKernelFor(language) {
     return this._runningKernels[language];
@@ -196,6 +185,13 @@ export default class KernelManager {
       if (kernelSpecs.length <= 1) {
         callback(kernelSpecs[0]);
         return;
+      }
+      
+      a = getInitConfig()
+      debugger
+      if(getInitConfig()[0].kernel) {
+          callback(_.find(kernelSpecs, {display_name: getInitConfig()[0].kernel}));
+          return;
       }
 
       if (!this.kernelPicker) {

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     ]
   },
   "scripts": {
-    "lint": "eslint .",
-    "fix": "eslint . --fix",
+    "lint": "node_modules/.bin/eslint .",
+    "fix": "node_modules/.bin/eslint . --fix",
     "build:docs": "markdox lib/plugin-api/hydrogen-provider.js lib/plugin-api/hydrogen-kernel.js -o PLUGIN_API.md"
   },
   "repository": "https://github.com/nteract/hydrogen",
@@ -75,7 +75,7 @@
     }
   },
   "devDependencies": {
-    "babel-eslint": "^7.1.0",
+    "babel-eslint": "^7.1.1",
     "eslint": "^3.12.2",
     "eslint-config-airbnb-base": "^11.0.0",
     "eslint-plugin-import": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@jupyterlab/services": "^0.34.2",
     "atom-message-panel": "^1.2.4",
     "atom-space-pen-views": "^2.0.5",
+    "cson-parser": "^1.3.5",
     "escape-string-regexp": "^1.0.5",
     "jmp": "^0.7.5",
     "lodash": "^4.14.0",

--- a/py.py
+++ b/py.py
@@ -1,0 +1,7 @@
+print('without newline')
+asd = 1
+asd
+# print('with newline\n')
+# print("""
+# with new line
+# """)


### PR DESCRIPTION
This is work in progress PR and it's open for discussion.

### Purposes:
1. Make hydrogen friendlier for development purposes
2. Forget about static code analyzers (as a bonus)
3. Be compatible with https://github.com/nteract/hydrogen/pull/566

### Changes:
1. ```hydrogen.cson``` file can be added in root of any of your projects. It configure multiple kernels initialization, for example you can launch some code before returning kernel to user.
2. startupCode setting was removed in prior of using new init file
3. Kernel root is always project root (and not first launched file dir)

### Hydrogen.cson
```cson
defaultKernel: 'Python 3'
#Status: Not done
# Specifies what kernel to launch as a default in this project
# Value: display_name

init:
# Key - display_name of kernel
# value - params
  "Javascript (Node.js)":
     code: '"use strict"' #code that should be launched before running files
     files: [ #list of files that would be executed by kernel before returning to user
         './any.file.js' #Path, for now, should be relative to project root
     ]
  "Python 3":
     code: '''
%matplotlib inline
import nltk
import numpy
'''
    
```