### PR TITLE
Support multiple language mappings

### DIFF
--- a/lib/autocomplete-provider.js
+++ b/lib/autocomplete-provider.js
@@ -2,7 +2,6 @@
 
 import _ from "lodash";
 import { log } from "./utils";
-import Config from "./config";
 import store from "./store";
 
 const iconHTML = `<img src='${__dirname}/../static/logo.svg' style='width: 100%;'>`;
@@ -42,11 +41,7 @@ export default function() {
         bufferPosition
       ]);
 
-      // Support none default grammars like magicpython
-      const languageMappings = Config.getJson("languageMappings");
-      const language = _.findKey(languageMappings, l => l === kernel.language);
-
-      const regex = regexes[kernel.language] || regexes[language];
+      const regex = regexes[kernel.language];
       if (regex) {
         prefix = _.head(line.match(regex)) || "";
       } else {

--- a/lib/autocomplete-provider.js
+++ b/lib/autocomplete-provider.js
@@ -1,8 +1,14 @@
-"use babel";
+/* @flow */
 
 import _ from "lodash";
 import { log } from "./utils";
 import store from "./store";
+
+type Autocomplete = {
+  editor: atom$TextEditor,
+  bufferPosition: atom$Point,
+  prefix: string
+};
 
 const iconHTML = `<img src='${__dirname}/../static/logo.svg' style='width: 100%;'>`;
 
@@ -29,14 +35,14 @@ export default function() {
     excludeLowerPriority: false,
 
     // Required: Return a promise, an array of suggestions, or null.
-    getSuggestions({ editor, bufferPosition, prefix }) {
+    getSuggestions({ editor, bufferPosition, prefix }: Autocomplete) {
       const kernel = store.kernel;
 
       if (!kernel || kernel.executionState !== "idle") {
         return null;
       }
 
-      const line = editor.getTextInRange([
+      const line = editor.getTextInBufferRange([
         [bufferPosition.row, 0],
         bufferPosition
       ]);

--- a/lib/config.js
+++ b/lib/config.js
@@ -52,7 +52,7 @@ const Config = {
     languageMappings: {
       title: "Language Mappings",
       includeTitle: false,
-      description: 'Some kernels may use a non-standard language name (e.g. jupyter-scala sets the language name to `scala211`). That leaves Hydrogen unable to figure out what kernel for your code. This field should be a valid JSON mapping from a kernel language name to Atom\'s lower-cased grammar name, e.g. ``` { "scala211": "scala", "Elixir": "elixir" } ```',
+      description: 'Custom Atom grammars and some kernels use non-standard language names. That leaves Hydrogen unable to figure out what kernel to start for your code. This field should be a valid JSON mapping from a kernel language name to Atom\'s grammar name ``` { "kernel name": "grammar name" } ```. For example ``` { "scala211": "scala", "javascript": "babel es6 javascript", "python": "magicpython" } ```.',
       type: "string",
       default: "{}"
     },

--- a/lib/kernel-manager.js
+++ b/lib/kernel-manager.js
@@ -170,11 +170,7 @@ class KernelManager {
   }
 
   kernelSpecProvidesLanguage(kernelSpec, grammarLanguage) {
-    const kernelLanguage = kernelSpec.language;
-    const mappedLanguage = Config.getJson("languageMappings")[kernelLanguage];
-
-    return mappedLanguage === grammarLanguage ||
-      kernelLanguage === grammarLanguage;
+    return kernelSpec.language === grammarLanguage;
   }
 
   getKernelSpecsFromSettings() {

--- a/lib/kernel-manager.js
+++ b/lib/kernel-manager.js
@@ -169,15 +169,12 @@ class KernelManager {
     });
   }
 
-  kernelSpecProvidesLanguage(kernelSpec, language) {
+  kernelSpecProvidesLanguage(kernelSpec, grammarLanguage) {
     const kernelLanguage = kernelSpec.language;
     const mappedLanguage = Config.getJson("languageMappings")[kernelLanguage];
 
-    if (mappedLanguage) {
-      return mappedLanguage === language;
-    }
-
-    return kernelLanguage.toLowerCase() === language;
+    return mappedLanguage === grammarLanguage ||
+      kernelLanguage === grammarLanguage;
   }
 
   getKernelSpecsFromSettings() {

--- a/lib/kernel.js
+++ b/lib/kernel.js
@@ -3,7 +3,7 @@
 import { Emitter } from "atom";
 import { observable, action } from "mobx";
 
-import { grammarToLanguage, log } from "./utils";
+import { log } from "./utils";
 import store from "./store";
 
 import WatchSidebar from "./watch-sidebar";
@@ -31,8 +31,7 @@ export default class Kernel {
     this.grammar = grammar;
     this.watchSidebar = new WatchSidebar(this);
 
-    // $FlowFixMe Since grammar is defined, grammarToLanguage will return a string
-    this.language = grammarToLanguage(grammar);
+    this.language = kernelSpec.language.toLowerCase();
     this.displayName = kernelSpec.display_name;
   }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,6 +4,7 @@ import { Disposable } from "atom";
 import ReactDOM from "react-dom";
 import _ from "lodash";
 
+import Config from "./config";
 import store from "./store";
 
 export function reactFactory(
@@ -23,7 +24,16 @@ export function reactFactory(
 }
 
 export function grammarToLanguage(grammar: ?atom$Grammar) {
-  return grammar ? grammar.name.toLowerCase() : null;
+  if (!grammar) return null;
+  const grammarLanguage = grammar.name.toLowerCase();
+
+  const mappings = Config.getJson("languageMappings");
+  const kernelLanguage = _.findKey(
+    mappings,
+    l => l.toLowerCase() === grammarLanguage
+  );
+
+  return kernelLanguage ? kernelLanguage.toLowerCase() : grammarLanguage;
 }
 
 const markupGrammars = new Set([

--- a/spec/utils-spec.js
+++ b/spec/utils-spec.js
@@ -11,10 +11,30 @@ import {
 } from "./../lib/utils";
 
 describe("utils", () => {
-  it("grammarToLanguage", () => {
-    expect(grammarToLanguage({ name: "Kernel Name" })).toEqual("kernel name");
-    expect(grammarToLanguage(null)).toBeNull();
-    expect(grammarToLanguage(undefined)).toBeNull();
+  describe("grammarToLanguage", () => {
+    it("should return null if no rammar given", () => {
+      expect(grammarToLanguage()).toBeNull();
+      expect(grammarToLanguage(null)).toBeNull();
+      expect(grammarToLanguage(undefined)).toBeNull();
+    });
+
+    it("should return language from grammar", () => {
+      expect(grammarToLanguage({ name: "Kernel Name" })).toEqual("kernel name");
+    });
+
+    it("should return respect languageMappings", () => {
+      atom.config.set(
+        "Hydrogen.languageMappings",
+        `{"Kernel Language": "Grammar Language"}`
+      );
+      expect(grammarToLanguage({ name: "Grammar Language" })).toEqual(
+        "kernel language"
+      );
+      expect(grammarToLanguage({ name: "Kernel Language" })).toEqual(
+        "kernel language"
+      );
+      atom.config.set("Hydrogen.languageMappings", "");
+    });
   });
 
   it("reactFactory", () => {


### PR DESCRIPTION
This will store running kernels by the language from their kernel spec.
It also makes sure that all names are normalized to lower case.

Fixes #684