### PR TITLE
Use @nteract/tranforms

### DIFF
--- a/lib/components/inspector/component.js
+++ b/lib/components/inspector/component.js
@@ -3,7 +3,7 @@
 import React from "react";
 import { observer } from "mobx-react";
 import ResizableBox from "react-resizable-box";
-import { richestMimetype, standardTransforms } from "@nteract/transforms";
+import { richestMimetype, transforms } from "@nteract/transforms";
 import { List as ImmutableList } from "immutable";
 
 const displayOrder = new ImmutableList([
@@ -25,9 +25,9 @@ const InspectorComponent = observer(({ store: { kernel }, panel }: Props) => {
   panel.show();
 
   const bundle = kernel.inspector.bundle;
-  const mimetype = richestMimetype(bundle, displayOrder, standardTransforms);
+  const mimetype = richestMimetype(bundle, displayOrder, transforms);
   // $FlowFixMe React element `Transform`. Expected React component instead of Transform
-  const Transform = standardTransforms.get(mimetype);
+  const Transform = transforms.get(mimetype);
   return (
     <ResizableBox
       isResizable={{ top: true }}

--- a/lib/components/inspector/component.js
+++ b/lib/components/inspector/component.js
@@ -3,6 +3,14 @@
 import React from "react";
 import { observer } from "mobx-react";
 import ResizableBox from "react-resizable-box";
+import { richestMimetype, standardTransforms } from "@nteract/transforms";
+import { List as ImmutableList } from "immutable";
+
+const displayOrder = new ImmutableList([
+  "text/html",
+  "text/markdown",
+  "text/plain"
+]);
 
 import type Kernel from "./../../kernel";
 
@@ -15,6 +23,11 @@ const InspectorComponent = observer(({ store: { kernel }, panel }: Props) => {
     return null;
   }
   panel.show();
+
+  const bundle = kernel.inspector.bundle;
+  const mimetype = richestMimetype(bundle, displayOrder, standardTransforms);
+  // $FlowFixMe React element `Transform`. Expected React component instead of Transform
+  const Transform = standardTransforms.get(mimetype);
   return (
     <ResizableBox
       isResizable={{ top: true }}
@@ -32,10 +45,9 @@ const InspectorComponent = observer(({ store: { kernel }, panel }: Props) => {
           />
         </div>
       </div>
-      <div
-        className="hydrogen-panel-body"
-        dangerouslySetInnerHTML={{ __html: kernel.inspector.HTML }}
-      />
+      <div className="hydrogen-panel-body">
+        <Transform data={bundle.get(mimetype)} />
+      </div>
     </ResizableBox>
   );
 });

--- a/lib/components/inspector/index.js
+++ b/lib/components/inspector/index.js
@@ -1,16 +1,12 @@
 /* @flow */
 
 import React from "react";
-import * as transformime from "transformime";
+import { Map as ImmutableMap } from "immutable";
 
 import { log, reactFactory } from "./../../utils";
 import store from "./../../store";
 import { getCodeToInspect } from "./../../code-manager";
 import InspectorComponent from "./component";
-
-import type Kernel from "./../../kernel";
-
-const transform = transformime.createTransform();
 
 export default class Inspector {
   constructor() {
@@ -41,40 +37,17 @@ export default class Inspector {
     kernel.inspect(code, cursorPos, (result: {
       data: Object,
       found: Boolean
-    }) => this.showInspectionResult(kernel, result));
-    // TODO: handle case when inspect request returns an error
-  }
+    }) => {
+      log("Inspector: Result:", result);
 
-  showInspectionResult(
-    kernel: Kernel,
-    result: { data: Object, found: Boolean }
-  ) {
-    log("Inspector: Result:", result);
-
-    if (!result.found) {
-      kernel.setInspectorVisibility(false);
-      atom.notifications.addInfo("No introspection available!");
-      return;
-    }
-
-    const onInspectResult = ({ mimetype, el }) => {
-      if (mimetype === "text/plain" || mimetype === "text/markdown") {
-        kernel.setInspectorResult(el.outerHTML);
-      } else if (mimetype === "text/html") {
-        const container = document.createElement("div");
-        container.appendChild(el);
-        kernel.setInspectorResult(container.outerHTML);
-      } else {
-        console.error("Inspector: Rendering error:", mimetype, el);
-        atom.notifications.addInfo("Cannot render introspection result!");
+      if (!result.found) {
+        kernel.setInspectorVisibility(false);
+        atom.notifications.addInfo("No introspection available!");
+        return;
       }
-    };
+      const bundle = new ImmutableMap(result.data);
 
-    const onError = error => {
-      console.error("Inspector: Rendering error:", error);
-      atom.notifications.addInfo("Cannot render introspection result!");
-    };
-
-    transform(result.data).then(onInspectResult, onError);
+      kernel.setInspectorResult(bundle);
+    });
   }
 }

--- a/lib/kernel.js
+++ b/lib/kernel.js
@@ -2,6 +2,7 @@
 
 import { Emitter } from "atom";
 import { observable, action } from "mobx";
+import { is, Map as ImmutableMap } from "immutable";
 
 import { log } from "./utils";
 import store from "./store";
@@ -13,7 +14,7 @@ export default class Kernel {
   @observable executionState = "loading";
   @observable inspector = {
     visible: false,
-    HTML: "",
+    bundle: new ImmutableMap(),
     height: 240
   };
 
@@ -47,11 +48,11 @@ export default class Kernel {
     this.inspector.height = height;
   }
 
-  @action setInspectorResult(HTML: string) {
-    if (this.inspector.visible === true && this.inspector.HTML === HTML) {
+  @action setInspectorResult(bundle: ImmutableMap<string, any>) {
+    if (this.inspector.visible === true && is(this.inspector.bundle, bundle)) {
       this.setInspectorVisibility(false);
-    } else if (HTML) {
-      this.inspector.HTML = HTML;
+    } else if (bundle.size !== 0) {
+      this.inspector.bundle = bundle;
       this.setInspectorVisibility(true);
     }
   }

--- a/lib/kernel.js
+++ b/lib/kernel.js
@@ -180,7 +180,9 @@ export default class Kernel {
       mime.startsWith("image/"));
 
     let mime;
-    if ({}.hasOwnProperty.call(data, "text/html")) {
+    if ({}.hasOwnProperty.call(data, "application/json")) {
+      mime = "application/json";
+    } else if ({}.hasOwnProperty.call(data, "text/html")) {
       mime = "text/html";
     } else if ({}.hasOwnProperty.call(data, "image/svg+xml")) {
       mime = "image/svg+xml";
@@ -188,8 +190,6 @@ export default class Kernel {
       mime = imageMimes[0];
     } else if ({}.hasOwnProperty.call(data, "text/markdown")) {
       mime = "text/markdown";
-    } else if ({}.hasOwnProperty.call(data, "application/pdf")) {
-      mime = "application/pdf";
     } else if ({}.hasOwnProperty.call(data, "text/latex")) {
       mime = "text/latex";
     } else if ({}.hasOwnProperty.call(data, "text/plain")) {

--- a/lib/kernel.js
+++ b/lib/kernel.js
@@ -77,7 +77,6 @@ export default class Kernel {
     throw new Error("Kernel: interrupt method not implemented");
   }
 
-  /* eslint-disable no-unused-vars */
   shutdown() {
     throw new Error("Kernel: shutdown method not implemented");
   }
@@ -102,7 +101,6 @@ export default class Kernel {
     throw new Error("Kernel: inspect method not implemented");
   }
 
-  /* eslint-enable no-unused-vars */
   _parseIOMessage(message: Message) {
     let result = this._parseDisplayIOMessage(message);
 
@@ -132,7 +130,6 @@ export default class Kernel {
     return null;
   }
 
-  /* eslint-disable camelcase*/
   _parseResultIOMessage(message: Message) {
     const { msg_type } = message.header;
 
@@ -141,65 +138,20 @@ export default class Kernel {
     }
     return null;
   }
-  /* eslint-enable camelcase*/
 
   _parseDataMime(data: Object) {
     if (!data) {
       return null;
     }
 
-    const mime = this._getMimeType(data);
-
-    if (!mime) {
-      return null;
-    }
-
-    let result;
-    if (mime === "text/plain") {
-      result = {
-        data: {
-          "text/plain": data[mime]
-        },
-        type: "text",
-        stream: "pyout"
-      };
-    } else {
-      result = {
-        data: {},
-        type: mime,
-        stream: "pyout"
-      };
-      result.data[mime] = data[mime];
-    }
+    const result = {
+      data: data,
+      stream: "pyout"
+    };
 
     return result;
   }
 
-  _getMimeType(data: Object) {
-    const imageMimes = Object.getOwnPropertyNames(data).filter(mime =>
-      mime.startsWith("image/"));
-
-    let mime;
-    if ({}.hasOwnProperty.call(data, "application/json")) {
-      mime = "application/json";
-    } else if ({}.hasOwnProperty.call(data, "text/html")) {
-      mime = "text/html";
-    } else if ({}.hasOwnProperty.call(data, "image/svg+xml")) {
-      mime = "image/svg+xml";
-    } else if (!(imageMimes.length === 0)) {
-      mime = imageMimes[0];
-    } else if ({}.hasOwnProperty.call(data, "text/markdown")) {
-      mime = "text/markdown";
-    } else if ({}.hasOwnProperty.call(data, "text/latex")) {
-      mime = "text/latex";
-    } else if ({}.hasOwnProperty.call(data, "text/plain")) {
-      mime = "text/plain";
-    }
-
-    return mime;
-  }
-
-  /* eslint-disable camelcase*/
   _parseErrorIOMessage(message: Message) {
     const { msg_type } = message.header;
 
@@ -209,7 +161,6 @@ export default class Kernel {
 
     return null;
   }
-  /* eslint-enable camelcase*/
 
   _parseErrorMessage(message: Message) {
     let errorString;
@@ -225,7 +176,6 @@ export default class Kernel {
       data: {
         "text/plain": errorString
       },
-      type: "text",
       stream: "error"
     };
 
@@ -241,7 +191,6 @@ export default class Kernel {
             ? message.content.text
             : message.content.data
         },
-        type: "text",
         stream: message.content.name
       };
 
@@ -257,7 +206,6 @@ export default class Kernel {
             ? message.content.text
             : message.content.data
         },
-        type: "text",
         stream: "stdout"
       };
 
@@ -273,7 +221,6 @@ export default class Kernel {
             ? message.content.text
             : message.content.data
         },
-        type: "text",
         stream: "stderr"
       };
     }
@@ -285,7 +232,6 @@ export default class Kernel {
     if (message.header.msg_type === "execute_input") {
       return {
         data: message.content.execution_count,
-        type: "number",
         stream: "execution_count"
       };
     }

--- a/lib/result-view.js
+++ b/lib/result-view.js
@@ -1,11 +1,16 @@
 "use babel";
 
 import { CompositeDisposable } from "atom";
-import { createTransform } from "transformime";
+import {
+  richestMimetype,
+  standardTransforms,
+  standardDisplayOrder
+} from "@nteract/transforms";
+import React from "react";
+import ReactDOM from "react-dom";
+import { Map as ImmutableMap } from "immutable";
 
 import { log } from "./utils";
-
-const transform = createTransform();
 
 export default class ResultView {
   constructor(marker) {
@@ -151,82 +156,76 @@ export default class ResultView {
       container = this.resultContainer;
     }
 
-    const onSuccess = ({ mimetype, el }) => {
-      log("ResultView: Hide status container");
-      this._hasResult = true;
-      this.statusContainer.classList.add("hidden");
+    log("ResultView: Hide status container");
+    this._hasResult = true;
+    this.statusContainer.classList.add("hidden");
 
-      const mimeType = mimetype;
-      let htmlElement = el;
+    const bundle = new ImmutableMap(result.data);
+    const mimeType = richestMimetype(
+      bundle,
+      standardDisplayOrder,
+      standardTransforms
+    );
+    const Transform = standardTransforms.get(mimeType);
 
-      if (mimeType === "text/plain") {
-        this.element.classList.remove("rich");
+    if (mimeType === "text/plain") {
+      this.element.classList.remove("rich");
 
-        const previousText = this.getAllText();
-        const text = result.data["text/plain"];
-        if (
-          previousText === "" &&
-          text.length < 50 &&
-          (text.indexOf("\n") === text.length - 1 || text.indexOf("\n") === -1)
-        ) {
-          this.setMultiline(false);
+      const previousText = this.getAllText();
+      const text = result.data["text/plain"];
+      if (
+        previousText === "" &&
+        text.length < 50 &&
+        (text.indexOf("\n") === text.length - 1 || text.indexOf("\n") === -1)
+      ) {
+        this.setMultiline(false);
 
-          this.addCopyTooltip(container);
+        this.addCopyTooltip(container);
 
-          container.onclick = () => {
-            atom.clipboard.write(this.getAllText());
-            atom.notifications.addSuccess("Copied to clipboard");
-          };
-        } else {
-          this.setMultiline(true);
-        }
+        container.onclick = () => {
+          atom.clipboard.write(this.getAllText());
+          atom.notifications.addSuccess("Copied to clipboard");
+        };
       } else {
-        this.element.classList.add("rich");
         this.setMultiline(true);
       }
+    } else if (mimeType === "application/json") {
+      this.setMultiline(true);
+    } else {
+      this.element.classList.add("rich");
+      this.setMultiline(true);
+    }
 
-      if (mimeType === "application/pdf") {
-        const webview = document.createElement("webview");
-        webview.src = htmlElement.href;
-        htmlElement = webview;
-      }
+    log("ResultView: Rendering as MIME ", mimeType);
+    // this.getAllText must be called after appending the htmlElement
+    // in order to obtain innerText
 
-      log("ResultView: Rendering as MIME ", mimeType);
-      log("ResultView: Rendering as ", htmlElement);
-      // this.getAllText must be called after appending the htmlElement
-      // in order to obtain innerText
-      container.appendChild(htmlElement);
+    ReactDOM.render(<Transform data={bundle.get(mimeType)} />, container);
 
-      if (mimeType === "text/html") {
-        if (this.getAllText() !== "") {
-          this.element.classList.remove("rich");
-        }
-      }
-
-      if (mimeType === "image/svg+xml") {
-        container.classList.add("svg");
-      }
-
-      if (mimeType === "text/markdown") {
-        this.element.classList.add("markdown");
+    if (mimeType === "text/html") {
+      if (this.getAllText() !== "") {
         this.element.classList.remove("rich");
       }
+    }
 
-      if (mimeType === "text/latex") {
-        this.element.classList.add("latex");
-      }
+    if (mimeType === "image/svg+xml") {
+      container.classList.add("svg");
+    }
 
-      if (this.errorContainer.getElementsByTagName("span").length === 0) {
-        this.errorContainer.classList.add("plain-error");
-      } else {
-        this.errorContainer.classList.remove("plain-error");
-      }
-    };
+    if (mimeType === "text/markdown") {
+      this.element.classList.add("markdown");
+      this.element.classList.remove("rich");
+    }
 
-    const onError = error =>
-      console.error("ResultView: Rendering error:", error);
+    if (mimeType === "text/latex") {
+      this.element.classList.add("latex");
+    }
 
-    transform(result.data).then(onSuccess, onError);
+    if (this.errorContainer.getElementsByTagName("span").length === 0) {
+      this.errorContainer.classList.add("plain-error");
+    } else {
+      this.errorContainer.classList.remove("plain-error");
+    }
   }
 
   getAllText() {

--- a/lib/result-view.js
+++ b/lib/result-view.js
@@ -1,11 +1,7 @@
 "use babel";
 
 import { CompositeDisposable } from "atom";
-import {
-  richestMimetype,
-  standardTransforms,
-  standardDisplayOrder
-} from "@nteract/transforms";
+import { richestMimetype, transforms, displayOrder } from "@nteract/transforms";
 import React from "react";
 import ReactDOM from "react-dom";
 import { Map as ImmutableMap } from "immutable";
@@ -161,12 +157,8 @@ export default class ResultView {
     this.statusContainer.classList.add("hidden");
 
     const bundle = new ImmutableMap(result.data);
-    const mimeType = richestMimetype(
-      bundle,
-      standardDisplayOrder,
-      standardTransforms
-    );
-    const Transform = standardTransforms.get(mimeType);
+    const mimeType = richestMimetype(bundle, displayOrder, transforms);
+    const Transform = transforms.get(mimeType);
 
     if (mimeType === "text/plain") {
       this.element.classList.remove("rich");

--- a/lib/ws-kernel.js
+++ b/lib/ws-kernel.js
@@ -57,7 +57,6 @@ export default class WSKernel extends Kernel {
       }
       const result = {
         data: "ok",
-        type: "text",
         stream: "status"
       };
       if (onResults) onResults(result);

--- a/lib/zmq-kernel.js
+++ b/lib/zmq-kernel.js
@@ -21,7 +21,7 @@ type Connection = {
   transport: string,
   version: number
 };
-/* eslint-disable camelcase */
+
 export default class ZMQKernel extends Kernel {
   executionCallbacks: Object = {};
   connection: Connection;
@@ -280,7 +280,6 @@ export default class ZMQKernel extends Kernel {
       if (msg_type === "execution_reply") {
         callback({
           data: "ok",
-          type: "text",
           stream: "status"
         });
       } else if (msg_type === "complete_reply") {
@@ -293,7 +292,6 @@ export default class ZMQKernel extends Kernel {
       } else {
         callback({
           data: "ok",
-          type: "text",
           stream: "status"
         });
       }

--- a/package.json
+++ b/package.json
@@ -50,8 +50,10 @@
   },
   "dependencies": {
     "@jupyterlab/services": "^0.41.0",
+    "@nteract/transforms": "^1.0.7",
     "atom-space-pen-views": "^2.0.5",
     "escape-string-regexp": "^1.0.5",
+    "immutable": "^3.8.1",
     "jmp": "^0.7.5",
     "lodash": "^4.14.0",
     "mobx": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "requirejs": "^2.2.0",
     "spawnteract": "^2.1.1",
     "tildify": "^1.2.0",
-    "transformime": "^3.2.0",
     "uuid": "^3.0.1",
     "ws": "^2.0.0",
     "xmlhttprequest": "^1.8.0"

--- a/styles/hydrogen.less
+++ b/styles/hydrogen.less
@@ -479,13 +479,17 @@
 }
 
 .hydrogen-panel-body {
+  padding: @component-padding;
   overflow-y: auto;
   max-height: calc(~'100% - 2px' - @font-size + 2 * @component-padding);
 
   span[style] {
       color: @text-color-info !important;
   }
-  pre {
+  code {
+    color: inherit;
+    white-space: pre;
+    padding: 0px;
     font-size: @font-size;
     font-family: inherit;
     background: inherit;

--- a/styles/hydrogen.less
+++ b/styles/hydrogen.less
@@ -55,7 +55,7 @@
         .bubble-output-container {
             padding: 0 2px 0 2px;
             overflow: hidden;
-            pre {
+            code {
                 font-size: inherit;
                 line-height: inherit;
                 cursor: pointer;
@@ -70,6 +70,7 @@
     }
 
     &.multiline:not(.rich) {
+        font-size: @font-size;
         .bubble-action-panel {
             display: inline-flex;
         }
@@ -118,7 +119,7 @@
         max-height: unset !important;
         overflow: hidden !important;
         white-space: normal;
-        pre {
+        code {
             font-size: @font-size;
             font-family: inherit;
 
@@ -128,6 +129,8 @@
             margin: 0;
             padding: 0;
             border: none;
+
+            white-space: pre;
         }
 
         img, svg {
@@ -164,12 +167,12 @@
 
     .bubble-error-container {
         &.plain-error {
-            pre {
+            code {
                 color: @error-base-color;
             }
         }
 
-        pre {
+        code {
             font-size: @font-size;
             font-family: inherit;
 
@@ -386,7 +389,7 @@
             max-height: inherit;
 
             position: relative;
-            pre {
+            code {
                 padding: 3px;
                 font-size: inherit;
                 display: block;
@@ -401,7 +404,7 @@
         }
 
         .bubble-error-container {
-            pre {
+            code {
                 font-size: inherit;
             }
         }


### PR DESCRIPTION
A initial stab at using [`@nteract/tranforms`](https://github.com/nteract/nteract/tree/master/packages/transforms) as a replacement for `transformime` in order to address #557, #560, #27 and #368 and support even more mimetypes.

## Moved to a later time:
- [x] Use `@nteract/tranforms` for inspector (the easy part 😄 )
- [ ] Refactor the following parts as React Components:
  - [ ] Result View probably powered by [`@nteract/display-area`](https://github.com/nteract/nteract/tree/master/packages/display-area)
    - [ ] Spinner component
    - [ ] Component for inline result
    - [ ] Component for multiline result
    - [ ] Component for rich output (I think we could even remove it and use the multiline output for simplicity and to have a more consistent appearance)
  - [ ] Watch Sidebar
    - [ ] Watch View component

There's quite a bit of work left to do and I don't know when I can get to it, so I'm parking it here 🚗 
It would be super cool if someone wants to help with this effort 😇 