### PR TITLE
Add support for multi language run cell

### DIFF
--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -6,7 +6,7 @@ import escapeStringRegexp from "escape-string-regexp";
 import _ from "lodash";
 
 import store from "./store";
-import { log } from "./utils";
+import { log, isMultilanguageGrammar, getEmbeddedScope } from "./utils";
 
 export function normalizeString(code) {
   if (code) {
@@ -143,7 +143,7 @@ export function getBreakpoints() {
   return breakpoints;
 }
 
-export function getCurrentCell() {
+function getCurrentCodeCell() {
   const buffer = store.editor.getBuffer();
   let start = buffer.getFirstPosition();
   let end = buffer.getEndPosition();
@@ -174,6 +174,40 @@ export function getCurrentCell() {
   log("CellManager: Cell [start, end]:", [start, end], "cursor:", cursor);
 
   return new Range(start, end);
+}
+
+function isEmbeddedCode(referenceScope, row) {
+  const scopes = store.editor
+    .scopeDescriptorForBufferPosition(new Point(row, 0))
+    .getScopesArray();
+  return _.includes(scopes, referenceScope);
+}
+
+function getCurrentFencedCodeBlock() {
+  const buffer = store.editor.getBuffer();
+  const { row: bufferEndRow } = buffer.getEndPosition();
+
+  const cursor = store.editor.getCursorBufferPosition();
+  let start = cursor.row;
+  let end = cursor.row;
+  const scope = getEmbeddedScope(store.editor, cursor);
+
+  while (start > 0 && isEmbeddedCode(scope, start - 1)) {
+    start -= 1;
+  }
+
+  while (end < bufferEndRow && isEmbeddedCode(scope, end + 1)) {
+    end += 1;
+  }
+
+  return new Range([start, 0], [end, 9999999]);
+}
+
+export function getCurrentCell() {
+  if (isMultilanguageGrammar(store.editor.getGrammar())) {
+    return getCurrentFencedCodeBlock();
+  }
+  return getCurrentCodeCell();
 }
 
 export function getCells() {

--- a/lib/main.js
+++ b/lib/main.js
@@ -412,12 +412,6 @@ const Hydrogen = {
 
   runCell(moveDown: boolean = false) {
     if (!store.editor) return;
-    if (isMultilanguageGrammar(store.editor.getGrammar())) {
-      atom.notifications.addError(
-        '"Run Cell" is not supported for this file type!'
-      );
-      return;
-    }
     const { start, end } = codeManager.getCurrentCell();
     const code = codeManager.getTextInRange(start, end);
     const endRow = codeManager.escapeBlankRows(start.row, end.row);

--- a/lib/store/index.js
+++ b/lib/store/index.js
@@ -2,7 +2,11 @@
 
 import { CompositeDisposable } from "atom";
 import { observable, computed, action } from "mobx";
-import { grammarToLanguage, isMultilanguageGrammar } from "./../utils";
+import {
+  grammarToLanguage,
+  isMultilanguageGrammar,
+  getEmbeddedScope
+} from "./../utils";
 
 import type Kernel from "./../kernel";
 
@@ -29,15 +33,15 @@ class Store {
     if (!isMultilanguageGrammar(topLevelGrammar)) {
       this.grammar = topLevelGrammar;
     } else {
-      const scopes = editor
-        .getCursorScope()
-        .getScopesArray()
-        .filter(s => s.indexOf("source.embedded.") === 0);
+      const embeddedScope = getEmbeddedScope(
+        editor,
+        editor.getCursorBufferPosition()
+      );
 
-      if (scopes.length === 0) {
+      if (!embeddedScope) {
         this.grammar = topLevelGrammar;
       } else {
-        const scope = scopes[0].replace(".embedded", "");
+        const scope = embeddedScope.replace(".embedded", "");
         this.grammar = atom.grammars.grammarForScopeName(scope);
       }
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,6 +2,7 @@
 
 import { Disposable } from "atom";
 import ReactDOM from "react-dom";
+import _ from "lodash";
 
 import store from "./store";
 
@@ -35,6 +36,16 @@ const markupGrammars = new Set([
 
 export function isMultilanguageGrammar(grammar: atom$Grammar) {
   return markupGrammars.has(grammar.scopeName);
+}
+
+export function getEmbeddedScope(
+  editor: atom$TextEditor,
+  position: atom$Point
+) {
+  const scopes = editor
+    .scopeDescriptorForBufferPosition(position)
+    .getScopesArray();
+  return _.find(scopes, s => s.indexOf("source.embedded.") === 0);
 }
 
 /* eslint-disable no-console */

--- a/spec/utils-spec.js
+++ b/spec/utils-spec.js
@@ -6,7 +6,8 @@ import { CompositeDisposable } from "atom";
 import {
   reactFactory,
   grammarToLanguage,
-  isMultilanguageGrammar
+  isMultilanguageGrammar,
+  getEmbeddedScope
 } from "./../lib/utils";
 
 describe("grammarToLanguage", () => {
@@ -40,4 +41,24 @@ describe("isMultilanguageGrammar", () => {
   ).toBe(false);
   expect(isMultilanguageGrammar({ scopeName: "source.gfm" })).toBe(true);
   expect(isMultilanguageGrammar({ scopeName: "source.asciidoc" })).toBe(true);
+});
+
+describe("getEmbeddedScope", () => {
+  const editor = {
+    scopeDescriptorForBufferPosition: () => {
+      return {
+        getScopesArray: () => [
+          "text.md",
+          "fenced.code.md",
+          "source.embedded.python"
+        ]
+      };
+    }
+  };
+  spyOn(editor, "scopeDescriptorForBufferPosition").andCallThrough();
+  const scope = getEmbeddedScope(editor, "position");
+  expect(scope).toEqual("source.embedded.python");
+  expect(editor.scopeDescriptorForBufferPosition).toHaveBeenCalledWith(
+    "position"
+  );
 });

--- a/spec/utils-spec.js
+++ b/spec/utils-spec.js
@@ -10,55 +10,57 @@ import {
   getEmbeddedScope
 } from "./../lib/utils";
 
-describe("grammarToLanguage", () => {
-  expect(grammarToLanguage({ name: "Kernel Name" })).toEqual("kernel name");
-  expect(grammarToLanguage(null)).toBeNull();
-  expect(grammarToLanguage(undefined)).toBeNull();
-});
+describe("utils", () => {
+  it("grammarToLanguage", () => {
+    expect(grammarToLanguage({ name: "Kernel Name" })).toEqual("kernel name");
+    expect(grammarToLanguage(null)).toBeNull();
+    expect(grammarToLanguage(undefined)).toBeNull();
+  });
 
-describe("reactFactory", () => {
-  const compDisposable = new CompositeDisposable();
-  spyOn(compDisposable, "add").andCallThrough();
-  spyOn(ReactDOM, "render");
-  spyOn(ReactDOM, "unmountComponentAtNode");
-  const teardown = jasmine.createSpy("teardown");
+  it("reactFactory", () => {
+    const compDisposable = new CompositeDisposable();
+    spyOn(compDisposable, "add").andCallThrough();
+    spyOn(ReactDOM, "render");
+    spyOn(ReactDOM, "unmountComponentAtNode");
+    const teardown = jasmine.createSpy("teardown");
 
-  reactFactory("reactElement", "domElement", teardown, compDisposable);
+    reactFactory("reactElement", "domElement", teardown, compDisposable);
 
-  expect(ReactDOM.render).toHaveBeenCalledWith("reactElement", "domElement");
-  expect(compDisposable.add).toHaveBeenCalled();
+    expect(ReactDOM.render).toHaveBeenCalledWith("reactElement", "domElement");
+    expect(compDisposable.add).toHaveBeenCalled();
 
-  expect(ReactDOM.unmountComponentAtNode).not.toHaveBeenCalled();
-  expect(teardown).not.toHaveBeenCalled();
-  compDisposable.dispose();
-  expect(ReactDOM.unmountComponentAtNode).toHaveBeenCalledWith("domElement");
-  expect(teardown).toHaveBeenCalled();
-});
+    expect(ReactDOM.unmountComponentAtNode).not.toHaveBeenCalled();
+    expect(teardown).not.toHaveBeenCalled();
+    compDisposable.dispose();
+    expect(ReactDOM.unmountComponentAtNode).toHaveBeenCalledWith("domElement");
+    expect(teardown).toHaveBeenCalled();
+  });
 
-describe("isMultilanguageGrammar", () => {
-  expect(
-    isMultilanguageGrammar(atom.workspace.buildTextEditor().getGrammar())
-  ).toBe(false);
-  expect(isMultilanguageGrammar({ scopeName: "source.gfm" })).toBe(true);
-  expect(isMultilanguageGrammar({ scopeName: "source.asciidoc" })).toBe(true);
-});
+  it("isMultilanguageGrammar", () => {
+    expect(
+      isMultilanguageGrammar(atom.workspace.buildTextEditor().getGrammar())
+    ).toBe(false);
+    expect(isMultilanguageGrammar({ scopeName: "source.gfm" })).toBe(true);
+    expect(isMultilanguageGrammar({ scopeName: "source.asciidoc" })).toBe(true);
+  });
 
-describe("getEmbeddedScope", () => {
-  const editor = {
-    scopeDescriptorForBufferPosition: () => {
-      return {
-        getScopesArray: () => [
-          "text.md",
-          "fenced.code.md",
-          "source.embedded.python"
-        ]
-      };
-    }
-  };
-  spyOn(editor, "scopeDescriptorForBufferPosition").andCallThrough();
-  const scope = getEmbeddedScope(editor, "position");
-  expect(scope).toEqual("source.embedded.python");
-  expect(editor.scopeDescriptorForBufferPosition).toHaveBeenCalledWith(
-    "position"
-  );
+  it("getEmbeddedScope", () => {
+    const editor = {
+      scopeDescriptorForBufferPosition: () => {
+        return {
+          getScopesArray: () => [
+            "text.md",
+            "fenced.code.md",
+            "source.embedded.python"
+          ]
+        };
+      }
+    };
+    spyOn(editor, "scopeDescriptorForBufferPosition").andCallThrough();
+    const scope = getEmbeddedScope(editor, "position");
+    expect(scope).toEqual("source.embedded.python");
+    expect(editor.scopeDescriptorForBufferPosition).toHaveBeenCalledWith(
+      "position"
+    );
+  });
 });


### PR DESCRIPTION
Turns out it is possible without any language specific code:
![cell](https://cloud.githubusercontent.com/assets/13285808/24512138/086ec7dc-156e-11e7-890c-d3a2bd4f6a5a.gif)

This PR also adds tests for `store.setGrammar`.

We can also add support for "Run All" in the future.
/cc @fasiha @rgbkrk @mcburton