### PR TITLE
Disable kernel interrupt on windows

### DIFF
--- a/lib/zmq-kernel.js
+++ b/lib/zmq-kernel.js
@@ -109,12 +109,16 @@ export default class ZMQKernel extends Kernel {
 
 
   interrupt() {
-    if (this.kernelProcess) {
+    if (process.platform === 'win32') {
+      atom.notifications.addWarning('Cannot interrupt this kernel', {
+        detail: 'Kernel interruption is currently not supported in Windows.',
+      });
+    } else if (this.kernelProcess) {
       log('ZMQKernel: sending SIGINT');
       this.kernelProcess.kill('SIGINT');
     } else {
       log('ZMQKernel: cannot interrupt an existing kernel');
-      atom.notifications.addWarning('Cannot interrupt this kernel');
+      atom.notifications.addWarning('Cannot interrupt an existing kernel');
     }
   }
 


### PR DESCRIPTION
Unfortunately windows doesn't support signals. 

[Node.js docs](https://nodejs.org/api/process.html#process_signal_events):

> Note: Windows does not support sending signals, but Node.js offers some emulation with process.kill(), and ChildProcess.kill(). Sending signal 0 can be used to test for the existence of a process. Sending SIGINT, SIGTERM, and SIGKILL cause the unconditional termination of the target process.

Closes #592 
