### PR TITLE
Add External output area

### DIFF
--- a/lib/components/output-area.js
+++ b/lib/components/output-area.js
@@ -18,11 +18,11 @@ const OututArea = observer(({ store: { kernel } }: { store: store }) => {
     <div>
       {kernel.outputStore.outputs.length > 0
         ? <div
-            className="btn btn-error icon icon-trashcan"
+            className="btn icon icon-trashcan"
             onClick={kernel.outputStore.clear}
             style={{
-              left: "50%",
-              transform: "translate(-50%, 0)",
+              left: "100%",
+              transform: "translateX(-100%)",
               position: "relative"
             }}
           >

--- a/lib/components/output-area.js
+++ b/lib/components/output-area.js
@@ -1,0 +1,37 @@
+/* @flow */
+
+import { CompositeDisposable } from "atom";
+import React from "react";
+import { observer } from "mobx-react";
+
+import History from "./result-view/history";
+import { OUTPUT_AREA_URI } from "./../utils";
+
+import typeof store from "../store";
+
+const OututArea = observer(({ store: { kernel } }: { store: store }) => {
+  if (!kernel) {
+    atom.workspace.hide(OUTPUT_AREA_URI);
+    return null;
+  }
+  return (
+    <div>
+      {kernel.outputStore.outputs.length > 0
+        ? <div
+            className="btn btn-error icon icon-trashcan"
+            onClick={kernel.outputStore.clear}
+            style={{
+              left: "50%",
+              transform: "translate(-50%, 0)",
+              position: "relative"
+            }}
+          >
+            Clear
+          </div>
+        : null}
+      <History store={kernel.outputStore} />
+    </div>
+  );
+});
+
+export default OututArea;

--- a/lib/components/output-area.js
+++ b/lib/components/output-area.js
@@ -9,7 +9,7 @@ import { OUTPUT_AREA_URI } from "./../utils";
 
 import typeof store from "../store";
 
-const OututArea = observer(({ store: { kernel } }: { store: store }) => {
+const OutputArea = observer(({ store: { kernel } }: { store: store }) => {
   if (!kernel) {
     atom.workspace.hide(OUTPUT_AREA_URI);
     return null;
@@ -34,4 +34,4 @@ const OututArea = observer(({ store: { kernel } }: { store: store }) => {
   );
 });
 
-export default OututArea;
+export default OutputArea;

--- a/lib/components/result-view/index.js
+++ b/lib/components/result-view/index.js
@@ -18,7 +18,11 @@ export default class ResultView {
     if (this.marker) this.marker.destroy();
   };
 
-  constructor(store: OutputStore, marker: atom$Marker) {
+  constructor(
+    store: OutputStore,
+    marker: atom$Marker,
+    showResult: boolean = true
+  ) {
     this.marker = marker;
     this.element = document.createElement("div");
     this.element.classList.add("hydrogen", "marker");
@@ -26,7 +30,11 @@ export default class ResultView {
     this.disposer = new CompositeDisposable();
 
     reactFactory(
-      <ResultViewComponent store={store} destroy={this.destroy} />,
+      <ResultViewComponent
+        store={store}
+        destroy={this.destroy}
+        showResult={showResult}
+      />,
       this.element,
       null,
       this.disposer

--- a/lib/components/result-view/result-view.js
+++ b/lib/components/result-view/result-view.js
@@ -12,7 +12,7 @@ import Status from "./status";
 
 import type { IObservableValue } from "mobx";
 import type OutputStore from "./../../store/output";
-type Props = { store: OutputStore, destroy: Function };
+type Props = { store: OutputStore, destroy: Function, showResult: boolean };
 
 @observer class ResultViewComponent extends React.Component {
   props: Props;
@@ -77,7 +77,7 @@ type Props = { store: OutputStore, destroy: Function };
       marginTop: `-${position.lineHeight}px`
     };
 
-    if (outputs.length === 0) {
+    if (outputs.length === 0 || this.props.showResult === false) {
       return <Status status={status} style={inlineStyle} />;
     }
 

--- a/lib/kernel.js
+++ b/lib/kernel.js
@@ -13,6 +13,7 @@ import {
 import store from "./store";
 
 import WatchesStore from "./store/watches";
+import OutputStore from "./store/output";
 import HydrogenKernel from "./plugin-api/hydrogen-kernel";
 
 export default class Kernel {
@@ -20,6 +21,7 @@ export default class Kernel {
   @observable inspector = {
     bundle: new ImmutableMap()
   };
+  outputStore = new OutputStore();
 
   kernelSpec: Kernelspec;
   grammar: atom$Grammar;

--- a/lib/kernel.js
+++ b/lib/kernel.js
@@ -6,6 +6,7 @@ import { is, Map as ImmutableMap } from "immutable";
 
 import {
   log,
+  focus,
   msgSpecToNotebookFormat,
   msgSpecV4toV5,
   INSPECTOR_URI
@@ -56,10 +57,7 @@ export default class Kernel {
       this.inspector.bundle = bundle;
       await atom.workspace.open(INSPECTOR_URI, { searchAllPanes: true });
     }
-    if (editor) {
-      const editorPane = atom.workspace.paneForItem(editor);
-      if (editorPane) editorPane.activate();
-    }
+    focus(editor);
   }
 
   getPluginWrapper() {

--- a/lib/main.js
+++ b/lib/main.js
@@ -23,6 +23,7 @@ import StatusBar from "./components/status-bar";
 
 import InspectorPane from "./panes/inspector";
 import WatchesPane from "./panes/watches";
+import OutputPane from "./panes/output-area";
 
 import { toggleInspector } from "./commands";
 
@@ -41,7 +42,8 @@ import {
   isMultilanguageGrammar,
   renderDevTools,
   INSPECTOR_URI,
-  WATCHES_URI
+  WATCHES_URI,
+  OUTPUT_AREA_URI
 } from "./utils";
 
 import type Kernel from "./kernel";
@@ -89,6 +91,8 @@ const Hydrogen = {
         "hydrogen:run-cell": () => this.runCell(),
         "hydrogen:run-cell-and-move-down": () => this.runCell(true),
         "hydrogen:toggle-watches": () => atom.workspace.toggle(WATCHES_URI),
+        "hydrogen:toggle-output-area": () =>
+          atom.workspace.toggle(OUTPUT_AREA_URI),
         "hydrogen:select-kernel": () => this.showKernelPicker(),
         "hydrogen:connect-to-remote-kernel": () => this.showWSKernelPicker(),
         "hydrogen:add-watch": () => {
@@ -164,6 +168,8 @@ const Hydrogen = {
             return new InspectorPane(store);
           case WATCHES_URI:
             return new WatchesPane(store);
+          case OUTPUT_AREA_URI:
+            return new OutputPane(store);
         }
       })
     );
@@ -172,7 +178,11 @@ const Hydrogen = {
       // Destroy any Panes when the package is deactivated.
       new Disposable(() => {
         atom.workspace.getPaneItems().forEach(item => {
-          if (item instanceof InspectorPane || item instanceof WatchesPane) {
+          if (
+            item instanceof InspectorPane ||
+            item instanceof WatchesPane ||
+            item instanceof OutputPane
+          ) {
             item.destroy();
           }
         });
@@ -300,15 +310,20 @@ const Hydrogen = {
       kernel.watchesStore.run();
       return;
     }
+    const outputStore = atom.workspace
+      .getPaneItems()
+      .find(item => item instanceof OutputPane)
+      ? kernel.outputStore
+      : this.insertResultBubble(store.editor, row);
 
-    this.clearBubblesOnRow(row);
-    const outputStore = this.insertResultBubble(store.editor, row);
     kernel.execute(code, result => {
       outputStore.appendOutput(result);
     });
   },
 
   insertResultBubble(editor: atom$TextEditor, row: number) {
+    this.clearBubblesOnRow(row);
+
     const buffer = editor.getBuffer();
     const lineLength = buffer.lineLengthForRow(row);
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -38,6 +38,7 @@ import AutocompleteProvider from "./autocomplete-provider";
 import HydrogenProvider from "./plugin-api/hydrogen-provider";
 import {
   log,
+  focus,
   reactFactory,
   isMultilanguageGrammar,
   renderDevTools,
@@ -322,9 +323,14 @@ const Hydrogen = {
       !globalOutputStore
     );
 
-    kernel.execute(code, result => {
+    kernel.execute(code, async result => {
       outputStore.appendOutput(result);
-      if (globalOutputStore) globalOutputStore.appendOutput(result);
+      if (globalOutputStore) {
+        globalOutputStore.appendOutput(result);
+
+        await atom.workspace.open(OUTPUT_AREA_URI, { searchAllPanes: true });
+        focus(store.editor);
+      }
     });
   },
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -310,18 +310,29 @@ const Hydrogen = {
       kernel.watchesStore.run();
       return;
     }
-    const outputStore = atom.workspace
+    const globalOutputStore = atom.workspace
       .getPaneItems()
       .find(item => item instanceof OutputPane)
       ? kernel.outputStore
-      : this.insertResultBubble(store.editor, row);
+      : null;
+
+    const outputStore = this.insertResultBubble(
+      store.editor,
+      row,
+      !globalOutputStore
+    );
 
     kernel.execute(code, result => {
       outputStore.appendOutput(result);
+      if (globalOutputStore) globalOutputStore.appendOutput(result);
     });
   },
 
-  insertResultBubble(editor: atom$TextEditor, row: number) {
+  insertResultBubble(
+    editor: atom$TextEditor,
+    row: number,
+    showResult: boolean
+  ) {
     this.clearBubblesOnRow(row);
 
     const buffer = editor.getBuffer();
@@ -339,7 +350,7 @@ const Hydrogen = {
       editorWidth: editor.getEditorWidthInChars()
     });
 
-    const view = new ResultView(outputStore, marker);
+    const view = new ResultView(outputStore, marker, showResult);
     const { element } = view;
 
     editor.decorateMarker(marker, {

--- a/lib/panes/output-area.js
+++ b/lib/panes/output-area.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { CompositeDisposable } from "atom";
+import { CompositeDisposable, Disposable } from "atom";
 import ResizeObserver from "resize-observer-polyfill";
 
 import React from "react";
@@ -21,6 +21,12 @@ export default class OutputPane {
     // Or fork react-rangeslider to fix https://github.com/whoisandie/react-rangeslider/issues/62
     const resizeObserver = new ResizeObserver(this.resize);
     resizeObserver.observe(this.element);
+
+    this.disposer.add(
+      new Disposable(() => {
+        if (store.kernel) store.kernel.outputStore.clear();
+      })
+    );
 
     reactFactory(
       <OutputArea store={store} />,

--- a/lib/panes/output-area.js
+++ b/lib/panes/output-area.js
@@ -1,0 +1,49 @@
+/* @flow */
+
+import { CompositeDisposable } from "atom";
+import ResizeObserver from "resize-observer-polyfill";
+
+import React from "react";
+
+import { reactFactory, OUTPUT_AREA_URI } from "./../utils";
+import typeof store from "../store";
+import OutputArea from "./../components/output-area";
+
+export default class OutputPane {
+  element = document.createElement("div");
+  disposer = new CompositeDisposable();
+
+  constructor(store: store) {
+    this.element.classList.add("hydrogen", "watch-sidebar");
+
+    // HACK: Dispatch a window resize Event for the slider history to recompute
+    // We should use native ResizeObserver once Atom ships with a newer version of Electron
+    // Or fork react-rangeslider to fix https://github.com/whoisandie/react-rangeslider/issues/62
+    const resizeObserver = new ResizeObserver(this.resize);
+    resizeObserver.observe(this.element);
+
+    reactFactory(
+      <OutputArea store={store} />,
+      this.element,
+      null,
+      this.disposer
+    );
+  }
+
+  resize = () => {
+    window.dispatchEvent(new Event("resize"));
+  };
+
+  getTitle = () => "Hydrogen Output Area";
+
+  getURI = () => OUTPUT_AREA_URI;
+
+  getDefaultLocation = () => "right";
+
+  getAllowedLocations = () => ["left", "right", "bottom"];
+
+  destroy() {
+    this.disposer.dispose();
+    this.element.remove();
+  }
+}

--- a/lib/store/output.js
+++ b/lib/store/output.js
@@ -141,5 +141,6 @@ export default class OutputStore {
 
   @action clear = () => {
     this.outputs.clear();
+    this.index = -1;
   };
 }

--- a/lib/store/output.js
+++ b/lib/store/output.js
@@ -138,4 +138,8 @@ export default class OutputStore {
   @action decrementIndex = () => {
     this.index = this.index > 0 ? this.index - 1 : 0;
   };
+
+  @action clear = () => {
+    this.outputs.clear();
+  };
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -30,6 +30,13 @@ export function reactFactory(
   disposer.add(disposable);
 }
 
+export function focus(item: ?mixed) {
+  if (item) {
+    const editorPane = atom.workspace.paneForItem(item);
+    if (editorPane) editorPane.activate();
+  }
+}
+
 export function grammarToLanguage(grammar: ?atom$Grammar) {
   if (!grammar) return null;
   const grammarLanguage = grammar.name.toLowerCase();

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -12,6 +12,7 @@ import store from "./store";
 
 export const INSPECTOR_URI = "atom://hydrogen/inspector";
 export const WATCHES_URI = "atom://hydrogen/watch-sidebar";
+export const OUTPUT_AREA_URI = "atom://hydrogen/output-area";
 
 export function reactFactory(
   reactElement: React$Element<any>,

--- a/lib/ws-kernel.js
+++ b/lib/ws-kernel.js
@@ -53,11 +53,8 @@ export default class WSKernel extends Kernel {
     };
 
     future.onReply = (message: Message) => {
-      if (message.content.status === "error") {
-        return;
-      }
       const result = {
-        data: "ok",
+        data: message.content.status,
         stream: "status"
       };
       if (onResults) onResults(result);

--- a/lib/zmq-kernel.js
+++ b/lib/zmq-kernel.js
@@ -273,11 +273,11 @@ export default class ZMQKernel extends Kernel {
 
     const { status } = message.content;
     if (status === "error") {
-      // Drop 'status: error' shell messages, wait for IO messages instead
-      return;
-    }
-
-    if (status === "ok") {
+      callback({
+        data: "error",
+        stream: "status"
+      });
+    } else if (status === "ok") {
       const { msg_type } = message.header;
 
       if (msg_type === "execution_reply") {

--- a/styles/hydrogen.less
+++ b/styles/hydrogen.less
@@ -163,6 +163,33 @@ svg:first-child {
   0%, 40%, 100% { transform: scaleY(0.32);}
   20% { transform: scaleY(0.8); }
 }
+
+.slider {
+  @btn-size: @component-icon-size + @component-icon-padding;
+  @pad: 3px;
+  padding: @pad @btn-size + 1;
+  height: @btn-size + 2 * @pad;
+  position: relative;
+  .rangeslider {
+    position: relative;
+    width: 100%;
+    max-width: 100%;
+    .rangeslider__handle {
+      cursor: pointer;
+      display: block;
+      position: absolute;
+      width: @btn-size;
+      height: @btn-size;
+      border-radius: @component-border-radius;
+      border: 1px solid @button-border-color;
+      background: @button-background-color;
+      &:hover {
+        background: @button-background-color-hover;
+      }
+    }
+  }
+}
+
 }
 
 // -------------- Watches -----------------
@@ -180,32 +207,6 @@ svg:first-child {
       font-size: @font-size;
       min-height: 3em;
       border: 1px solid @base-border-color;
-    }
-
-    .slider {
-      @btn-size: @component-icon-size + @component-icon-padding;
-      @pad: 3px;
-      padding: @pad @btn-size + 1;
-      height: @btn-size + 2 * @pad;
-      position: relative;
-      .rangeslider {
-        position: relative;
-        width: 100%;
-        max-width: 100%;
-        .rangeslider__handle {
-          cursor: pointer;
-          display: block;
-          position: absolute;
-          width: @btn-size;
-          height: @btn-size;
-          border-radius: @component-border-radius;
-          border: 1px solid @button-border-color;
-          background: @button-background-color;
-          &:hover {
-            background: @button-background-color-hover;
-          }
-        }
-      }
     }
   }
 


### PR DESCRIPTION
This is a initial implementation of a external output display using docks:
![external](https://cloud.githubusercontent.com/assets/13285808/26563237/488115c4-44cf-11e7-8871-b97f500758b4.gif)

If the output pane is present, output is redirected to this pane, only the spinner and status icons stay in the text editor.

I don't know what the best behavior for this panel would be. We can iterate one this an collect feedback from users.

Fixes #760