### PR TITLE
support language-weave files

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -31,7 +31,11 @@ const markupGrammars = new Set([
   "source.asciidoc",
   "text.restructuredtext",
   "text.tex.latex.knitr",
-  "text.md"
+  "text.md",
+  "source.weave.noweb",
+  "source.weave.md",
+  "source.pweave.noweb",
+  "source.pweave.md"
 ]);
 
 export function isMultilanguageGrammar(grammar: atom$Grammar) {


### PR DESCRIPTION
Adds support for Weave files. Merge after https://github.com/mpastell/language-weave/pull/3 is merged. 

cc: https://github.com/nteract/hydrogen/issues/684