### PR TITLE
Add deprecation note for connecting to existing zmq kernels

### DIFF
--- a/lib/kernel-manager.js
+++ b/lib/kernel-manager.js
@@ -11,7 +11,7 @@ import ZMQKernel from "./zmq-kernel";
 
 import KernelPicker from "./kernel-picker";
 import store from "./store";
-import { getEditorDirectory, log } from "./utils";
+import { getEditorDirectory, log, deprecationNote } from "./utils";
 
 import type { Connection } from "./zmq-kernel";
 
@@ -66,6 +66,7 @@ class KernelManager {
     connectionFile: string,
     onStarted: (kernel: ZMQKernel) => void
   ) {
+    deprecationNote();
     const language = grammar.name;
 
     log("KernelManager: startExistingKernel: Assuming", language);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,6 +6,8 @@ import ReactDOM from "react-dom";
 import _ from "lodash";
 import os from "os";
 import path from "path";
+// $FlowFixMe
+import { shell } from "electron";
 
 import Config from "./config";
 import store from "./store";
@@ -133,4 +135,30 @@ export function renderDevTools() {
       log("Could not enable dev tools", e);
     }
   }
+}
+
+export function deprecationNote() {
+  atom.notifications.addWarning("This feature will be deprecated soon!", {
+    description:
+      "Connecting to existing kernels via a `connection.json` file will be deprecated soon.\n\nFor some time now Hydrogen supports using [kernel gateways](https://nteract.gitbooks.io/hydrogen/docs/Usage/RemoteKernelConnection.html) for connection to existing kernels. Using that option is a lot simpler while being powerful.\n\nPlease get in touch with us if using remote kernels isn't a option for you.",
+    dismissable: true,
+    buttons: [
+      {
+        className: "icon icon-x",
+        text: "I really need this feature",
+        onDidClick: () => {
+          shell.openExternal("https://github.com/nteract/hydrogen/issues/new");
+        }
+      },
+      {
+        className: "icon icon-check",
+        text: "I'll try remote kernels",
+        onDidClick: () => {
+          shell.openExternal(
+            "https://nteract.gitbooks.io/hydrogen/docs/Usage/RemoteKernelConnection.html"
+          );
+        }
+      }
+    ]
+  });
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -140,14 +140,14 @@ export function renderDevTools() {
 export function deprecationNote() {
   atom.notifications.addWarning("This feature will be deprecated soon!", {
     description:
-      "Connecting to existing kernels via a `connection.json` file will be deprecated soon.\n\nFor some time now Hydrogen supports using [kernel gateways](https://nteract.gitbooks.io/hydrogen/docs/Usage/RemoteKernelConnection.html) for connection to existing kernels. Using that option is a lot simpler while being powerful.\n\nPlease get in touch with us if using remote kernels isn't a option for you.",
+      "Connecting to existing kernels via a `connection.json` file will be deprecated soon.\n\nFor some time now Hydrogen supports using [kernel gateways](https://nteract.gitbooks.io/hydrogen/docs/Usage/RemoteKernelConnection.html) for connection to existing kernels. Using that option is a lot simpler yet very powerful.\n\nPlease get in touch with us if using remote kernels isn't a option for you.",
     dismissable: true,
     buttons: [
       {
         className: "icon icon-x",
         text: "I really need this feature",
         onDidClick: () => {
-          shell.openExternal("https://github.com/nteract/hydrogen/issues/new");
+          shell.openExternal("https://github.com/nteract/hydrogen/issues/858");
         }
       },
       {


### PR DESCRIPTION
We've deprecated connecting to existing ZMQ kernels via a `connection.json` file via the docs in favor of remote kernels for some time now. I think using remote kernels is superior in any way.

This will add a deprecation note if the feature is used so we can get feedback if there are use-cases we haven't thought about:
![bildschirmfoto 2017-06-05 um 19 20 13](https://cloud.githubusercontent.com/assets/13285808/26795688/d71f7ae4-4a26-11e7-8daf-df5a4b8a09ab.png)

Removing this feature will allow us to simplify our kernel handling a lot. In particular this part of the code base made quite some trouble when trying to properly type it in #832.