### PR TITLE
add refresh-all-result-bubbles command

### DIFF
--- a/docs/Usage/GettingStarted.md
+++ b/docs/Usage/GettingStarted.md
@@ -35,10 +35,13 @@ When you place the cursor inside a cell and hit **"Run Cell"**, Hydrogen will ex
 These commands will run all code inside the editor or all code above the cursor.
 
 
-## "Hydrogen: Refresh All Result Bubbles"
+## "Hydrogen: Restart Kernel And Re Evaluate Bubbles"
 
 Restart running kernel and re-evaluate all bubbles on editor.  
-It evaluate all code in editor, and each existing bubbles up-to-date state.  
+This command works in following way.
+
+1. Restart kernel to cleanup evaluation environment.
+2. Run all code and update all existing bubbles.
 
 ## Watch Expressions
 

--- a/docs/Usage/GettingStarted.md
+++ b/docs/Usage/GettingStarted.md
@@ -35,6 +35,11 @@ When you place the cursor inside a cell and hit **"Run Cell"**, Hydrogen will ex
 These commands will run all code inside the editor or all code above the cursor.
 
 
+## "Hydrogen: Refresh All Result Bubbles"
+
+Restart running kernel and re-evaluate all bubbles on editor.  
+It evaluate all code in editor, and each existing bubbles up-to-date state.  
+
 ## Watch Expressions
 
 After you've run some code with Hydrogen, you can use the **"Hydrogen: Toggle Watches"** command from the Command Palette to open the watch expression sidebar. Whatever code you write in watch expressions will be re-run after each time you send that kernel any other code.

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -231,7 +231,7 @@ export function getCells(
   editor: atom$TextEditor,
   breakpoints: Array<atom$Point> = []
 ) {
-  if (!_.isEmpty(breakpoints)) {
+  if (breakpoints.length !== 0) {
     breakpoints.sort((a, b) => a.compare(b));
   } else {
     breakpoints = getBreakpoints(editor);

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -227,8 +227,20 @@ export function getCurrentCell(editor: atom$TextEditor) {
   return getCurrentCodeCell(editor);
 }
 
-export function getCells(editor: atom$TextEditor) {
-  const breakpoints = getBreakpoints(editor);
+export function getCells(
+  editor: atom$TextEditor,
+  oldBreakpoints: ?Array<atom$Point>
+) {
+  let breakpoints = getBreakpoints(editor);
+  if (oldBreakpoints && oldBreakpoints.length > 0) {
+    breakpoints = breakpoints.concat(oldBreakpoints);
+    breakpoints.sort((a, b) => a.compare(b));
+    breakpoints = _.uniqBy(breakpoints, range => range.toString());
+  }
+  return getCellsForBreakPoints(breakpoints);
+}
+
+export function getCellsForBreakPoints(breakpoints: Array<atom$Point>) {
   let start = breakpoints.shift();
 
   return _.map(breakpoints, end => {

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -135,7 +135,7 @@ export function getRegexString(editor: atom$TextEditor) {
 
 export function getBreakpoints(editor: atom$TextEditor) {
   const buffer = editor.getBuffer();
-  const breakpoints = [new Point(0, 0)];
+  const breakpoints = [];
 
   const regexString = getRegexString(editor);
   if (regexString) {
@@ -235,14 +235,35 @@ export function getCells(
   if (oldBreakpoints && oldBreakpoints.length > 0) {
     breakpoints = breakpoints.concat(oldBreakpoints);
     breakpoints.sort((a, b) => a.compare(b));
-    breakpoints = _.uniqBy(breakpoints, range => range.toString());
+    // Ensure one breakbreakpoint per row.
+    //
+    // In following Python code we pick brakpoint [0, 6] and ignore [0, 12].
+    //
+    // e.g. python
+    // code: `a = 1 # %%`
+    // - 1st-run: detected breakpoint by finding `# %%`: [0, 6] (start of comment)
+    // - 1st-run: creat bubble which start point is [0, 12] (end of line)
+    // - 2nd-run: exising breakpoint: [0, 12] (end of line)
+    // - 2nd-run: detected breakpoint by finding `# %%`: [0, 6] (start of comment)
+    // Without eliminating [0, 12], we result in creating two cell.
+    //  cell-1: [0, 0] to [0, 6]
+    //  cell-2: [0, 6] to [0, 12] (should not created this!)
+    let seenBreakpointByRow = {};
+    breakpoints = breakpoints.filter(point => {
+      const row = point.row;
+      if (seenBreakpointByRow[row]) {
+        return false;
+      } else {
+        seenBreakpointByRow[row] = true;
+        return true;
+      }
+    });
   }
   return getCellsForBreakPoints(breakpoints);
 }
 
 export function getCellsForBreakPoints(breakpoints: Array<atom$Point>) {
-  let start = breakpoints.shift();
-
+  let start = new Point(0, 0);
   return _.map(breakpoints, end => {
     const cell = new Range(start, end);
     start = new Point(end.row + 1, 0);

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -229,35 +229,12 @@ export function getCurrentCell(editor: atom$TextEditor) {
 
 export function getCells(
   editor: atom$TextEditor,
-  oldBreakpoints: ?Array<atom$Point>
+  breakpoints: Array<atom$Point> = []
 ) {
-  let breakpoints = getBreakpoints(editor);
-  if (oldBreakpoints && oldBreakpoints.length > 0) {
-    breakpoints = breakpoints.concat(oldBreakpoints);
+  if (!_.isEmpty(breakpoints)) {
     breakpoints.sort((a, b) => a.compare(b));
-    // Ensure one breakbreakpoint per row.
-    //
-    // In following Python code we pick brakpoint [0, 6] and ignore [0, 12].
-    //
-    // e.g. python
-    // code: `a = 1 # %%`
-    // - 1st-run: detected breakpoint by finding `# %%`: [0, 6] (start of comment)
-    // - 1st-run: creat bubble which start point is [0, 12] (end of line)
-    // - 2nd-run: exising breakpoint: [0, 12] (end of line)
-    // - 2nd-run: detected breakpoint by finding `# %%`: [0, 6] (start of comment)
-    // Without eliminating [0, 12], we result in creating two cell.
-    //  cell-1: [0, 0] to [0, 6]
-    //  cell-2: [0, 6] to [0, 12] (should not created this!)
-    let seenBreakpointByRow = {};
-    breakpoints = breakpoints.filter(point => {
-      const row = point.row;
-      if (seenBreakpointByRow[row]) {
-        return false;
-      } else {
-        seenBreakpointByRow[row] = true;
-        return true;
-      }
-    });
+  } else {
+    breakpoints = getBreakpoints(editor);
   }
   return getCellsForBreakPoints(breakpoints);
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -115,6 +115,8 @@ const Hydrogen = {
           this.handleKernelCommand({ command: "interrupt-kernel" }),
         "hydrogen:restart-kernel": () =>
           this.handleKernelCommand({ command: "restart-kernel" }),
+        "hydrogen:refresh-all-result-bubbles": () =>
+          this.refreshAllResultBubbles(),
         "hydrogen:shutdown-kernel": () =>
           this.handleKernelCommand({ command: "shutdown-kernel" })
       })
@@ -250,10 +252,12 @@ const Hydrogen = {
 
   handleKernelCommand({
     command,
-    payload
+    payload,
+    onRestarted
   }: {
     command: string,
-    payload: ?Kernelspec
+    payload: ?Kernelspec,
+    onRestarted: ?Function
   }) {
     log("handleKernelCommand:", arguments);
 
@@ -281,7 +285,7 @@ const Hydrogen = {
     if (command === "interrupt-kernel") {
       kernel.interrupt();
     } else if (command === "restart-kernel") {
-      kernel.restart();
+      kernel.restart(onRestarted);
     } else if (command === "shutdown-kernel") {
       this.clearResultBubbles();
       // Note that destroy alone does not shut down a WSKernel
@@ -388,6 +392,19 @@ const Hydrogen = {
     this.markerBubbleMap = {};
   },
 
+  refreshAllResultBubbles() {
+    let breakpoints = [];
+    _.forEach(this.markerBubbleMap, (bubble: ResultView) => {
+      breakpoints.push(bubble.marker.getBufferRange().start);
+    });
+    this.clearResultBubbles();
+
+    this.handleKernelCommand({
+      command: "restart-kernel",
+      onRestarted: () => this.runAll(breakpoints)
+    });
+  },
+
   clearBubblesOnRow(row: number) {
     log("clearBubblesOnRow:", row);
     _.forEach(this.markerBubbleMap, (bubble: ResultView) => {
@@ -419,7 +436,7 @@ const Hydrogen = {
     }
   },
 
-  runAll() {
+  runAll(oldBreakpoints: ?Array<atom$Point>) {
     const { editor, kernel, grammar } = store;
     if (!editor || !grammar) return;
     if (isMultilanguageGrammar(editor.getGrammar())) {
@@ -430,17 +447,21 @@ const Hydrogen = {
     }
 
     if (editor && kernel) {
-      this._runAll(editor, kernel);
+      this._runAll(editor, kernel, oldBreakpoints);
       return;
     }
 
     kernelManager.startKernelFor(grammar, editor, (kernel: ZMQKernel) => {
-      this._runAll(editor, kernel);
+      this._runAll(editor, kernel, oldBreakpoints);
     });
   },
 
-  _runAll(editor: atom$TextEditor, kernel: Kernel) {
-    const cells = codeManager.getCells(editor);
+  _runAll(
+    editor: atom$TextEditor,
+    kernel: Kernel,
+    oldBreakpoints: ?Array<atom$Point>
+  ) {
+    let cells = codeManager.getCells(editor, oldBreakpoints);
     _.forEach(
       cells,
       ({ start, end }: { start: atom$Point, end: atom$Point }) => {

--- a/lib/main.js
+++ b/lib/main.js
@@ -252,12 +252,10 @@ const Hydrogen = {
 
   handleKernelCommand({
     command,
-    payload,
-    onRestarted
+    payload
   }: {
     command: string,
-    payload: ?Kernelspec,
-    onRestarted: ?Function
+    payload: ?Kernelspec
   }) {
     log("handleKernelCommand:", arguments);
 
@@ -285,7 +283,7 @@ const Hydrogen = {
     if (command === "interrupt-kernel") {
       kernel.interrupt();
     } else if (command === "restart-kernel") {
-      kernel.restart(onRestarted);
+      kernel.restart();
     } else if (command === "shutdown-kernel") {
       this.clearResultBubbles();
       // Note that destroy alone does not shut down a WSKernel
@@ -406,10 +404,9 @@ const Hydrogen = {
     this.clearResultBubbles();
 
     const runAll = () => this.runAll(breakpoints);
-    this.handleKernelCommand({
-      command: "restart-kernel",
-      onRestarted: () => setTimeout(runAll, 500) // FIXME: see#863 need discussion.
-    });
+
+    // FIXME: temporal workaround until hydrogen#863 fixed.
+    kernel.restart(() => setTimeout(runAll, 500));
   },
 
   clearBubblesOnRow(row: number) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -115,8 +115,8 @@ const Hydrogen = {
           this.handleKernelCommand({ command: "interrupt-kernel" }),
         "hydrogen:restart-kernel": () =>
           this.handleKernelCommand({ command: "restart-kernel" }),
-        "hydrogen:refresh-all-result-bubbles": () =>
-          this.refreshAllResultBubbles(),
+        "hydrogen:restart-kernel-and-re-evaluate-bubbles": () =>
+          this.restartKernelAndReEvaluateBubbles(),
         "hydrogen:shutdown-kernel": () =>
           this.handleKernelCommand({ command: "shutdown-kernel" })
       })
@@ -390,7 +390,7 @@ const Hydrogen = {
     this.markerBubbleMap = {};
   },
 
-  refreshAllResultBubbles() {
+  restartKernelAndReEvaluateBubbles() {
     const { editor, kernel } = store;
     if (!editor || !kernel) {
       this.runAll();

--- a/lib/main.js
+++ b/lib/main.js
@@ -405,9 +405,10 @@ const Hydrogen = {
     });
     this.clearResultBubbles();
 
+    const runAll = () => this.runAll(breakpoints);
     this.handleKernelCommand({
       command: "restart-kernel",
-      onRestarted: () => this.runAll(breakpoints)
+      onRestarted: () => setTimeout(runAll, 500) // FIXME: see#863 need discussion.
     });
   },
 
@@ -442,7 +443,7 @@ const Hydrogen = {
     }
   },
 
-  runAll(oldBreakpoints: ?Array<atom$Point>) {
+  runAll(breakpoints: ?Array<atom$Point>) {
     const { editor, kernel, grammar } = store;
     if (!editor || !grammar) return;
     if (isMultilanguageGrammar(editor.getGrammar())) {
@@ -453,21 +454,21 @@ const Hydrogen = {
     }
 
     if (editor && kernel) {
-      this._runAll(editor, kernel, oldBreakpoints);
+      this._runAll(editor, kernel, breakpoints);
       return;
     }
 
     kernelManager.startKernelFor(grammar, editor, (kernel: ZMQKernel) => {
-      this._runAll(editor, kernel, oldBreakpoints);
+      this._runAll(editor, kernel, breakpoints);
     });
   },
 
   _runAll(
     editor: atom$TextEditor,
     kernel: Kernel,
-    oldBreakpoints: ?Array<atom$Point>
+    breakpoints?: Array<atom$Point>
   ) {
-    let cells = codeManager.getCells(editor, oldBreakpoints);
+    let cells = codeManager.getCells(editor, breakpoints);
     _.forEach(
       cells,
       ({ start, end }: { start: atom$Point, end: atom$Point }) => {

--- a/lib/main.js
+++ b/lib/main.js
@@ -393,6 +393,12 @@ const Hydrogen = {
   },
 
   refreshAllResultBubbles() {
+    const { editor, kernel } = store;
+    if (!editor || !kernel) {
+      this.runAll();
+      return;
+    }
+
     let breakpoints = [];
     _.forEach(this.markerBubbleMap, (bubble: ResultView) => {
       breakpoints.push(bubble.marker.getBufferRange().start);

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
       "hydrogen:run-all",
       "hydrogen:run-all-above",
       "hydrogen:run-cell",
-      "hydrogen:run-cell-and-move-down"
+      "hydrogen:run-cell-and-move-down",
+      "hydrogen:refresh-all-result-bubbles"
     ]
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
       "hydrogen:run-all-above",
       "hydrogen:run-cell",
       "hydrogen:run-cell-and-move-down",
-      "hydrogen:refresh-all-result-bubbles"
+      "hydrogen:restart-kernel-and-re-evaluate-bubbles"
     ]
   },
   "scripts": {

--- a/spec/code-manager-spec.js
+++ b/spec/code-manager-spec.js
@@ -66,12 +66,13 @@ describe("CodeManager", () => {
     const toRange = range => Range.fromObject(range);
 
     describe("getCellsForBreakPoints", () => {
-      it("return cell(range) from array of points", () => {
+      it("return cells(ranges) from array of points", () => {
         const points = [[1, 2], [3, 4], [5, 6], [10, 5]];
-        const cell1 = [[1, 2], [3, 4]];
-        const cell2 = [[4, 0], [5, 6]];
-        const cell3 = [[6, 0], [10, 5]];
-        const cellsExpected = [cell1, cell2, cell3].map(toRange);
+        const cell1 = [[0, 0], [1, 2]];
+        const cell2 = [[2, 0], [3, 4]];
+        const cell3 = [[4, 0], [5, 6]];
+        const cell4 = [[6, 0], [10, 5]];
+        const cellsExpected = [cell1, cell2, cell3, cell4].map(toRange);
         const cellsActual = CM.getCellsForBreakPoints(points.map(toPoint));
         expect(cellsActual).toEqual(cellsExpected);
       });
@@ -89,18 +90,18 @@ describe("CodeManager", () => {
       }
       beforeEach(
         waitAsync(async () => {
-          await atom.packages.activatePackage("language-javascript");
-          const jsGrammar = atom.grammars.grammarForScopeName("source.js");
-          editor.setGrammar(jsGrammar);
-          const code = "var v1 = 1; // %%\nvar v2 = 2;\nvar v2 = 3; // %%\n";
+          await atom.packages.activatePackage("language-python");
+          editor.setGrammar(atom.grammars.grammarForScopeName("source.python"));
+          const code = "v0 = 0 # %%\nv1 = 1\nv2 = 2 # %%\nv3 = 3\n";
           editor.setText(code);
         })
       );
       describe("no arg", () => {
-        it("return cell(range) by collecting breakpoints from comments in editor", () => {
-          const cell1 = [[0, 0], [0, 12]];
-          const cell2 = [[1, 0], [2, 12]];
-          const cell3 = [[3, 0], [3, 0]];
+        it("return cell(range) by collecting breakpoints from comments in comment", () => {
+          // EOF is always treated as implicit breakpoints
+          const cell1 = [[0, 0], [0, 7]];
+          const cell2 = [[1, 0], [2, 7]];
+          const cell3 = [[3, 0], [4, 0]];
           const cellsActual = CM.getCells(editor);
           const cellsExpected = [cell1, cell2, cell3].map(toRange);
           expect(cellsActual).toEqual(cellsExpected);
@@ -108,11 +109,11 @@ describe("CodeManager", () => {
       });
       describe("with arg(= oldBreakpoints)", () => {
         it("return cells(range) from exising and detected breakpoints", () => {
-          oldBreakpoints = [[1, 12], [2, 12]];
-          const cell1 = [[0, 0], [0, 12]];
-          const cell2 = [[1, 0], [1, 12]];
-          const cell3 = [[2, 0], [2, 12]];
-          const cell4 = [[3, 0], [3, 0]];
+          oldBreakpoints = [[1, 7], [2, 11]];
+          const cell1 = [[0, 0], [0, 7]];
+          const cell2 = [[1, 0], [1, 7]];
+          const cell3 = [[2, 0], [2, 7]];
+          const cell4 = [[3, 0], [4, 0]];
           const cellsActual = CM.getCells(editor, oldBreakpoints.map(toPoint));
           const cellsExpected = [cell1, cell2, cell3, cell4].map(toRange);
           expect(cellsActual).toEqual(cellsExpected);

--- a/spec/code-manager-spec.js
+++ b/spec/code-manager-spec.js
@@ -1,6 +1,7 @@
 "use babel";
 
 import * as CM from "../lib/code-manager";
+import { Point, Range } from "atom";
 
 describe("CodeManager", () => {
   let editor;
@@ -57,6 +58,66 @@ describe("CodeManager", () => {
       spyOn(editor, "getSelectedText");
       CM.getSelectedText(editor);
       expect(editor.getSelectedText).toHaveBeenCalled();
+    });
+  });
+
+  describe("cells", () => {
+    const toPoint = point => Point.fromObject(point);
+    const toRange = range => Range.fromObject(range);
+
+    describe("getCellsForBreakPoints", () => {
+      it("return cell(range) from array of points", () => {
+        const points = [[1, 2], [3, 4], [5, 6], [10, 5]];
+        const cell1 = [[1, 2], [3, 4]];
+        const cell2 = [[4, 0], [5, 6]];
+        const cell3 = [[6, 0], [10, 5]];
+        const cellsExpected = [cell1, cell2, cell3].map(toRange);
+        const cellsActual = CM.getCellsForBreakPoints(points.map(toPoint));
+        expect(cellsActual).toEqual(cellsExpected);
+      });
+    });
+    describe("getCells", () => {
+      // runAsync is borrowed and modified from link below.
+      // https://github.com/jasmine/jasmine/issues/923#issuecomment-169634461
+      function waitAsync(fn) {
+        return done => {
+          fn().then(done, function rejected(e) {
+            fail(e);
+            done();
+          });
+        };
+      }
+      beforeEach(
+        waitAsync(async () => {
+          await atom.packages.activatePackage("language-javascript");
+          const jsGrammar = atom.grammars.grammarForScopeName("source.js");
+          editor.setGrammar(jsGrammar);
+          const code = "var v1 = 1; // %%\nvar v2 = 2;\nvar v2 = 3; // %%\n";
+          editor.setText(code);
+        })
+      );
+      describe("no arg", () => {
+        it("return cell(range) by collecting breakpoints from comments in editor", () => {
+          const cell1 = [[0, 0], [0, 12]];
+          const cell2 = [[1, 0], [2, 12]];
+          const cell3 = [[3, 0], [3, 0]];
+          const cellsActual = CM.getCells(editor);
+          const cellsExpected = [cell1, cell2, cell3].map(toRange);
+          expect(cellsActual).toEqual(cellsExpected);
+        });
+      });
+      describe("with arg(= oldBreakpoints)", () => {
+        it("return cells(range) from exising and detected breakpoints", () => {
+          oldBreakpoints = [[1, 12], [2, 12]];
+          const cell1 = [[0, 0], [0, 12]];
+          const cell2 = [[1, 0], [1, 12]];
+          const cell3 = [[2, 0], [2, 12]];
+          const cell4 = [[3, 0], [3, 0]];
+          const cellsActual = CM.getCells(editor, oldBreakpoints.map(toPoint));
+          const cellsExpected = [cell1, cell2, cell3, cell4].map(toRange);
+          expect(cellsActual).toEqual(cellsExpected);
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
![refresh-all-result-bubbles](https://user-images.githubusercontent.com/155205/26867118-fba72b72-4b9e-11e7-8275-cbcdc5eff68b.gif)

# What this PR do?

Add new command `hydrogen:refresh-all-result-bubbles`

This command do
- restart and runAll by **not** clearing existing breakpoints(start position of existing result-bubbles).

Detailed explanation for how this command works
1. collect existing breakpoints(start point of existing bubbles) from editor.
2. clear result-bubbles
3. restart
4. runAll( this is passed as callback of `restart()`)

I thinks `all` is a bit verbose, but want to make it explicit.
But feel free to change something like `hydrogen:refresh-result-bubbles`

# Motivation

When I want to re-evaluate whole code in editor, there is no way to refresh existing result-bubbles.
Currently it's just not cleared by `run-all-above` or `run-all`, but it's just showing old slate result.
I want make sure currently visible result-bubbles are **all refreshed, believable** and as long as evaluate code from top-to-bottom from clean state.

This command allow "all visible bubble is refreshed by this command from clean state(kernel restarted to clear out scope)".

# Side-node(skip if you haven't read original issue comment and code)

First, I tried to **merge** existing breakpoints(start point of existing bubbles) with detected breakpoint(e.g. `%%` in comment).
But quit this approach.
- It doesn't fit `refresh-result-bubbles`, since detecting bp in comment add new bubbles.
- Handling position diff between detected breakpoint(start of comment) and start of bubble was pain.
- These two position have relation, but not equal, bubble is created at point after skipping line-comment upward.
- Because of two these position diff, **merging** is not easy, and I also noticed this is not necessary, so simplified to current state.

# Next step I want to add

But postponed since I'm not sure **this** PR is acceptable first of all.

Currently there is two way to add breakpoints.
- Add special chars in comment(e.g. `%%`).
- via `hydrogne:run-all-above` command

I want to add breakpoint
- without modifying editor, just add marker at end of line with block decoration with empty content.
- without evaluating code. This is important to avoid `x is already defined` error with language it force "one-time declaration"(e.g. JavaScript).

When that's done, the workflow I'm imaging is this
1. place breakpoints by `hydrogen:toggle-breakpoints`
  - No editor modification, no code-evaluation.
  - Just add/remove blank bubbles on each selected lines.
2. `hydrogen:refresh-all-result-bubbles`
