### PR TITLE
Fix kernel picker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,4 @@ script:
 
 env:
   matrix:
-    - ATOM_CHANNEL=beta
-
-before_install:
-  - python -m pip install ipykernel --user
-  - python -m ipykernel install --user
+    - ATOM_CHANNEL=beta  

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -181,11 +181,13 @@ function getCurrentCodeCell(editor: atom$TextEditor) {
   }
 
   if (cursor.row > 0) {
-    buffer.backwardsScanInRange(regex, new Range(start, cursor), ({
-      range
-    }) => {
-      start = new Point(range.start.row + 1, 0);
-    });
+    buffer.backwardsScanInRange(
+      regex,
+      new Range(start, cursor),
+      ({ range }) => {
+        start = new Point(range.start.row + 1, 0);
+      }
+    );
   }
 
   buffer.scanInRange(regex, new Range(cursor, end), ({ range }) => {

--- a/lib/components/inspector/index.js
+++ b/lib/components/inspector/index.js
@@ -34,20 +34,26 @@ export default class Inspector {
       return;
     }
 
-    kernel.inspect(code, cursorPos, (result: {
-      data: Object,
-      found: Boolean
-    }) => {
-      log("Inspector: Result:", result);
+    kernel.inspect(
+      code,
+      cursorPos,
+      (
+        result: {
+          data: Object,
+          found: Boolean
+        }
+      ) => {
+        log("Inspector: Result:", result);
 
-      if (!result.found) {
-        kernel.setInspectorVisibility(false);
-        atom.notifications.addInfo("No introspection available!");
-        return;
+        if (!result.found) {
+          kernel.setInspectorVisibility(false);
+          atom.notifications.addInfo("No introspection available!");
+          return;
+        }
+        const bundle = new ImmutableMap(result.data);
+
+        kernel.setInspectorResult(bundle);
       }
-      const bundle = new ImmutableMap(result.data);
-
-      kernel.setInspectorResult(bundle);
-    });
+    );
   }
 }

--- a/lib/kernel-manager.js
+++ b/lib/kernel-manager.js
@@ -89,11 +89,9 @@ class KernelManager {
 
     log("KernelManager: startKernel:", displayName);
 
-    launchSpec(kernelSpec, { cwd: getEditorDirectory(store.editor) }).then(({
-      config,
-      connectionFile,
-      spawn
-    }) => {
+    launchSpec(kernelSpec, {
+      cwd: getEditorDirectory(store.editor)
+    }).then(({ config, connectionFile, spawn }) => {
       const kernel = new ZMQKernel(
         kernelSpec,
         grammar,

--- a/lib/kernel-manager.js
+++ b/lib/kernel-manager.js
@@ -10,7 +10,7 @@ import Config from "./config";
 import ZMQKernel from "./zmq-kernel";
 import KernelPicker from "./kernel-picker";
 import store from "./store";
-import { grammarToLanguage, getEditorDirectory, log } from "./utils";
+import { getEditorDirectory, log } from "./utils";
 
 class KernelManager {
   constructor() {
@@ -37,10 +37,9 @@ class KernelManager {
       }
     }
 
-    const language = grammarToLanguage(grammar);
-    this.getKernelSpecFor(language, kernelSpec => {
+    this.getKernelSpecForGrammar(grammar, kernelSpec => {
       if (!kernelSpec) {
-        const message = `No kernel for language \`${language}\` found`;
+        const message = `No kernel for grammar \`${grammar.name}\` found`;
         const description =
           "Check that the language for this file is set in Atom and that you have a Jupyter kernel installed for it.";
         atom.notifications.addError(message, { description });
@@ -52,7 +51,7 @@ class KernelManager {
   }
 
   startExistingKernel(grammar, connection, connectionFile, onStarted) {
-    const language = grammarToLanguage(grammar);
+    const language = grammar.name;
 
     log("KernelManager: startExistingKernel: Assuming", language);
 
@@ -86,9 +85,9 @@ class KernelManager {
   }
 
   startKernel(kernelSpec, grammar, onStarted) {
-    const language = grammarToLanguage(grammar);
+    const displayName = kernelSpec.display_name;
 
-    log("KernelManager: startKernelFor:", language);
+    log("KernelManager: startKernel:", displayName);
 
     launchSpec(kernelSpec, { cwd: getEditorDirectory(store.editor) }).then(({
       config,
@@ -104,7 +103,7 @@ class KernelManager {
       );
 
       kernel.connect(() => {
-        log("KernelManager: startKernelFor: kernel for", language, "connected");
+        log("KernelManager: startKernel:", displayName, "connected");
 
         store.newKernel(kernel);
 
@@ -147,6 +146,18 @@ class KernelManager {
     return callback([]);
   }
 
+  getAllKernelSpecsForGrammar(grammar, callback) {
+    if (grammar) {
+      return this.getAllKernelSpecs(kernelSpecs => {
+        const specs = kernelSpecs.filter(spec =>
+          this.kernelSpecProvidesGrammar(spec, grammar));
+
+        return callback(specs);
+      });
+    }
+    return callback([]);
+  }
+
   getKernelSpecFor(language, callback) {
     if (!language) {
       return;
@@ -169,8 +180,47 @@ class KernelManager {
     });
   }
 
+  getKernelSpecForGrammar(grammar, callback) {
+    if (!grammar) {
+      return;
+    }
+
+    this.getAllKernelSpecsForGrammar(grammar, kernelSpecs => {
+      if (kernelSpecs.length <= 1) {
+        callback(kernelSpecs[0]);
+        return;
+      }
+
+      if (!this.kernelPicker) {
+        this.kernelPicker = new KernelPicker(onUpdated =>
+          onUpdated(kernelSpecs));
+        this.kernelPicker.onConfirmed = ({ kernelSpec }) =>
+          callback(kernelSpec);
+      }
+      this.kernelPicker.toggle();
+    });
+  }
+
   kernelSpecProvidesLanguage(kernelSpec, grammarLanguage) {
     return kernelSpec.language.toLowerCase() === grammarLanguage.toLowerCase();
+  }
+
+  kernelSpecProvidesGrammar(kernelSpec, grammar) {
+    if (!grammar || !grammar.name || !kernelSpec || !kernelSpec.language) {
+      return false;
+    }
+    const grammarLanguage = grammar.name.toLowerCase();
+    const kernelLanguage = kernelSpec.language.toLowerCase();
+    if (kernelLanguage === grammarLanguage) {
+      return true;
+    }
+
+    const mappedLanguage = Config.getJson("languageMappings")[kernelLanguage];
+    if (!mappedLanguage) {
+      return false;
+    }
+
+    return mappedLanguage.toLowerCase() === grammarLanguage;
   }
 
   getKernelSpecsFromSettings() {

--- a/lib/kernel-manager.js
+++ b/lib/kernel-manager.js
@@ -150,7 +150,8 @@ class KernelManager {
     if (grammar) {
       return this.getAllKernelSpecs(kernelSpecs => {
         const specs = kernelSpecs.filter(spec =>
-          this.kernelSpecProvidesGrammar(spec, grammar));
+          this.kernelSpecProvidesGrammar(spec, grammar)
+        );
 
         return callback(specs);
       });
@@ -169,13 +170,13 @@ class KernelManager {
         return;
       }
 
-      if (!this.kernelPicker) {
-        this.kernelPicker = new KernelPicker(onUpdated =>
-          onUpdated(kernelSpecs)
-        );
-        this.kernelPicker.onConfirmed = ({ kernelSpec }) =>
-          callback(kernelSpec);
+      if (this.kernelPicker) {
+        this.kernelPicker.kernelSpecs = kernelSpecs;
+      } else {
+        this.kernelPicker = new KernelPicker(kernelSpecs);
       }
+
+      this.kernelPicker.onConfirmed = ({ kernelSpec }) => callback(kernelSpec);
       this.kernelPicker.toggle();
     });
   }
@@ -191,12 +192,13 @@ class KernelManager {
         return;
       }
 
-      if (!this.kernelPicker) {
-        this.kernelPicker = new KernelPicker(onUpdated =>
-          onUpdated(kernelSpecs));
-        this.kernelPicker.onConfirmed = ({ kernelSpec }) =>
-          callback(kernelSpec);
+      if (this.kernelPicker) {
+        this.kernelPicker.kernelSpecs = kernelSpecs;
+      } else {
+        this.kernelPicker = new KernelPicker(kernelSpecs);
       }
+
+      this.kernelPicker.onConfirmed = ({ kernelSpec }) => callback(kernelSpec);
       this.kernelPicker.toggle();
     });
   }

--- a/lib/kernel-picker.js
+++ b/lib/kernel-picker.js
@@ -7,8 +7,8 @@ import { log } from "./utils";
 
 // View to display a list of grammars to apply to the current editor.
 export default class SignalListView extends SelectListView {
-  initialize(getKernelSpecs) {
-    this.getKernelSpecs = getKernelSpecs;
+  initialize(kernelSpecs) {
+    this.kernelSpecs = kernelSpecs;
     super.initialize(...arguments);
 
     this.onConfirmed = null;
@@ -48,14 +48,12 @@ export default class SignalListView extends SelectListView {
     }
     this.focusFilterEditor();
 
-    this.getKernelSpecs(kernelSpec => {
-      this.languageOptions = _.map(kernelSpec, spec => ({
-        name: spec.display_name,
-        kernelSpec: spec
-      }));
+    this.languageOptions = _.map(this.kernelSpecs, spec => ({
+      name: spec.display_name,
+      kernelSpec: spec
+    }));
 
-      this.setItems(this.languageOptions);
-    });
+    this.setItems(this.languageOptions);
   }
 
   getEmptyMessage() {

--- a/lib/kernel.js
+++ b/lib/kernel.js
@@ -241,7 +241,7 @@ export default class Kernel {
 
   destroy() {
     log("Kernel: Destroying base kernel");
-    store.deleteKernel(this.language);
+    store.deleteKernel(this);
     if (this.pluginWrapper) {
       this.pluginWrapper.destroyed = true;
     }

--- a/lib/main.js
+++ b/lib/main.js
@@ -86,7 +86,9 @@ const Hydrogen = {
     store.subscriptions.add(
       atom.workspace.observeActivePaneItem(item => {
         const currentEditor = atom.workspace.getActiveTextEditor();
-        store.updateEditor(item === currentEditor ? currentEditor : null);
+        store.updateEditorAndGrammar(
+          item === currentEditor ? currentEditor : null
+        );
       })
     );
 
@@ -95,7 +97,7 @@ const Hydrogen = {
         const editorSubscriptions = new CompositeDisposable();
         editorSubscriptions.add(
           editor.onDidChangeGrammar(() => {
-            store.setGrammar(editor);
+            store.updateEditorAndGrammar(editor);
           })
         );
 
@@ -103,7 +105,7 @@ const Hydrogen = {
           editorSubscriptions.add(
             editor.onDidChangeCursorPosition(
               _.debounce(() => {
-                store.setGrammar(editor);
+                store.updateEditorAndGrammar(editor);
               }, 75)
             )
           );
@@ -213,7 +215,12 @@ const Hydrogen = {
   }: { command: string, payload: ?Kernelspec }) {
     log("handleKernelCommand:", arguments);
 
-    const { kernel, grammar, language } = store;
+    const { kernel, grammar } = store;
+
+    if (!grammar) {
+      atom.notifications.addError("Undefined grammar");
+      return;
+    }
 
     if (command === "switch-kernel") {
       this.clearResultBubbles();
@@ -223,7 +230,7 @@ const Hydrogen = {
     }
 
     if (!kernel) {
-      const message = `No running kernel for language \`${language || "null"}\` found`;
+      const message = `No running kernel for grammar \`${grammar.name}\` found`;
       atom.notifications.addError(message);
       return;
     }
@@ -436,9 +443,8 @@ const Hydrogen = {
   showKernelPicker() {
     if (!this.kernelPicker) {
       this.kernelPicker = new KernelPicker((callback: Function) => {
-        kernelManager.getAllKernelSpecsFor(store.language, kernelSpecs =>
-          callback(kernelSpecs)
-        );
+        kernelManager.getAllKernelSpecsForGrammar(store.grammar, kernelSpecs =>
+          callback(kernelSpecs));
       });
       this.kernelPicker.onConfirmed = ({
         kernelSpec
@@ -463,7 +469,7 @@ const Hydrogen = {
     }
 
     this.wsKernelPicker.toggle(store.grammar, (kernelSpec: Kernelspec) =>
-      kernelManager.kernelSpecProvidesLanguage(kernelSpec, store.language)
+      kernelManager.kernelSpecProvidesGrammar(kernelSpec, store.grammar)
     );
   }
 };

--- a/lib/main.js
+++ b/lib/main.js
@@ -441,20 +441,23 @@ const Hydrogen = {
   },
 
   showKernelPicker() {
-    if (!this.kernelPicker) {
-      this.kernelPicker = new KernelPicker((callback: Function) => {
-        kernelManager.getAllKernelSpecsForGrammar(store.grammar, kernelSpecs =>
-          callback(kernelSpecs));
-      });
-      this.kernelPicker.onConfirmed = ({
-        kernelSpec
-      }: { kernelSpec: Kernelspec }) =>
-        this.handleKernelCommand({
-          command: "switch-kernel",
-          payload: kernelSpec
-        });
-    }
-    this.kernelPicker.toggle();
+    kernelManager.getAllKernelSpecsForGrammar(store.grammar, kernelSpecs => {
+      if (this.kernelPicker) {
+        this.kernelPicker.kernelSpecs = kernelSpecs;
+      } else {
+        this.kernelPicker = new KernelPicker(kernelSpecs);
+
+        this.kernelPicker.onConfirmed = ({
+          kernelSpec
+        }: { kernelSpec: Kernelspec }) =>
+          this.handleKernelCommand({
+            command: "switch-kernel",
+            payload: kernelSpec
+          });
+      }
+
+      this.kernelPicker.toggle();
+    });
   },
 
   showWSKernelPicker() {

--- a/lib/main.js
+++ b/lib/main.js
@@ -394,14 +394,14 @@ const Hydrogen = {
 
   _runAll(editor: atom$TextEditor, kernel: Kernel) {
     const cells = codeManager.getCells(editor);
-    _.forEach(cells, ({
-      start,
-      end
-    }: { start: atom$Point, end: atom$Point }) => {
-      const code = codeManager.getTextInRange(editor, start, end);
-      const endRow = codeManager.escapeBlankRows(editor, start.row, end.row);
-      this._createResultBubble(kernel, code, endRow);
-    });
+    _.forEach(
+      cells,
+      ({ start, end }: { start: atom$Point, end: atom$Point }) => {
+        const code = codeManager.getTextInRange(editor, start, end);
+        const endRow = codeManager.escapeBlankRows(editor, start.row, end.row);
+        this._createResultBubble(kernel, code, endRow);
+      }
+    );
   },
 
   runAllAbove() {

--- a/lib/main.js
+++ b/lib/main.js
@@ -86,9 +86,7 @@ const Hydrogen = {
     store.subscriptions.add(
       atom.workspace.observeActivePaneItem(item => {
         const currentEditor = atom.workspace.getActiveTextEditor();
-        store.updateEditorAndGrammar(
-          item === currentEditor ? currentEditor : null
-        );
+        store.updateEditor(item === currentEditor ? currentEditor : null);
       })
     );
 
@@ -97,7 +95,7 @@ const Hydrogen = {
         const editorSubscriptions = new CompositeDisposable();
         editorSubscriptions.add(
           editor.onDidChangeGrammar(() => {
-            store.updateEditorAndGrammar(editor);
+            store.setGrammar(editor);
           })
         );
 
@@ -105,7 +103,7 @@ const Hydrogen = {
           editorSubscriptions.add(
             editor.onDidChangeCursorPosition(
               _.debounce(() => {
-                store.updateEditorAndGrammar(editor);
+                store.setGrammar(editor);
               }, 75)
             )
           );

--- a/lib/plugin-api/hydrogen-provider.js
+++ b/lib/plugin-api/hydrogen-provider.js
@@ -1,7 +1,6 @@
 "use babel";
 
 import store from "./../store";
-import { grammarToLanguage } from "./../utils";
 /**
  * @version 1.0.0
  *
@@ -42,8 +41,9 @@ export default class HydrogenProvider {
   getActiveKernel() {
     if (!store.kernel) {
       const grammar = store.editor.getGrammar();
-      const language = grammarToLanguage(grammar);
-      throw new Error(`No running kernel for language \`${language}\` found`);
+      throw new Error(
+        `No running kernel for grammar \`${grammar.name}\` found`
+      );
     }
 
     return store.kernel.getPluginWrapper();

--- a/lib/signal-list-view.js
+++ b/lib/signal-list-view.js
@@ -60,7 +60,7 @@ export default class SignalListView extends SelectListView {
       this.panel = atom.workspace.addModalPanel({ item: this });
     }
     this.focusFilterEditor();
-    const language = store.language;
+    const grammar = store.grammar;
 
     // disable all commands if no kernel is running
     const kernel = store.kernel;
@@ -82,7 +82,7 @@ export default class SignalListView extends SelectListView {
       this.setItems(_.union(basicCommands, wsKernelCommands));
     } else {
       // add commands to switch to other kernels
-      kernelManager.getAllKernelSpecsFor(language, kernelSpecs => {
+      kernelManager.getAllKernelSpecsForGrammar(grammar, kernelSpecs => {
         _.pull(kernelSpecs, kernel.kernelSpec);
 
         const switchCommands = kernelSpecs.map(kernelSpec => ({

--- a/lib/store/index.js
+++ b/lib/store/index.js
@@ -2,12 +2,10 @@
 
 import { CompositeDisposable } from "atom";
 import { observable, computed, action } from "mobx";
-import {
-  grammarToLanguage,
-  isMultilanguageGrammar,
-  getEmbeddedScope
-} from "./../utils";
+import { isMultilanguageGrammar, getEmbeddedScope } from "./../utils";
 
+import Config from "./../config";
+import kernelManager from "./../kernel-manager";
 import type Kernel from "./../kernel";
 
 class Store {
@@ -17,38 +15,19 @@ class Store {
   @observable grammar: ?atom$Grammar;
 
   @computed get kernel(): ?Kernel {
-    return this.runningKernels.get(grammarToLanguage(this.grammar));
-  }
-  @computed get language(): ?string {
-    return grammarToLanguage(this.grammar);
-  }
-
-  @action setGrammar(editor: ?atom$TextEditor) {
-    if (!editor) {
-      this.grammar = null;
-      return;
-    }
-
-    const topLevelGrammar = editor.getGrammar();
-    if (!isMultilanguageGrammar(topLevelGrammar)) {
-      this.grammar = topLevelGrammar;
-    } else {
-      const embeddedScope = getEmbeddedScope(
-        editor,
-        editor.getCursorBufferPosition()
-      );
-
-      if (!embeddedScope) {
-        this.grammar = topLevelGrammar;
-      } else {
-        const scope = embeddedScope.replace(".embedded", "");
-        this.grammar = atom.grammars.grammarForScopeName(scope);
+    for (let kernelLanguage of this.runningKernels.keys().sort()) {
+      const kernel = this.runningKernels.get(kernelLanguage);
+      const kernelSpec = kernel.kernelSpec;
+      if (kernelManager.kernelSpecProvidesGrammar(kernelSpec, this.grammar)) {
+        return kernel;
       }
     }
+    return null;
   }
 
   @action newKernel(kernel: Kernel) {
-    this.runningKernels.set(kernel.language, kernel);
+    const mappedLanguage = Config.getJson("languageMappings")[kernel.language];
+    this.runningKernels.set(mappedLanguage || kernel.language, kernel);
   }
 
   @action deleteKernel(language: string) {
@@ -61,9 +40,29 @@ class Store {
     this.runningKernels = new Map();
   }
 
-  @action updateEditor(editor: ?atom$TextEditor) {
+  @action updateEditorAndGrammar(editor: ?atom$TextEditor) {
     this.editor = editor;
-    this.setGrammar(editor);
+
+    if (!this.editor) {
+      this.grammar = null;
+      return null;
+    }
+
+    let topLevelGrammar = this.editor.getGrammar();
+
+    if (isMultilanguageGrammar(topLevelGrammar)) {
+      const embeddedScope = getEmbeddedScope(
+        this.editor,
+        this.editor.getCursorBufferPosition()
+      );
+
+      if (embeddedScope) {
+        const scope = embeddedScope.replace(".embedded", "");
+        topLevelGrammar = atom.grammars.grammarForScopeName(scope);
+      }
+    }
+
+    this.grammar = topLevelGrammar;
   }
 }
 

--- a/lib/store/index.js
+++ b/lib/store/index.js
@@ -39,15 +39,18 @@ class Store {
     this.runningKernels = new Map();
   }
 
-  @action updateEditorAndGrammar(editorOrNull: ?atom$TextEditor) {
+  @action updateEditor(editor: ?atom$TextEditor) {
+    this.editor = editor;
+    this.setGrammar(editor);
+  }
+
+  @action setGrammar(editorOrNull: ?atom$TextEditor) {
     if (!editorOrNull) {
-      this.editor = null;
       this.grammar = null;
       return;
     }
 
     const editor: atom$TextEditor = editorOrNull;
-    this.editor = editor;
 
     let grammar = editor.getGrammar();
 

--- a/lib/store/index.js
+++ b/lib/store/index.js
@@ -29,8 +29,12 @@ class Store {
     this.runningKernels.set(mappedLanguage || kernel.language, kernel);
   }
 
-  @action deleteKernel(language: string) {
-    this.runningKernels.delete(language);
+  @action deleteKernel(kernel: Kernel) {
+    for (let [language, runningKernel] of this.runningKernels.entries()) {
+      if (kernel === runningKernel) {
+        this.runningKernels.delete(language);
+      }
+    }
   }
 
   @action dispose() {

--- a/lib/store/index.js
+++ b/lib/store/index.js
@@ -15,8 +15,7 @@ class Store {
   @observable grammar: ?atom$Grammar;
 
   @computed get kernel(): ?Kernel {
-    for (let kernelLanguage of this.runningKernels.keys().sort()) {
-      const kernel = this.runningKernels.get(kernelLanguage);
+    for (let kernel of this.runningKernels.values()) {
       const kernelSpec = kernel.kernelSpec;
       if (kernelManager.kernelSpecProvidesGrammar(kernelSpec, this.grammar)) {
         return kernel;
@@ -40,29 +39,31 @@ class Store {
     this.runningKernels = new Map();
   }
 
-  @action updateEditorAndGrammar(editor: ?atom$TextEditor) {
-    this.editor = editor;
-
-    if (!this.editor) {
+  @action updateEditorAndGrammar(editorOrNull: ?atom$TextEditor) {
+    if (!editorOrNull) {
+      this.editor = null;
       this.grammar = null;
-      return null;
+      return;
     }
 
-    let topLevelGrammar = this.editor.getGrammar();
+    const editor: atom$TextEditor = editorOrNull;
+    this.editor = editor;
 
-    if (isMultilanguageGrammar(topLevelGrammar)) {
+    let grammar = editor.getGrammar();
+
+    if (isMultilanguageGrammar(grammar)) {
       const embeddedScope = getEmbeddedScope(
-        this.editor,
-        this.editor.getCursorBufferPosition()
+        editor,
+        editor.getCursorBufferPosition()
       );
 
       if (embeddedScope) {
         const scope = embeddedScope.replace(".embedded", "");
-        topLevelGrammar = atom.grammars.grammarForScopeName(scope);
+        grammar = atom.grammars.grammarForScopeName(scope);
       }
     }
 
-    this.grammar = topLevelGrammar;
+    this.grammar = grammar;
   }
 }
 

--- a/lib/zmq-kernel.js
+++ b/lib/zmq-kernel.js
@@ -103,27 +103,28 @@ export default class ZMQKernel extends Kernel {
       let socketNames = ["shellSocket", "controlSocket", "ioSocket"];
 
       let waitGroup = socketNames.length;
-      let setExecutionState = this.setExecutionState.bind(this);
-      function onConnect({ socketName, socket }) {
+
+      const onConnect = ({ socketName, socket }) => {
         log("ZMQKernel: " + socketName + " connected");
         socket.unmonitor();
 
         waitGroup--;
         if (waitGroup === 0) {
           log("ZMQKernel: all main sockets connected");
-          setExecutionState("idle");
+          this.setExecutionState("idle");
           if (done) done();
         }
-      }
+      };
+
+      const monitor = (socketName, socket) => {
+        log("ZMQKernel: monitor " + socketName);
+        socket.on("connect", onConnect.bind(this, { socketName, socket }));
+        socket.monitor();
+      };
 
       monitor("shellSocket", this.shellSocket);
       monitor("controlSocket", this.controlSocket);
       monitor("ioSocket", this.ioSocket);
-      function monitor(socketName, socket) {
-        log("ZMQKernel: monitor " + socketName);
-        socket.on("connect", onConnect.bind(this, { socketName, socket }));
-        socket.monitor();
-      }
     } catch (err) {
       console.error("ZMQKernel:", err);
     }

--- a/lib/zmq-kernel.js
+++ b/lib/zmq-kernel.js
@@ -103,6 +103,7 @@ export default class ZMQKernel extends Kernel {
       let socketNames = ["shellSocket", "controlSocket", "ioSocket"];
 
       let waitGroup = socketNames.length;
+      let setExecutionState = this.setExecutionState.bind(this);
       function onConnect({ socketName, socket }) {
         log("ZMQKernel: " + socketName + " connected");
         socket.unmonitor();
@@ -110,6 +111,7 @@ export default class ZMQKernel extends Kernel {
         waitGroup--;
         if (waitGroup === 0) {
           log("ZMQKernel: all main sockets connected");
+          setExecutionState("idle");
           if (done) done();
         }
       }

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "lint-staged": "^3.4.0",
     "markdox": "^0.1.10",
     "mobx-react-devtools": "^4.2.11",
-    "prettier": "^1.1.0",
+    "prettier": "~1.2.2",
     "react-addons-test-utils": "^15.4.2",
     "react-test-renderer": "^15.5.4"
   }

--- a/spec/components/status-bar-spec.js
+++ b/spec/components/status-bar-spec.js
@@ -41,7 +41,7 @@ describe("Status Bar", () => {
 
     // with kernel
     const editor = atom.workspace.buildTextEditor();
-    store.updateEditorAndGrammar(editor);
+    store.updateEditor(editor);
     expect(store.editor).toBe(editor);
 
     const grammar = editor.getGrammar();
@@ -70,7 +70,7 @@ describe("Status Bar", () => {
     expect(component.text()).toBe("Null Kernel | starting");
 
     // doesn't update if switched to editor with same grammar
-    store.updateEditorAndGrammar(atom.workspace.buildTextEditor());
+    store.updateEditor(atom.workspace.buildTextEditor());
     expect(StatusBar.prototype.render).toHaveBeenCalledTimes(2);
 
     // update execution state

--- a/spec/store-spec.js
+++ b/spec/store-spec.js
@@ -131,7 +131,7 @@ describe("Store", () => {
     store.runningKernels.set("lang1", "foo");
     store.runningKernels.set("lang2", "bar");
     expect(store.runningKernels.size).toBe(2);
-    store.deleteKernel("lang1");
+    store.deleteKernel("foo");
     expect(store.runningKernels.size).toBe(1);
     expect(store.runningKernels.get("lang2")).toBe("bar");
   });

--- a/spec/store-spec.js
+++ b/spec/store-spec.js
@@ -28,8 +28,7 @@ describe("Store", () => {
       const grammar = editor.getGrammar();
       expect(grammar.name).toBe("Null Grammar");
       expect(store.editor).toBeNull();
-      store.updateEditorAndGrammar(editor);
-      expect(store.editor).toBe(editor);
+      store.setGrammar(editor);
       expect(store.grammar).toBe(grammar);
 
       const currentKernel = {
@@ -55,12 +54,12 @@ describe("Store", () => {
     });
 
     it("should set grammar to null if editor is null", () => {
-      store.updateEditorAndGrammar(null);
+      store.setGrammar(null);
       expect(store.grammar).toBeNull();
     });
 
     it("should set grammar to null if editor is undefined", () => {
-      store.updateEditorAndGrammar(undefined);
+      store.setGrammar(undefined);
       expect(store.grammar).toBeNull();
     });
 
@@ -68,7 +67,7 @@ describe("Store", () => {
       const grammar = { scopeName: "source.python", name: "Python" };
       const editor = { getGrammar: () => grammar };
 
-      store.updateEditorAndGrammar(editor);
+      store.setGrammar(editor);
       expect(store.grammar).toEqual(grammar);
       expect(store.grammar.name.toLowerCase()).toBe("python");
     });
@@ -95,7 +94,7 @@ describe("Store", () => {
         pythonGrammar
       );
 
-      store.updateEditorAndGrammar(editor);
+      store.setGrammar(editor);
       expect(store.grammar).toEqual(pythonGrammar);
       expect(store.grammar.name.toLowerCase()).toBe("python");
     });
@@ -112,7 +111,7 @@ describe("Store", () => {
         }
       };
 
-      store.updateEditorAndGrammar(editor);
+      store.setGrammar(editor);
       expect(store.grammar).toEqual(grammar);
       expect(store.grammar.name.toLowerCase()).toBe("github markdown");
     });
@@ -138,12 +137,12 @@ describe("Store", () => {
   });
 
   it("should update editor", () => {
-    spyOn(store, "updateEditorAndGrammar").and.callThrough();
+    spyOn(store, "setGrammar").and.callThrough();
     expect(store.editor).toBeNull();
     const editor = atom.workspace.buildTextEditor();
-    store.updateEditorAndGrammar(editor);
+    store.updateEditor(editor);
     expect(store.editor).toBe(editor);
-    expect(store.updateEditorAndGrammar).toHaveBeenCalledWith(editor);
+    expect(store.setGrammar).toHaveBeenCalledWith(editor);
     expect(store.grammar).toBe(editor.getGrammar());
     expect(store.grammar.name.toLowerCase()).toBe("null grammar");
   });


### PR DESCRIPTION
This PR fixes several issues triggered when multiple kernels for the same language are available.

1. **Issue with `languageMappings`**: in a system with two kernels (one for `javascript` and another for `babel`) and `languageMappings` set to `{"babel": "javascript"}`, the kernel picker should show both kernels.

2. **Issue with multilanguage files**: in a system with four kernels (`jp-babel`, `ijavascript`, `ipython2` and `ipython3`) and in a multilanguage file (with javascript and python code), the list of kernels shown in the menu picker should be updated according to the scope grammar.

This PR also fixes a minor issue with the status bar (it ensures the status bar is set to `idle` once all the main sockets have been connected).

I've split this PR so that each commit can be reviewed on its own.
