### PR TITLE
Tests: Upgrade to jasmine 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "build:docs": "markdox lib/plugin-api/hydrogen-provider.js lib/plugin-api/hydrogen-kernel.js -o PLUGIN_API.md",
     "precommit": "lint-staged"
   },
+  "atomTestRunner": "atom-jasmine2-test-runner",
   "repository": "https://github.com/nteract/hydrogen",
   "license": "MIT",
   "engines": {
@@ -90,6 +91,7 @@
     }
   },
   "devDependencies": {
+    "atom-jasmine2-test-runner": "^0.6.0",
     "babel-eslint": "^7.1.0",
     "enzyme": "^2.7.1",
     "eslint": "^3.16.1",

--- a/spec/components/status-bar-spec.js
+++ b/spec/components/status-bar-spec.js
@@ -31,7 +31,7 @@ describe("Status Bar", () => {
   });
 
   it("should update status correctly", () => {
-    spyOn(StatusBar.prototype, "render").andCallThrough();
+    spyOn(StatusBar.prototype, "render").and.callThrough();
     const kernel = {
       language: "null grammar",
       displayName: "Null Kernel",
@@ -39,20 +39,20 @@ describe("Status Bar", () => {
     };
     const component = shallow(<StatusBar store={store} onClick={() => {}} />);
     // empty
-    expect(StatusBar.prototype.render.calls.length).toEqual(1);
+    expect(StatusBar.prototype.render).toHaveBeenCalledTimes(1);
     expect(component.type()).toBeNull();
     expect(component.text()).toBe("");
     // with kernel
     store.updateEditor(atom.workspace.buildTextEditor());
     store.newKernel(kernel);
-    expect(StatusBar.prototype.render.calls.length).toEqual(2);
+    expect(StatusBar.prototype.render).toHaveBeenCalledTimes(2);
     expect(component.text()).toBe("Null Kernel | starting");
     // doesn't update if switched to editor with same grammar
     store.updateEditor(atom.workspace.buildTextEditor());
-    expect(StatusBar.prototype.render.calls.length).toEqual(2);
+    expect(StatusBar.prototype.render).toHaveBeenCalledTimes(2);
     // update execution state
     store.kernel.executionState = "idle";
-    expect(StatusBar.prototype.render.calls.length).toEqual(3);
+    expect(StatusBar.prototype.render).toHaveBeenCalledTimes(3);
     expect(component.text()).toBe("Null Kernel | idle");
     // reset store
     store.runningKernels = new Map();

--- a/spec/kernel-manager-spec.js
+++ b/spec/kernel-manager-spec.js
@@ -62,6 +62,7 @@ describe("Kernel manager", () => {
       });
 
       it("should return {} if no kernelspec is set", () => {
+        atom.config.set("Hydrogen.kernelspec", "");
         expect(kernelManager.getKernelSpecsFromSettings()).toEqual({});
       });
 
@@ -80,89 +81,62 @@ describe("Kernel manager", () => {
         expect(specs).toEqual(kernelSpecs.kernelspecs);
       }));
 
-    describe("getAllKernelSpecs", () =>
-      it("should return an array with specs", () =>
-        waitsForPromise(
-          () =>
-            new Promise(resolve => {
-              kernelManager._kernelSpecs = kernelSpecs.kernelspecs;
-              kernelManager.getAllKernelSpecs(specs => {
-                expect(specs.length).toEqual(2);
-                expect(specs[0]).toEqual(
-                  kernelSpecs.kernelspecs.ijavascript.spec
-                );
-                expect(specs[1]).toEqual(kernelSpecs.kernelspecs.python2.spec);
-                resolve();
-              });
-            })
-        )));
+    describe("getAllKernelSpecs", () => {
+      it("should return an array with specs", done => {
+        kernelManager._kernelSpecs = kernelSpecs.kernelspecs;
+        kernelManager.getAllKernelSpecs(specs => {
+          expect(specs.length).toEqual(2);
+          expect(specs[0]).toEqual(kernelSpecs.kernelspecs.ijavascript.spec);
+          expect(specs[1]).toEqual(kernelSpecs.kernelspecs.python2.spec);
+          done();
+        });
+      });
+    });
 
     describe("getAllKernelSpecsFor", () => {
-      it("should return an array with specs for given language", () =>
-        waitsForPromise(
-          () =>
-            new Promise(resolve => {
-              kernelManager._kernelSpecs = kernelSpecs.kernelspecs;
-              kernelManager.getAllKernelSpecsFor("python", specs => {
-                expect(specs.length).toEqual(1);
-                expect(specs[0]).toEqual(kernelSpecs.kernelspecs.python2.spec);
-                resolve();
-              });
-            })
-        ));
+      it("should return an array with specs for given language", done => {
+        kernelManager._kernelSpecs = kernelSpecs.kernelspecs;
+        kernelManager.getAllKernelSpecsFor("python", specs => {
+          expect(specs.length).toEqual(1);
+          expect(specs[0]).toEqual(kernelSpecs.kernelspecs.python2.spec);
+          done();
+        });
+      });
 
-      it("should return an empty array", () =>
-        waitsForPromise(
-          () =>
-            new Promise(resolve => {
-              kernelManager._kernelSpecs = kernelSpecs.kernelspecs;
-              kernelManager.getAllKernelSpecsFor("julia", specs => {
-                expect(specs).toEqual([]);
-                resolve();
-              });
-            })
-        ));
+      it("should return an empty array", done => {
+        kernelManager._kernelSpecs = kernelSpecs.kernelspecs;
+        kernelManager.getAllKernelSpecsFor("julia", specs => {
+          expect(specs).toEqual([]);
+          done();
+        });
+      });
     });
 
     describe("getKernelSpecFor", () => {
-      it("should return spec for given language", () =>
-        waitsForPromise(
-          () =>
-            new Promise(resolve => {
-              kernelManager._kernelSpecs = kernelSpecs.kernelspecs;
-              kernelManager.getKernelSpecFor("python", kernelSpec => {
-                expect(kernelSpec).toEqual(
-                  kernelSpecs.kernelspecs.python2.spec
-                );
-                resolve();
-              });
-            })
-        ));
+      it("should return spec for given language", done => {
+        kernelManager._kernelSpecs = kernelSpecs.kernelspecs;
+        kernelManager.getKernelSpecFor("python", kernelSpec => {
+          expect(kernelSpec).toEqual(kernelSpecs.kernelspecs.python2.spec);
+          done();
+        });
+      });
 
-      it("should return undefined", () =>
-        waitsForPromise(
-          () =>
-            new Promise(resolve => {
-              kernelManager._kernelSpecs = kernelSpecs.kernelspecs;
-              kernelManager.getKernelSpecFor("julia", kernelSpecForJulia => {
-                expect(kernelSpecForJulia).toBeUndefined();
-                resolve();
-              });
-            })
-        ));
+      it("should return undefined", done => {
+        kernelManager._kernelSpecs = kernelSpecs.kernelspecs;
+        kernelManager.getKernelSpecFor("julia", kernelSpecForJulia => {
+          expect(kernelSpecForJulia).toBeUndefined();
+          done();
+        });
+      });
     });
 
-    it("should update kernelspecs", () =>
-      waitsForPromise(
-        () =>
-          new Promise(resolve => {
-            kernelManager.getKernelSpecsFromJupyter((err, specs) => {
-              if (!err) {
-                expect(specs instanceof Object).toEqual(true);
-              }
-              resolve();
-            });
-          })
-      ));
+    it("should update kernelspecs", done => {
+      kernelManager.getKernelSpecsFromJupyter((err, specs) => {
+        if (!err) {
+          expect(specs instanceof Object).toEqual(true);
+        }
+        done();
+      });
+    });
   });
 });

