### PR TITLE
KernelManager: Fix language detection

### DIFF
--- a/lib/kernel-manager.js
+++ b/lib/kernel-manager.js
@@ -166,7 +166,7 @@ class KernelManager {
   }
 
   kernelSpecProvidesLanguage(kernelSpec, grammarLanguage) {
-    return kernelSpec.language === grammarLanguage;
+    return kernelSpec.language.toLowerCase() === grammarLanguage.toLowerCase();
   }
 
   getKernelSpecsFromSettings() {


### PR DESCRIPTION
* Use lowercase in language name comparisons

* Ensured that `grammarToLanguage(grammar)` returns the mapped language.

Fixes #696