### PR TITLE
Use the busy-signal service

### DIFF
--- a/lib/components/status-bar.js
+++ b/lib/components/status-bar.js
@@ -9,9 +9,7 @@ type Props = { store: { kernel: ?Kernel }, onClick: Function };
 
 const StatusBar = observer(({ store: { kernel }, onClick }: Props) => {
   if (!kernel) return null;
-  return (
-    <a onClick={onClick}>{kernel.displayName} | {kernel.executionState}</a>
-  );
+  return <a onClick={onClick}>{kernel.displayName}</a>;
 });
 
 export default StatusBar;

--- a/lib/main.js
+++ b/lib/main.js
@@ -5,6 +5,7 @@ import { Emitter, CompositeDisposable } from "atom";
 import _ from "lodash";
 import { autorun } from "mobx";
 import React from "react";
+import { install as installPackageDeps } from "atom-package-deps";
 
 import ResultView from "./result-view";
 import SignalListView from "./signal-list-view";
@@ -42,6 +43,7 @@ const Hydrogen = {
   watchSidebarIsVisible: false,
 
   activate() {
+    installPackageDeps("Hydrogen");
     this.emitter = new Emitter();
     this.inspector = new Inspector();
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -165,6 +165,10 @@ const Hydrogen = {
     return this.hydrogenProvider;
   },
 
+  consumeBusySignal(registry) {
+    store.setBusySignalRegistry(registry);
+  },
+
   consumeStatusBar(statusBar: atom$StatusBar) {
     const statusBarElement = document.createElement("div");
     statusBarElement.className = "inline-block";

--- a/lib/store/index.js
+++ b/lib/store/index.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import { CompositeDisposable } from "atom";
-import { observable, computed, action } from "mobx";
+import { observable, computed, action, reaction } from "mobx";
 import { isMultilanguageGrammar, getEmbeddedScope } from "./../utils";
 
 import Config from "./../config";
@@ -13,6 +13,7 @@ class Store {
   @observable runningKernels = new Map();
   @observable editor = atom.workspace.getActiveTextEditor();
   @observable grammar: ?atom$Grammar;
+  @observable busySignalRegistry = null;
 
   @computed get kernel(): ?Kernel {
     for (let kernel of this.runningKernels.values()) {
@@ -26,6 +27,7 @@ class Store {
 
   @action newKernel(kernel: Kernel) {
     const mappedLanguage = Config.getJson("languageMappings")[kernel.language];
+    this._registerBusySignal(kernel);
     this.runningKernels.set(mappedLanguage || kernel.language, kernel);
   }
 
@@ -69,6 +71,27 @@ class Store {
     }
 
     this.grammar = grammar;
+  }
+
+  @action setBusySignalRegistry(registry) {
+    this.busySignalRegistry = registry;
+    this.runningKernels.forEach(this._registerBusySignal);
+  }
+
+  _registerBusySignal(kernel: Kernel) {
+    if (this.busySignalRegistry) {
+      const busySignalProvider = this.busySignalRegistry.create();
+      reaction(
+        () => kernel.executionState,
+        state => {
+          busySignalProvider.clear();
+          if (state != "idle") {
+            const message = kernel.displayName + " is " + state;
+            busySignalProvider.add(message);
+          }
+        }
+      );
+    }
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@nteract/transform-plotly": "1.1.0",
     "@nteract/transforms": "^1.0.7",
     "atom-space-pen-views": "^2.0.5",
+    "atom-package-deps": "^4.6.0",
     "escape-string-regexp": "^1.0.5",
     "immutable": "^3.8.1",
     "jmp": "^0.7.5",
@@ -71,6 +72,9 @@
     "ws": "^2.0.0",
     "xmlhttprequest": "^1.8.0"
   },
+  "package-deps": [
+    "busy-signal"
+  ],
   "consumedServices": {
     "status-bar": {
       "versions": {

--- a/package.json
+++ b/package.json
@@ -76,6 +76,11 @@
       "versions": {
         "^1.0.0": "consumeStatusBar"
       }
+    },
+    "busy-signal": {
+      "versions": {
+        "^1.0.0": "consumeBusySignal"
+      }
     }
   },
   "providedServices": {


### PR DESCRIPTION
This PR migrates the status bar indicator from a custom component to the [busy-signal](https://github.com/steelbrain/busy-signal) service, a part of the [linter](https://github.com/steelbrain/linter) family of packages.

Since linter is one of the most installed packages in Atom, it makes most sense to converge around their busy-signal service. Most Atom user will already have it installed. This also helps declutter the status bar.

Here's a screenshot:
<img width="260" alt="hydrogen-busy-signal" src="https://cloud.githubusercontent.com/assets/271982/25321766/3905ce3a-287f-11e7-8265-596365dce204.png">

This PR does three things:
1. Introduces the code to use the `busy-signal` service.
2. Removes the old custom status bar component.
3. Introduces `atom-package-dep` to express the dependency on `busy-signal` and offer automatic installation.

I'm fairly inexperienced developing for Atom, so please review carefully.