### PR TITLE
Keep ZMQKernel class if restarted

### DIFF
--- a/lib/kernel-manager.js
+++ b/lib/kernel-manager.js
@@ -120,17 +120,22 @@ class KernelManager {
     }
 
     const kernelStartDir = projectPath != null ? projectPath : currentPath;
-
-    launchSpec(kernelSpec, {
+    const options = {
       cwd: kernelStartDir,
       stdio: ["ignore", "pipe", "pipe"]
-    }).then(({ config, connectionFile, spawn }) => {
+    };
+
+    launchSpec(
+      kernelSpec,
+      options
+    ).then(({ config, connectionFile, spawn }) => {
       const kernel = new ZMQKernel(
         kernelSpec,
         grammar,
         config,
         connectionFile,
-        spawn
+        spawn,
+        options
       );
 
       kernel.connect(() => {

--- a/lib/main.js
+++ b/lib/main.js
@@ -281,7 +281,6 @@ const Hydrogen = {
     if (command === "interrupt-kernel") {
       kernel.interrupt();
     } else if (command === "restart-kernel") {
-      this.clearResultBubbles();
       kernel.restart();
     } else if (command === "shutdown-kernel") {
       this.clearResultBubbles();

--- a/lib/ws-kernel.js
+++ b/lib/ws-kernel.js
@@ -123,6 +123,6 @@ export default class WSKernel extends Kernel {
   destroy() {
     log("WSKernel: destroying jupyter-js-services Session");
     this.session.dispose();
-    super.destroy(...arguments);
+    super.destroy();
   }
 }

--- a/lib/zmq-kernel.js
+++ b/lib/zmq-kernel.js
@@ -3,10 +3,10 @@
 import fs from "fs";
 import { Message, Socket } from "jmp";
 import v4 from "uuid/v4";
+import { launchSpecFromConnectionInfo } from "spawnteract";
 
 import Kernel from "./kernel";
 import InputView from "./input-view";
-import kernelManager from "./kernel-manager";
 import { log } from "./utils";
 
 export type Connection = {
@@ -27,6 +27,7 @@ export default class ZMQKernel extends Kernel {
   connection: Connection;
   connectionFile: string;
   kernelProcess: child_process$ChildProcess;
+  options: Object;
 
   shellSocket: Socket;
   controlSocket: Socket;
@@ -38,11 +39,13 @@ export default class ZMQKernel extends Kernel {
     grammar: atom$Grammar,
     connection: Connection,
     connectionFile: string,
-    kernelProcess: ?child_process$ChildProcess
+    kernelProcess: ?child_process$ChildProcess,
+    options: ?Object
   ) {
     super(kernelSpec, grammar);
     this.connection = connection;
     this.connectionFile = connectionFile;
+    this.options = options || {};
 
     if (kernelProcess) {
       this.kernelProcess = kernelProcess;
@@ -165,8 +168,14 @@ export default class ZMQKernel extends Kernel {
 
   restart(onRestarted: ?Function) {
     if (this.kernelProcess) {
-      this.destroy(true);
-      kernelManager.startKernel(this.kernelSpec, this.grammar, onRestarted);
+      this.shutdown(true);
+      const { spawn } = launchSpecFromConnectionInfo(
+        this.kernelSpec,
+        this.connection,
+        this.connectionFile,
+        this.options
+      );
+      this.kernelProcess = spawn;
       return;
     }
 
@@ -411,10 +420,10 @@ export default class ZMQKernel extends Kernel {
     return true;
   }
 
-  destroy(restart: ?boolean = false) {
+  destroy() {
     log("ZMQKernel: destroy:", this);
 
-    this.shutdown(restart);
+    this.shutdown();
 
     if (this.kernelProcess) {
       this._kill();
@@ -426,7 +435,7 @@ export default class ZMQKernel extends Kernel {
     this.ioSocket.close();
     this.stdinSocket.close();
 
-    super.destroy(...arguments);
+    super.destroy();
   }
 
   _getUsername() {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "react-dom": "^15.5.4",
     "react-rangeslider": "^2.1.0",
     "requirejs": "^2.2.0",
-    "spawnteract": "^3.0.0",
+    "spawnteract": "^3.1.0",
     "tildify": "^1.2.0",
     "uuid": "^3.0.1",
     "ws": "^2.0.0",


### PR DESCRIPTION
This makes restarting a lot smother (and a bit faster):
- only spawn a new kernel process and keep the ZMQ sockets open
- don't clear the result bubbles on restart.

![restart](https://cloud.githubusercontent.com/assets/13285808/26767152/6d0847a0-499d-11e7-9225-9ac45d30a3a4.gif)

Fixes #849 
/cc @wowserx