### PR TITLE
fix(WatchSidebar): setCode doesn't return watch view

### DIFF
--- a/lib/watch-sidebar.js
+++ b/lib/watch-sidebar.js
@@ -90,7 +90,9 @@ export default class WatchSidebar {
     if (!watchText) {
       this.addWatch();
     } else {
-      this.createWatch().setCode(watchText).run();
+      const watch = this.createWatch();
+      watch.setCode(watchText);
+      watch.run();
     }
     this.show();
   }


### PR DESCRIPTION
Fix exception caused by #588 because `setCode()` doesn't return watch view anymore.