### PR TITLE
Fix deprecation warning

### DIFF
--- a/lib/kernel-manager.js
+++ b/lib/kernel-manager.js
@@ -10,7 +10,7 @@ import Config from "./config";
 import ZMQKernel from "./zmq-kernel";
 import KernelPicker from "./kernel-picker";
 import store from "./store";
-import { grammarToLanguage, log } from "./utils";
+import { grammarToLanguage, getEditorDirectory, log } from "./utils";
 
 class KernelManager {
   constructor() {
@@ -21,7 +21,7 @@ class KernelManager {
     try {
       const rootDirectory = atom.project.rootDirectories[0]
         ? atom.project.rootDirectories[0].path
-        : path.dirname(atom.workspace.getActiveTextEditor().getPath());
+        : getEditorDirectory(store.editor);
       const connectionFile = path.join(
         rootDirectory,
         "hydrogen",
@@ -89,11 +89,7 @@ class KernelManager {
 
     log("KernelManager: startKernelFor:", language);
 
-    const projectPath = path.dirname(
-      atom.workspace.getActiveTextEditor().getPath()
-    );
-    const spawnOptions = { cwd: projectPath };
-    launchSpec(kernelSpec, spawnOptions).then(({
+    launchSpec(kernelSpec, { cwd: getEditorDirectory(store.editor) }).then(({
       config,
       connectionFile,
       spawn

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,6 +3,8 @@
 import { Disposable } from "atom";
 import ReactDOM from "react-dom";
 import _ from "lodash";
+import os from "os";
+import path from "path";
 
 import store from "./store";
 
@@ -48,6 +50,10 @@ export function getEmbeddedScope(
   return _.find(scopes, s => s.indexOf("source.embedded.") === 0);
 }
 
+export function getEditorDirectory(editor: atom$TextEditor) {
+  const editorPath = editor.getPath();
+  return editorPath ? path.dirname(editorPath) : os.homedir();
+}
 /* eslint-disable no-console */
 export function log(...message: Array<any>) {
   if (atom.inDevMode() || atom.config.get("Hydrogen.debug")) {

--- a/spec/utils-spec.js
+++ b/spec/utils-spec.js
@@ -2,12 +2,15 @@
 
 import ReactDOM from "react-dom";
 import { CompositeDisposable } from "atom";
+import os from "os";
+import path from "path";
 
 import {
   reactFactory,
   grammarToLanguage,
   isMultilanguageGrammar,
-  getEmbeddedScope
+  getEmbeddedScope,
+  getEditorDirectory
 } from "./../lib/utils";
 
 describe("utils", () => {
@@ -42,6 +45,19 @@ describe("utils", () => {
     ).toBe(false);
     expect(isMultilanguageGrammar({ scopeName: "source.gfm" })).toBe(true);
     expect(isMultilanguageGrammar({ scopeName: "source.asciidoc" })).toBe(true);
+  });
+
+  describe("getEditorDirectory", () => {
+    it("should return the directory of the current file", () => {
+      const filePath = "/directory/file.txt";
+      const editor = { getPath: () => filePath };
+      expect(getEditorDirectory(editor)).toBe(path.dirname(filePath));
+    });
+
+    it("should return the home directory if file isn't saved", () => {
+      const editor = { getPath: () => undefined };
+      expect(getEditorDirectory(editor)).toBe(os.homedir());
+    });
   });
 
   it("getEmbeddedScope", () => {


### PR DESCRIPTION
occuring when editor.getPath() returns undefined.

This happens when the file isn't saved before execution.
Fixes #685 