### PR TITLE
Support language-markdown package

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -30,6 +30,7 @@ const markupGrammars = new Set([
   'source.asciidoc',
   'text.restructuredtext',
   'text.tex.latex.knitr',
+  'text.md',
 ]);
 
 export function isMultilanguageGrammar(grammar: atom$Grammar) {


### PR DESCRIPTION
Aaaaand another PR for markup language support.
(Every time I push a PR I find a new language we can easily support, I should have done them in batches 😂)

Once https://github.com/burodepeper/language-markdown/pull/172 is merged we can support the [`language-markdown`](https://github.com/burodepeper/language-markdown) package (a popular package as a replacement for the included markdown language):

![markdown](https://cloud.githubusercontent.com/assets/13285808/24314427/d5285978-10e1-11e7-83f1-47e7535ef267.gif)