### PR TITLE
Set icon height to 100%

### DIFF
--- a/styles/hydrogen.less
+++ b/styles/hydrogen.less
@@ -84,6 +84,7 @@ svg:first-child {
   width: 1.2em;
   margin: 0;
   text-align: center;
+  height: 100%;
 }
 
 // ---------- Multiline Output ------------


### PR DESCRIPTION
Fixes #808 

Default icon height is 16px which causes problems with smaller font sizes.