### PR TITLE
Make use of all available space in external output area

### DIFF
--- a/lib/components/output-area.js
+++ b/lib/components/output-area.js
@@ -15,7 +15,7 @@ const OutputArea = observer(({ store: { kernel } }: { store: store }) => {
     return null;
   }
   return (
-    <div className="watch-sidebar">
+    <div className="sidebar output-area">
       {kernel.outputStore.outputs.length > 0
         ? <div
             className="btn icon icon-trashcan"
@@ -23,7 +23,9 @@ const OutputArea = observer(({ store: { kernel } }: { store: store }) => {
             style={{
               left: "100%",
               transform: "translateX(-100%)",
-              position: "relative"
+              position: "relative",
+              flex: "0 0 auto",
+              width: "fit-content"
             }}
           >
             Clear

--- a/lib/components/output-area.js
+++ b/lib/components/output-area.js
@@ -15,7 +15,7 @@ const OutputArea = observer(({ store: { kernel } }: { store: store }) => {
     return null;
   }
   return (
-    <div>
+    <div className="watch-sidebar">
       {kernel.outputStore.outputs.length > 0
         ? <div
             className="btn icon icon-trashcan"

--- a/lib/components/result-view/history.js
+++ b/lib/components/result-view/history.js
@@ -22,7 +22,7 @@ const counterStyle = {
 const History = observer(({ store }: { store: OutputStore }) => {
   const output = store.outputs[store.index];
   return output
-    ? <div>
+    ? <div className="history">
         <div className="slider">
           <div
             className="btn btn-xs icon icon-chevron-left"

--- a/lib/components/watch-sidebar/index.js
+++ b/lib/components/watch-sidebar/index.js
@@ -16,7 +16,7 @@ const Watches = observer(({ store: { kernel } }: { store: store }) => {
     return null;
   }
   return (
-    <div className="watch-sidebar">
+    <div className="sidebar watch-sidebar">
       {kernel.watchesStore.watches.map(watch => <Watch store={watch} />)}
       <div className="btn-group">
         <button

--- a/lib/components/watch-sidebar/index.js
+++ b/lib/components/watch-sidebar/index.js
@@ -16,7 +16,7 @@ const Watches = observer(({ store: { kernel } }: { store: store }) => {
     return null;
   }
   return (
-    <div>
+    <div className="watch-sidebar">
       {kernel.watchesStore.watches.map(watch => <Watch store={watch} />)}
       <div className="btn-group">
         <button

--- a/lib/panes/output-area.js
+++ b/lib/panes/output-area.js
@@ -13,7 +13,7 @@ export default class OutputPane {
   disposer = new CompositeDisposable();
 
   constructor(store: store) {
-    this.element.classList.add("hydrogen", "watch-sidebar");
+    this.element.classList.add("hydrogen");
 
     this.disposer.add(
       new Disposable(() => {

--- a/lib/panes/watches.js
+++ b/lib/panes/watches.js
@@ -13,7 +13,7 @@ export default class WatchesPane {
   disposer = new CompositeDisposable();
 
   constructor(store: store) {
-    this.element.classList.add("hydrogen", "watch-sidebar");
+    this.element.classList.add("hydrogen");
 
     reactFactory(<Watches store={store} />, this.element, null, this.disposer);
   }

--- a/styles/hydrogen.less
+++ b/styles/hydrogen.less
@@ -192,10 +192,51 @@ svg:first-child {
   }
 }
 
+// -------------- Sidebar -----------------
+
+.sidebar {
+  padding: 10px;
+
+  .multiline-container {
+    width: 100%;
+    overflow: auto;
+    padding: @component-padding;
+
+    // Style fix for plotly toolbar
+    .modebar-group {
+      display: flex;
+    }
+  }
+
+  video, img, svg {
+    width: unset !important;
+    height: unset !important;
+    max-width: 100% !important;
+  }
+}
+
+// ------------ Output Area ---------------
+
+.output-area {
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  .history {
+    display: flex;
+    flex-direction: column;
+  }
+  .slider {
+    flex: 0 0 auto;
+  }
+  .multiline-container {
+    flex: 0 1 auto;
+  }
+}
+
 // -------------- Watches -----------------
 
 .watch-sidebar {
-  padding: 10px;
   overflow-y: auto;
 
   .watch-view {
@@ -219,21 +260,10 @@ svg:first-child {
   }
 
   .multiline-container {
-    width: 100%;
     max-height: 450px;
-    overflow: auto;
-    padding: @component-padding;
-
-    // Style fix for plotly toolbar
-    .modebar-group {
-      display: flex;
-    }
   }
 
   video, img, svg {
-    width: unset !important;
-    height: unset !important;
-    max-width: 100% !important;
     max-height: 450px !important;
   }
 }

--- a/styles/hydrogen.less
+++ b/styles/hydrogen.less
@@ -164,6 +164,8 @@ svg:first-child {
   20% { transform: scaleY(0.8); }
 }
 
+// -------------- Slider ------------------
+
 .slider {
   @btn-size: @component-icon-size + @component-icon-padding;
   @pad: 3px;
@@ -190,11 +192,9 @@ svg:first-child {
   }
 }
 
-}
-
 // -------------- Watches -----------------
 
-.hydrogen.watch-sidebar {
+.watch-sidebar {
   padding: 10px;
   overflow-y: auto;
 
@@ -235,6 +235,7 @@ svg:first-child {
     height: unset !important;
     max-width: 100% !important;
     max-height: 450px !important;
+  }
 }
 }
 


### PR DESCRIPTION
Makes sure to use all available space instead of cropping the output window to a fixed height. 
![height_2](https://cloud.githubusercontent.com/assets/13285808/26808373/81680388-4a5c-11e7-90af-074301c72858.gif)

Fixes #833 