### PR TITLE
Fix: Unmount react if result bubble is destroyed

### DIFF
--- a/lib/result-view.js
+++ b/lib/result-view.js
@@ -309,6 +309,12 @@ export default class ResultView {
     if (this.marker) {
       this.marker.destroy();
     }
+    [
+      ...this.errorContainer.childNodes,
+      ...this.resultContainer.childNodes
+    ].forEach(item => {
+      ReactDOM.unmountComponentAtNode(item);
+    });
     this.element.innerHTML = "";
   }
 }


### PR DESCRIPTION
I'm not 100% sure if this is really necessary.

But if it is this fixes a memory leak since it unmounts React if the result bubble isn't needed anymore.