### PR TITLE
Add empty display message

### DIFF
--- a/lib/components/result-view/history.js
+++ b/lib/components/result-view/history.js
@@ -56,7 +56,7 @@ const History = observer(({ store }: { store: OutputStore }) => {
           />
         </div>
       </div>
-    : null;
+    : <ul className="background-message centered">No output to display</ul>;
 });
 
 export default History;


### PR DESCRIPTION
Closes #834 

Thought simple worked here, open to feedback of course.

![empty-display](https://user-images.githubusercontent.com/10860657/26956511-f8b8d916-4c83-11e7-9f5b-bbf71604f5d4.png)
