### PR TITLE
Determine status bar style from theme

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -43,8 +43,7 @@ const Hydrogen = {
     this.markerBubbleMap = {};
 
     this.statusBarElement = document.createElement('div');
-    this.statusBarElement.classList.add('hydrogen');
-    this.statusBarElement.classList.add('status-container');
+    this.statusBarElement.classList.add('hydrogen-status', 'inline-block');
     this.statusBarElement.onclick = this.showKernelCommands.bind(this);
 
     this.onEditorChanged(atom.workspace.getActiveTextEditor());

--- a/lib/status-view.js
+++ b/lib/status-view.js
@@ -4,21 +4,19 @@ export default class StatusView {
 
   constructor(language) {
     this.language = language;
-    this.element = document.createElement('div');
-    this.element.classList.add('hydrogen');
-    this.element.classList.add('status');
+    this.element = document.createElement('a');
 
-    this.element.innerText = `${this.language}: starting`;
+    this.element.textContent = `${this.language}: starting`;
   }
 
 
   setStatus(status) {
-    this.element.innerText = `${this.language}: ${status}`;
+    this.element.textContent = `${this.language}: ${status}`;
   }
 
 
   destroy() {
-    this.element.innerHTML = '';
+    this.element.textContent = '';
     this.element.remove();
   }
 }

--- a/styles/hydrogen.less
+++ b/styles/hydrogen.less
@@ -412,16 +412,6 @@
     }
 }
 
-.hydrogen.status-container {
-    display: inline-block;
-    cursor: pointer;
-    vertical-align: top;
-
-    .status:hover {
-        text-decoration: underline;
-    }
-}
-
 .hidden {
     display: none;
 }


### PR DESCRIPTION
The `inline-block` and `status-bar` classes will provide the correct CSS depending on the theme. 

Fixes #604 