### PR TITLE
Hide expand button

### DIFF
--- a/lib/components/result-view/result-view.js
+++ b/lib/components/result-view/result-view.js
@@ -6,7 +6,7 @@ import * as Immutable from "immutable";
 import { observer } from "mobx-react";
 import { action, observable } from "mobx";
 import { Display } from "@nteract/display-area";
-
+import { DEFAULT_SCROLL_HEIGHT } from "@nteract/display-area";
 import { transforms, displayOrder } from "./transforms";
 import Status from "./status";
 
@@ -14,8 +14,7 @@ import type { IObservableValue } from "mobx";
 import type OutputStore from "./../../store/output";
 type Props = { store: OutputStore, destroy: Function, showResult: boolean };
 
-@observer
-class ResultViewComponent extends React.Component {
+@observer class ResultViewComponent extends React.Component {
   props: Props;
   el: ?HTMLElement;
   containerTooltip = new CompositeDisposable();
@@ -131,12 +130,12 @@ class ResultViewComponent extends React.Component {
                 className="icon icon-file-symlink-file"
                 onClick={this.openInEditor}
               />
-              <div
-                className={`icon icon-${this.expanded.get()
-                  ? "fold"
-                  : "unfold"}`}
-                onClick={this.toggleExpand}
-              />
+              {this.el.scrollHeight > this.el.clientHeight
+                ? <div
+                    className={`icon icon-${this.expanded.get() ? "fold" : "unfold"}`}
+                    onClick={this.toggleExpand}
+                  />
+                : null}
             </div>}
       </div>
     );

--- a/lib/components/result-view/result-view.js
+++ b/lib/components/result-view/result-view.js
@@ -5,8 +5,7 @@ import React from "react";
 import * as Immutable from "immutable";
 import { observer } from "mobx-react";
 import { action, observable } from "mobx";
-import { Display } from "@nteract/display-area";
-import { DEFAULT_SCROLL_HEIGHT } from "@nteract/display-area";
+import Display, { DEFAULT_SCROLL_HEIGHT } from "@nteract/display-area/lib/display";
 import { transforms, displayOrder } from "./transforms";
 import Status from "./status";
 
@@ -14,7 +13,8 @@ import type { IObservableValue } from "mobx";
 import type OutputStore from "./../../store/output";
 type Props = { store: OutputStore, destroy: Function, showResult: boolean };
 
-@observer class ResultViewComponent extends React.Component {
+@observer
+class ResultViewComponent extends React.Component {
   props: Props;
   el: ?HTMLElement;
   containerTooltip = new CompositeDisposable();
@@ -130,9 +130,11 @@ type Props = { store: OutputStore, destroy: Function, showResult: boolean };
                 className="icon icon-file-symlink-file"
                 onClick={this.openInEditor}
               />
-              {this.el.scrollHeight > this.el.clientHeight
+              {this.el && this.el.scrollHeight > DEFAULT_SCROLL_HEIGHT
                 ? <div
-                    className={`icon icon-${this.expanded.get() ? "fold" : "unfold"}`}
+                    className={`icon icon-${this.expanded.get()
+                      ? "fold"
+                      : "unfold"}`}
                     onClick={this.toggleExpand}
                   />
                 : null}


### PR DESCRIPTION
Expand-button is now hidden if the height of the content of the resultview is smaller than the clientHeight.
#796 