### PR TITLE
Max-height 100% for media in output

### DIFF
--- a/styles/hydrogen.less
+++ b/styles/hydrogen.less
@@ -35,6 +35,7 @@ img {
 
 img, svg, video, audio {
   display: block;
+  max-height: 100%;
 }
 
 td, th {


### PR DESCRIPTION
Currently, when plotting using e.g. the R-kernel images needs to be scrolled to view full output, this adds `max-height: 100%`

<img width="50%" alt="before" src="https://cloud.githubusercontent.com/assets/5368302/26275930/63eb80d4-3d6c-11e7-9242-ea80261a476a.png" align="left">
<img width="40%" alt="after" src="https://cloud.githubusercontent.com/assets/5368302/26275931/6747dd5e-3d6c-11e7-8c3d-8042d30d36b3.png">


