### PR TITLE
Add mobx-react-devtools

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -22,7 +22,12 @@ import WSKernel from "./ws-kernel";
 import Inspector from "./components/inspector";
 import AutocompleteProvider from "./autocomplete-provider";
 import HydrogenProvider from "./plugin-api/hydrogen-provider";
-import { log, reactFactory, isMultilanguageGrammar } from "./utils";
+import {
+  log,
+  reactFactory,
+  isMultilanguageGrammar,
+  renderDevTools
+} from "./utils";
 
 import type Kernel from "./kernel";
 
@@ -118,6 +123,8 @@ const Hydrogen = {
     );
 
     this.hydrogenProvider = null;
+
+    renderDevTools();
 
     autorun(() => {
       this.setWatchSidebar(store.kernel);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import { Disposable } from "atom";
+import React from "react";
 import ReactDOM from "react-dom";
 import _ from "lodash";
 
@@ -52,5 +53,19 @@ export function getEmbeddedScope(
 export function log(...message: Array<any>) {
   if (atom.inDevMode() || atom.config.get("Hydrogen.debug")) {
     console.debug("Hydrogen:", ...message);
+  }
+}
+
+export function renderDevTools() {
+  if (atom.inDevMode() || atom.config.get("Hydrogen.debug")) {
+    try {
+      const devTools = require("mobx-react-devtools");
+      const div = document.createElement("div");
+      document.getElementsByTagName("body")[0].appendChild(div);
+      devTools.setLogEnabled(true);
+      ReactDOM.render(<devTools.default noPanel />, div);
+    } catch (e) {
+      log("Could not enable dev tools", e);
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "husky": "^0.13.3",
     "lint-staged": "^3.4.0",
     "markdox": "^0.1.10",
+    "mobx-react-devtools": "^4.2.11",
     "prettier": "^0.22.0",
     "react-addons-test-utils": "^15.4.2"
   }


### PR DESCRIPTION
This will add [`mobx-react-devtools`](https://github.com/mobxjs/mobx-react-devtools) to our dev dependencies to get great logging for our mobx actions.