### PR TITLE
Don't scroll past end in watch text editor

### DIFF
--- a/lib/watch-sidebar.js
+++ b/lib/watch-sidebar.js
@@ -83,7 +83,7 @@ export default class WatchSidebar {
   }
 
   addWatch() {
-    this.createWatch().inputElement.element.focus();
+    this.createWatch().focus();
   }
 
   addWatchFromEditor() {

--- a/lib/watch-sidebar.js
+++ b/lib/watch-sidebar.js
@@ -97,13 +97,14 @@ export default class WatchSidebar {
   }
 
   removeWatch() {
-    const watches = (this.watchViews.map((v, k) => ({
+    const watches = this.watchViews.map((v, k) => ({
       name: v.getCode(),
       value: k,
-    })));
+    }));
     WatchesPicker.onConfirmed = (item) => {
       this.watchViews[item.value].destroy();
       this.watchViews.splice(item.value, 1);
+      if (this.watchViews.length === 0) this.addWatch();
     };
     WatchesPicker.setItems(watches);
     WatchesPicker.toggle();

--- a/lib/watch-view.js
+++ b/lib/watch-view.js
@@ -1,6 +1,6 @@
 'use babel';
 
-import { TextEditorView } from 'atom-space-pen-views';
+import { TextEditor } from 'atom';
 
 import ResultView from './result-view';
 import log from './log';
@@ -12,10 +12,8 @@ export default class WatchView {
     this.element = document.createElement('div');
     this.element.classList.add('hydrogen', 'watch-view');
 
-    this.inputElement = new TextEditorView();
-    this.inputElement.element.classList.add('watch-input');
-
-    this.inputEditor = this.inputElement.getModel();
+    this.inputEditor = new TextEditor();
+    this.inputEditor.element.classList.add('watch-input');
     this.inputEditor.setGrammar(this.kernel.grammar);
     this.inputEditor.setSoftWrapped(true);
     this.inputEditor.setLineNumberGutterVisible(false);
@@ -24,7 +22,7 @@ export default class WatchView {
     this.resultView = new ResultView();
     this.resultView.setMultiline(true);
 
-    this.element.appendChild(this.inputElement.element);
+    this.element.appendChild(this.inputEditor.element);
     this.element.appendChild(this.resultView.element);
 
     this.addHistorySwitch().clearHistory();
@@ -114,11 +112,14 @@ export default class WatchView {
 
   setCode(code) {
     this.inputEditor.setText(code);
-    return this;
   }
 
   getCode() {
-    return this.inputElement.getText();
+    return this.inputEditor.getText();
+  }
+
+  focus() {
+    this.inputEditor.element.focus();
   }
 
   clearResults() {


### PR DESCRIPTION
Minor improvements to the watch sidebar:
- Don't scroll past end in watch text editor by removing the use of `atom-space-pen-views` (is deprecated).
- Ensure at least one watch view in the sidebar

