### PR TITLE
Remove unnecessary CSS

### DIFF
--- a/styles/hydrogen.less
+++ b/styles/hydrogen.less
@@ -505,13 +505,3 @@
         color: @text-color-info !important;
     }
 }
-
-atom-text-editor,
-atom-text-editor::shadow {
-    .gutter .line-number {
-        &.breakpoint {
-            margin-bottom: -1px;
-            border-bottom: 1px solid @text-color-info;
-        }
-    }
-}


### PR DESCRIPTION
This is a leftover of #227 which was replaced by #328

The `atom-text-editor::shadow` selector is deprecated since Atom 1.13 and will raise a warning.