### PR TITLE
Make kernel start in project dir root default and add setting

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -42,7 +42,10 @@ const Config = {
           value: "projectDirOfFile",
           description: "The project directory relative to the file"
         },
-        { value: "dirOfFile", description: "Current directory of the file" }
+        {
+          value: "dirOfFile",
+          description: "Current directory of the file"
+        }
       ],
       default: "firstProjectDir"
     },

--- a/lib/config.js
+++ b/lib/config.js
@@ -28,12 +28,23 @@ const Config = {
       type: "boolean",
       default: false
     },
-    startInProjectRootDir: {
-      title: "Start kernel in project root directory",
+    startDir: {
+      title: "Directory to start kernel in",
       includeTitle: false,
-      description: "If enabled, the kernel is started in the project's root directory (default). If disabled, it is started in the current file's directory. Restart Atom for changes to take effect.",
-      type: "boolean",
-      default: true
+      description: "Restart the kernel for changes to take effect.",
+      type: "string",
+      enum: [
+        {
+          value: "firstProjectDir",
+          description: "The first started project's directory (default)"
+        },
+        {
+          value: "projectDirOfFile",
+          description: "The project directory relative to the file"
+        },
+        { value: "dirOfFile", description: "Current directory of the file" }
+      ],
+      default: "firstProjectDir"
     },
     kernelNotifications: {
       title: "Enable Kernel Notifications",

--- a/lib/config.js
+++ b/lib/config.js
@@ -28,6 +28,13 @@ const Config = {
       type: "boolean",
       default: false
     },
+    startInProjectRootDir: {
+      title: "Start kernel in project root directory",
+      includeTitle: false,
+      description: "If enabled, the kernel is started in the project's root directory (default). If disabled, it is started in the current file's directory. Restart Atom for changes to take effect.",
+      type: "boolean",
+      default: true
+    },
     kernelNotifications: {
       title: "Enable Kernel Notifications",
       includeTitle: false,

--- a/lib/kernel-manager.js
+++ b/lib/kernel-manager.js
@@ -86,11 +86,18 @@ class KernelManager {
 
   startKernel(kernelSpec, grammar, onStarted) {
     const displayName = kernelSpec.display_name;
+    let kernelStartDir;
 
     log("KernelManager: startKernel:", displayName);
 
+    if (atom.config.get("Hydrogen.startInProjectRootDir")) {
+      kernelStartDir = atom.project.getPaths()[0];
+    } else {
+      kernelStartDir = getEditorDirectory(store.editor);
+    }
+
     launchSpec(kernelSpec, {
-      cwd: getEditorDirectory(store.editor)
+      cwd: kernelStartDir
     }).then(({ config, connectionFile, spawn }) => {
       const kernel = new ZMQKernel(
         kernelSpec,

--- a/lib/kernel-manager.js
+++ b/lib/kernel-manager.js
@@ -88,20 +88,23 @@ class KernelManager {
     const displayName = kernelSpec.display_name;
     let kernelStartDir;
     let currentPath = getEditorDirectory(store.editor);
+    let projectPath;
 
     log("KernelManager: startKernel:", displayName);
 
     switch (atom.config.get("Hydrogen.startDir")) {
       case "firstProjectDir":
-        if (atom.project.getPaths().length > 0) {
-          kernelStartDir = atom.project.getPaths()[0];
-          break;
-        }
-      case "projectDirOfFile":
-        kernelStartDir = atom.project.relativizePath(currentPath)[0];
+        projectPath = atom.project.getPaths()[0];
         break;
-      default:
-        kernelStartDir = currentPath;
+      case "projectDirOfFile":
+        projectPath = atom.project.relativizePath(currentPath)[0];
+        break;
+    }
+
+    if (projectPath != null) {
+      kernelStartDir = projectPath;
+    } else {
+      kernelStartDir = currentPath;
     }
 
     launchSpec(kernelSpec, {

--- a/lib/kernel-manager.js
+++ b/lib/kernel-manager.js
@@ -87,13 +87,21 @@ class KernelManager {
   startKernel(kernelSpec, grammar, onStarted) {
     const displayName = kernelSpec.display_name;
     let kernelStartDir;
+    let currentPath = getEditorDirectory(store.editor);
 
     log("KernelManager: startKernel:", displayName);
 
-    if (atom.config.get("Hydrogen.startInProjectRootDir")) {
-      kernelStartDir = atom.project.getPaths()[0];
-    } else {
-      kernelStartDir = getEditorDirectory(store.editor);
+    switch (atom.config.get("Hydrogen.startDir")) {
+      case "firstProjectDir":
+        if (atom.project.getPaths().length > 0) {
+          kernelStartDir = atom.project.getPaths()[0];
+          break;
+        }
+      case "projectDirOfFile":
+        kernelStartDir = atom.project.relativizePath(currentPath)[0];
+        break;
+      default:
+        kernelStartDir = currentPath;
     }
 
     launchSpec(kernelSpec, {


### PR DESCRIPTION
xref [#523](https://github.com/nteract/hydrogen/issues/523#issuecomment-300893935)

* Makes project directory root the default kernel start directory
* Adds setting (`startInProjectRootDir`) to control this behaviour with the possibility to revert to previous behaviour (start kernel in same dir as file current file)