### PR TITLE
Fix: Sequential output is not displayed

### DIFF
--- a/lib/result-view.js
+++ b/lib/result-view.js
@@ -183,6 +183,15 @@ export default class ResultView {
     const mimeType = richestMimetype(bundle, displayOrder, transforms);
     const Transform = transforms.get(mimeType);
 
+    // If transforms use unsafe eval, we might need to use loophole due to Atom's CSP:
+    // allowUnsafeEval(() => {
+    //   allowUnsafeNewFunction(() => {
+    //     ReactDOM.render(<Transform data={bundle.get(mimeType)} />, div);
+    //   });
+    // });
+    const div = document.createElement("div");
+    ReactDOM.render(<Transform data={bundle.get(mimeType)} />, div);
+
     if (mimeType === "text/plain") {
       this.element.classList.remove("rich");
 
@@ -214,14 +223,7 @@ export default class ResultView {
     log("ResultView: Rendering as MIME ", mimeType);
     // this.getAllText must be called after appending the htmlElement
     // in order to obtain innerText
-
-    // If transforms use unsafe eval, we might need to use loophole due to Atom's CSP:
-    // allowUnsafeEval(() => {
-    //   allowUnsafeNewFunction(() => {
-    //     ReactDOM.render(<Transform data={bundle.get(mimeType)} />, container);
-    //   });
-    // });
-    ReactDOM.render(<Transform data={bundle.get(mimeType)} />, container);
+    container.appendChild(div);
 
     if (mimeType === "text/html") {
       if (this.getAllText() !== "") {

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "markdox": "^0.1.10",
     "mobx-react-devtools": "^4.2.11",
     "prettier": "^0.22.0",
-    "react-addons-test-utils": "^15.4.2"
+    "react-addons-test-utils": "^15.4.2",
+    "react-test-renderer": "^15.5.4"
   }
 }


### PR DESCRIPTION
A regression slipped through in #655.

[As before](https://github.com/nteract/hydrogen/pull/655/files#diff-375c469d3548707f41002f462a83207fL198) we should append new output to the container until we refactor the result view as a proper react component.

Fixes #708 
Fixes #707