### PR TITLE
Replace kernel notification regexp with boolean

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -21,9 +21,9 @@ const Config = {
     },
     kernelNotifications: {
       title: 'Enable Kernel Notifications',
-      description: 'By default, kernel notifications are only displayed in the developer console. This setting defines a RegExp to filter what kernel notifications will also be shown as Atom notification bubbles. Example: `error|warning`',
-      type: 'string',
-      default: '(?!)',
+      description: 'Notify if kernels writes to stdout. By default, kernel notifications are only displayed in the developer console.',
+      type: 'boolean',
+      default: false,
     },
     gateways: {
       title: 'List of kernel gateways to use',

--- a/lib/zmq-kernel.js
+++ b/lib/zmq-kernel.js
@@ -22,27 +22,16 @@ export default class ZMQKernel extends Kernel {
     if (this.kernelProcess) {
       log('ZMQKernel: @kernelProcess:', this.kernelProcess);
 
-      const getKernelNotificationsRegExp = () => {
-        try {
-          const pattern = atom.config.get('Hydrogen.kernelNotifications');
-          const flags = 'im';
-          return new RegExp(pattern, flags);
-        } catch (err) {
-          return null;
-        }
-      };
-
       this.kernelProcess.stdout.on('data', (data) => {
         data = data.toString();
 
-        log('ZMQKernel: stdout:', data);
-
-        const regexp = getKernelNotificationsRegExp();
-        if (regexp && regexp.test(data)) {
+        if (atom.config.get('Hydrogen.kernelNotifications')) {
           atom.notifications.addInfo(this.kernelSpec.display_name, {
             description: data,
             dismissable: true,
           });
+        } else {
+          log('ZMQKernel: stdout:', data);
         }
       });
 


### PR DESCRIPTION
This simplifies it for users to config notifications from the kernel process (`stdout`). Though this will make it less flexible.

Fixes https://github.com/nteract/hydrogen/pull/622#discussion_r103333484