### PR TITLE
Disable commands if in mini text editor

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -42,7 +42,7 @@ const Hydrogen = {
 
     this.markerBubbleMap = {};
 
-    store.subscriptions.add(atom.commands.add('atom-text-editor', {
+    store.subscriptions.add(atom.commands.add('atom-text-editor:not([mini])', {
       'hydrogen:run': () => this.run(),
       'hydrogen:run-all': () => this.runAll(),
       'hydrogen:run-all-above': () => this.runAllAbove(),


### PR DESCRIPTION
~~This will probably fix #669~~. For more infos see https://github.com/nteract/hydrogen/issues/669#issuecomment-289307440

I was able to reproduce the error of #669 inside the settings panel. Before one was able to execute a Hydrogen command inside a settings text box.

The watch sidebar still works. ~~I haven't tested it with `julia-client` though.~~