### PR TITLE
ZMQ kernel should call restart-callback on light-restart

### DIFF
--- a/lib/zmq-kernel.js
+++ b/lib/zmq-kernel.js
@@ -176,6 +176,7 @@ export default class ZMQKernel extends Kernel {
         this.options
       );
       this.kernelProcess = spawn;
+      if (onRestarted) onRestarted(this);
       return;
     }
 


### PR DESCRIPTION
By #853, restart callback become just ignored on lightweight-restart.
This PR gives it back, means call callback on light-restart again.