--- a/spec/store-spec.js
+++ b/spec/store-spec.js
@@ -68,7 +68,9 @@ describe("Store", () => {
       };
 
       const pythonGrammar = { scopeName: "source.python", name: "Python" };
-      spyOn(atom.grammars, "grammarForScopeName").andReturn(pythonGrammar);
+      spyOn(atom.grammars, "grammarForScopeName").and.returnValue(
+        pythonGrammar
+      );
 
       store.setGrammar(editor);
       expect(store.grammar).toEqual(pythonGrammar);
@@ -113,7 +115,7 @@ describe("Store", () => {
   });
 
   it("should update editor", () => {
-    spyOn(store, "setGrammar").andCallThrough();
+    spyOn(store, "setGrammar").and.callThrough();
     expect(store.editor).toBeNull();
     const editor = atom.workspace.buildTextEditor();
     store.updateEditor(editor);

--- a/spec/utils-spec.js
+++ b/spec/utils-spec.js
@@ -42,7 +42,7 @@ describe("utils", () => {
 
   it("reactFactory", () => {
     const compDisposable = new CompositeDisposable();
-    spyOn(compDisposable, "add").andCallThrough();
+    spyOn(compDisposable, "add").and.callThrough();
     spyOn(ReactDOM, "render");
     spyOn(ReactDOM, "unmountComponentAtNode");
     const teardown = jasmine.createSpy("teardown");
@@ -92,7 +92,7 @@ describe("utils", () => {
         };
       }
     };
-    spyOn(editor, "scopeDescriptorForBufferPosition").andCallThrough();
+    spyOn(editor, "scopeDescriptorForBufferPosition").and.callThrough();
     const scope = getEmbeddedScope(editor, "position");
     expect(scope).toEqual("source.embedded.python");
     expect(editor.scopeDescriptorForBufferPosition).toHaveBeenCalledWith(


### PR DESCRIPTION
Atom itself uses the quite dated Jasmine 1.3.

This upgrades our test to [Jasmine 2](https://jasmine.github.io/2.5/introduction) via [`atom-jasmine2-test-runner`](https://github.com/UziTech/atom-jasmine2-test-runner) for better async support and more.

We will still have access to the atom globals.

I think this closes #691 for now since it is a lot easier than switching to jest.