### PR TITLE
Bump React dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,10 +62,10 @@
     "jmp": "^0.7.5",
     "lodash": "^4.14.0",
     "loophole": "^1.1.0",
-    "mobx": "^3.1.0",
+    "mobx": "^3.1.11",
     "mobx-react": "^4.2.1",
-    "react": "^15.4.2",
-    "react-dom": "^15.4.2",
+    "react": "^15.5.4",
+    "react-dom": "^15.5.4",
     "react-rangeslider": "^2.0.1",
     "requirejs": "^2.2.0",
     "resize-observer-polyfill": "^1.4.2",
@@ -97,7 +97,7 @@
   "devDependencies": {
     "atom-jasmine2-test-runner": "^0.7.0",
     "babel-eslint": "^7.1.0",
-    "enzyme": "^2.7.1",
+    "enzyme": "^2.8.2",
     "eslint": "^3.16.1",
     "eslint-config-prettier": "^2.0.0",
     "eslint-plugin-flowtype": "^2.30.4",
@@ -108,7 +108,6 @@
     "markdox": "^0.1.10",
     "mobx-react-devtools": "^4.2.11",
     "prettier": "~1.3.0",
-    "react-addons-test-utils": "^15.4.2",
     "react-test-renderer": "^15.5.4"
   }
 }


### PR DESCRIPTION
Bump React to bring us inline with @nteract packages and remove
deprecated `react-addons-test-utils`.