### PR TITLE
Add asciidoc as markup grammar

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -25,7 +25,7 @@ export function grammarToLanguage(grammar: ?atom$Grammar) {
   return (grammar) ? grammar.name.toLowerCase() : null;
 }
 
-const markupGrammars = new Set(['source.gfm']);
+const markupGrammars = new Set(['source.gfm', 'source.asciidoc']);
 
 export function isMultilanguageGrammar(grammar: atom$Grammar) {
   return markupGrammars.has(grammar.scopeName);

--- a/spec/utils-spec.js
+++ b/spec/utils-spec.js
@@ -3,7 +3,7 @@
 import ReactDOM from 'react-dom';
 import { CompositeDisposable } from 'atom';
 
-import { reactFactory, grammarToLanguage } from './../lib/utils';
+import { reactFactory, grammarToLanguage, isMultilanguageGrammar } from './../lib/utils';
 
 describe('grammarToLanguage', () => {
   expect(grammarToLanguage({ name: 'Kernel Name' })).toEqual('kernel name');
@@ -28,4 +28,10 @@ describe('reactFactory', () => {
   compDisposable.dispose();
   expect(ReactDOM.unmountComponentAtNode).toHaveBeenCalledWith('domElement');
   expect(teardown).toHaveBeenCalled();
+});
+
+describe('isMultilanguageGrammar', () => {
+  expect(isMultilanguageGrammar(atom.workspace.buildTextEditor().getGrammar())).toBe(false);
+  expect(isMultilanguageGrammar({ scopeName: 'source.gfm' })).toBe(true);
+  expect(isMultilanguageGrammar({ scopeName: 'source.asciidoc' })).toBe(true);
 });


### PR DESCRIPTION
During testing #637 asciidoc didn't work for me. Turns out I used the wrong syntax to define code blocks:
![asciidoc](https://cloud.githubusercontent.com/assets/13285808/24292879/77cfa724-108f-11e7-9ffd-14d7358010ec.gif)

/cc @fasiha
