### PR TITLE
Fix empty display message of output area

### DIFF
--- a/lib/components/output-area.js
+++ b/lib/components/output-area.js
@@ -30,7 +30,9 @@ const OutputArea = observer(({ store: { kernel } }: { store: store }) => {
           >
             Clear
           </div>
-        : null}
+        : <ul className="background-message centered">
+            <li>No output to display</li>
+          </ul>}
       <History store={kernel.outputStore} />
     </div>
   );

--- a/lib/components/result-view/history.js
+++ b/lib/components/result-view/history.js
@@ -56,7 +56,7 @@ const History = observer(({ store }: { store: OutputStore }) => {
           />
         </div>
       </div>
-    : <ul className="background-message centered">No output to display</ul>;
+    : null;
 });
 
 export default History;


### PR DESCRIPTION
This fixes a few small issues introduced in #866:
- Move empty message from `history` to `output-area` component. Otherwise the empty message would be displayed in the watch sidebar as well. This would look a bit odd since the panel actually isn't empty.
- Move the message into a `<li>` element to fix centering if the output area is wider than the message. This is the way recommended by the Atom style guide