### PR TITLE
Fix CI: Switch to trusty dist for to fix Atom 1.18 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+language: generic
+dist: trusty
 sudo: false
 notifications:
   email:
@@ -10,4 +12,5 @@ script:
 
 env:
   matrix:
-    - ATOM_CHANNEL=beta  
+    - ATOM_CHANNEL=stable
+    - ATOM_CHANNEL=beta


### PR DESCRIPTION
This also adds `ATOM_CHANNEL=stable` to our build matrix.