### PR TITLE
Fix styling issue with material theme

### DIFF
--- a/styles/hydrogen.less
+++ b/styles/hydrogen.less
@@ -128,6 +128,7 @@
 
             margin: 0;
             padding: 0;
+            border: none;
         }
 
         img, svg {


### PR DESCRIPTION
Fix #575 

Atom's material theme adds a border to `pre` which breaks our layout.