### PR TITLE
Pin atom-jasmine2-test-runner@0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     }
   },
   "devDependencies": {
-    "atom-jasmine2-test-runner": "^0.7.0",
+    "atom-jasmine2-test-runner": "0.7.0",
     "babel-eslint": "^7.1.0",
     "enzyme": "^2.8.2",
     "eslint": "^3.16.1",


### PR DESCRIPTION
`atom-jasmine2-test-runner@0.7.1` adds `pathwatcher` as a native dependency. This can lead to quite some inconvenience for some developers.