### PR TITLE
Refactor kernel-picker to remove atom-space-pen-views

### DIFF
--- a/lib/kernel-manager.js
+++ b/lib/kernel-manager.js
@@ -161,7 +161,7 @@ class KernelManager {
         this.kernelPicker = new KernelPicker(kernelSpecs);
       }
 
-      this.kernelPicker.onConfirmed = ({ kernelSpec }) => callback(kernelSpec);
+      this.kernelPicker.onConfirmed = kernelSpec => callback(kernelSpec);
       this.kernelPicker.toggle();
     });
   }

--- a/lib/kernel-picker.js
+++ b/lib/kernel-picker.js
@@ -5,7 +5,7 @@ import _ from "lodash";
 
 import { log } from "./utils";
 
-export default class SignalListView {
+export default class KernelPicker {
   constructor(kernelSpecs) {
     this.kernelSpecs = kernelSpecs;
     this.onConfirmed = null;
@@ -25,7 +25,7 @@ export default class SignalListView {
         this.cancel();
       },
       didCancelSelection: () => this.cancel(),
-      emptyMessage: "No running kernels found."
+      emptyMessage: "No kernels found"
     });
   }
 

--- a/lib/kernel-picker.js
+++ b/lib/kernel-picker.js
@@ -1,70 +1,64 @@
 "use babel";
 
-import { SelectListView } from "atom-space-pen-views";
+import SelectListView from "atom-select-list";
 import _ from "lodash";
 
 import { log } from "./utils";
 
-// View to display a list of grammars to apply to the current editor.
-export default class SignalListView extends SelectListView {
-  initialize(kernelSpecs) {
+export default class SignalListView {
+  constructor(kernelSpecs) {
     this.kernelSpecs = kernelSpecs;
-    super.initialize(...arguments);
-
     this.onConfirmed = null;
-    this.list.addClass("mark-active");
-  }
 
-  getFilterKey() {
-    return "name";
+    this.selectListView = new SelectListView({
+      itemsClassList: ["mark-active"],
+      items: [],
+      filterKeyForItem: item => item.display_name,
+      elementForItem: item => {
+        const element = document.createElement("li");
+        element.textContent = item.display_name;
+        return element;
+      },
+      didConfirmSelection: item => {
+        log("Selected kernel:", item);
+        if (this.onConfirmed) this.onConfirmed(item);
+        this.cancel();
+      },
+      didCancelSelection: () => this.cancel(),
+      emptyMessage: "No running kernels found."
+    });
   }
 
   destroy() {
     this.cancel();
+    return this.selectListView.destroy();
   }
 
-  viewForItem(item) {
-    const element = document.createElement("li");
-    element.textContent = item.name;
-    return element;
-  }
-
-  cancelled() {
-    if (this.panel) this.panel.destroy();
+  cancel() {
+    if (this.panel != null) {
+      this.panel.destroy();
+    }
     this.panel = null;
     this.editor = null;
-  }
-
-  confirmed(item) {
-    log("Selected command:", item);
-    if (this.onConfirmed) this.onConfirmed(item);
-    this.cancel();
+    if (this.previouslyFocusedElement) {
+      this.previouslyFocusedElement.focus();
+      this.previouslyFocusedElement = null;
+    }
   }
 
   attach() {
-    this.storeFocusedElement();
-    if (!this.panel) {
-      this.panel = atom.workspace.addModalPanel({ item: this });
-    }
-    this.focusFilterEditor();
-
-    this.languageOptions = _.map(this.kernelSpecs, spec => ({
-      name: spec.display_name,
-      kernelSpec: spec
-    }));
-
-    this.setItems(this.languageOptions);
+    this.previouslyFocusedElement = document.activeElement;
+    if (this.panel == null)
+      this.panel = atom.workspace.addModalPanel({ item: this.selectListView });
+    this.selectListView.focus();
+    this.selectListView.reset();
   }
 
-  getEmptyMessage() {
-    return "No running kernels found.";
-  }
-
-  toggle() {
-    if (this.panel) {
+  async toggle() {
+    if (this.panel != null) {
       this.cancel();
-    } else if (atom.workspace.getActiveTextEditor()) {
-      this.editor = atom.workspace.getActiveTextEditor();
+    } else {
+      await this.selectListView.update({ items: this.kernelSpecs });
       this.attach();
     }
   }

--- a/lib/main.js
+++ b/lib/main.js
@@ -469,9 +469,7 @@ const Hydrogen = {
       } else {
         this.kernelPicker = new KernelPicker(kernelSpecs);
 
-        this.kernelPicker.onConfirmed = ({
-          kernelSpec
-        }: { kernelSpec: Kernelspec }) =>
+        this.kernelPicker.onConfirmed = (kernelSpec: Kernelspec) =>
           this.handleKernelCommand({
             command: "switch-kernel",
             payload: kernelSpec


### PR DESCRIPTION
This pr is heavily influenced by [this example.](https://github.com/atom/grammar-selector/blob/master/lib/grammar-list-view.js)

I haven't found any bugs yet, but this probably needs a little testing.