### PR TITLE
Listen for grammar changes of the editor and update store

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { Emitter } from 'atom';
+import { Emitter, CompositeDisposable } from 'atom';
 
 import _ from 'lodash';
 import { autorun } from 'mobx';
@@ -79,19 +79,22 @@ const Hydrogen = {
     }));
 
     store.subscriptions.add(atom.workspace.observeTextEditors((editor) => {
+      const editorSubscriptions = new CompositeDisposable();
+      editorSubscriptions.add(editor.onDidChangeGrammar(() => {
+        store.setGrammar(editor);
+      }));
+
       if (isMultilanguageGrammar(editor.getGrammar())) {
-        const cursorSubscription = editor.onDidChangeCursorPosition(
+        editorSubscriptions.add(editor.onDidChangeCursorPosition(
           _.debounce(() => { store.setGrammar(editor); }, 75),
-        );
-
-        const editorSubscription = editor.onDidDestroy(() => {
-          cursorSubscription.dispose();
-          editorSubscription.dispose();
-        });
-
-        store.subscriptions.add(cursorSubscription);
-        store.subscriptions.add(editorSubscription);
+        ));
       }
+
+      editorSubscriptions.add(editor.onDidDestroy(() => {
+        editorSubscriptions.dispose();
+      }));
+
+      store.subscriptions.add(editorSubscriptions);
     }));
 
     this.hydrogenProvider = null;

--- a/types/atom.js.flow
+++ b/types/atom.js.flow
@@ -706,6 +706,7 @@ declare class atom$TextEditor extends atom$Model {
   onDidSave(callback: (event: {path: string}) => mixed): IDisposable,
   getBuffer(): atom$TextBuffer,
   observeGrammar(callback: (grammar: atom$Grammar) => mixed): IDisposable,
+  onDidChangeGrammar(callback: (grammar: atom$Grammar) => mixed): IDisposable,
   onWillInsertText(callback: (event: {cancel: () => void, text: string}) => void):
       IDisposable,
   // Note that the range property of the event is undocumented.


### PR DESCRIPTION
Noticed while testing #665 and frequently switching grammars:
![grammar-update](https://cloud.githubusercontent.com/assets/13285808/24325617/bebbc8a8-119c-11e7-9a71-c76d6f82eda8.gif)
