### PR TITLE
Ignore commands when no active text editor

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -324,6 +324,7 @@ const Hydrogen = {
 
 
   run(moveDown: boolean = false) {
+    if (!store.editor) return;
     const codeBlock = codeManager.findCodeBlock();
     if (!codeBlock) {
       return;


### PR DESCRIPTION
This will fix #669 by ignoring commands invoked while the active pane is not an ordinary text editor (e.g. a console.

@lgeiger and I talked about various ways of doing this including the possibility of registering commands directly to DOM elements of "real" text editors to avoid invoking the command in the wrong context. I will be experimenting with that, but for now this is the simplest fix I could find.