### PR TITLE
add toggle-result-bubble command

### DIFF
--- a/docs/Usage/GettingStarted.md
+++ b/docs/Usage/GettingStarted.md
@@ -43,6 +43,12 @@ This command works in following way.
 1. Restart kernel to cleanup evaluation environment.
 2. Run all code and update all existing bubbles.
 
+## "Hydrogen: Toggle Bubble"
+
+Toggle(add or remove) bobble at current cursor line.
+You can **preset** bubble before executing code.
+If executed with selection, toggle bubble on each selected lines respectively.
+
 ## Watch Expressions
 
 After you've run some code with Hydrogen, you can use the **"Hydrogen: Toggle Watches"** command from the Command Palette to open the watch expression sidebar. Whatever code you write in watch expressions will be re-run after each time you send that kernel any other code.

--- a/docs/Usage/GettingStarted.md
+++ b/docs/Usage/GettingStarted.md
@@ -47,7 +47,13 @@ This command works in following way.
 
 Toggle(add or remove) bobble at current cursor line.
 You can **preset** bubble before executing code.
-If executed with selection, toggle bubble on each selected lines respectively.
+If executed with selection, toggle bubble on each selected line.
+
+Typical workflow with this command is
+
+1. Add bubble at line you want manually by `hydrogen:toggle-bubble`
+2. Execute code cleanly by `restart-kernel-and-re-evaluate-bubbles`
+3. Modify code, then repeat 1-3 until you fully understand/investigated code.
 
 ## Watch Expressions
 

--- a/lib/components/result-view/status.js
+++ b/lib/components/result-view/status.js
@@ -19,6 +19,8 @@ const Status = observer(({ status, style }: Props) => {
       );
     case "ok":
       return <div className="inline-container icon icon-check" style={style} />;
+    case "empty":
+      return <div className="inline-container icon icon-zap" style={style} />;
     default:
       return <div className="inline-container icon icon-x" style={style} />;
   }

--- a/lib/main.js
+++ b/lib/main.js
@@ -422,14 +422,13 @@ const Hydrogen = {
         if (marker.getStartBufferPosition().row === row) {
           bubble.destroy();
           delete this.markerBubbleMap[marker.id];
-          if (!destroyed) {
-            destroyed = true;
-          }
+          destroyed = true;
         }
       });
 
       if (!destroyed) {
-        this.insertResultBubble(editor, row, true);
+        const outputStore = this.insertResultBubble(editor, row, true);
+        outputStore.status = "empty";
       }
     }
   },

--- a/lib/main.js
+++ b/lib/main.js
@@ -395,10 +395,6 @@ const Hydrogen = {
 
   restartKernelAndReEvaluateBubbles() {
     const { editor, kernel } = store;
-    if (!editor || !kernel) {
-      this.runAll();
-      return;
-    }
 
     let breakpoints = [];
     _.forEach(this.markerBubbleMap, (bubble: ResultView) => {
@@ -406,7 +402,11 @@ const Hydrogen = {
     });
     this.clearResultBubbles();
 
-    kernel.restart(() => this.runAll(breakpoints));
+    if (!editor || !kernel) {
+      this.runAll(breakpoints);
+    } else {
+      kernel.restart(() => this.runAll(breakpoints));
+    }
   },
 
   toggleBubble() {

--- a/lib/main.js
+++ b/lib/main.js
@@ -118,7 +118,8 @@ const Hydrogen = {
         "hydrogen:restart-kernel-and-re-evaluate-bubbles": () =>
           this.restartKernelAndReEvaluateBubbles(),
         "hydrogen:shutdown-kernel": () =>
-          this.handleKernelCommand({ command: "shutdown-kernel" })
+          this.handleKernelCommand({ command: "shutdown-kernel" }),
+        "hydrogen:toggle-bubble": () => this.toggleBubble()
       })
     );
 
@@ -406,6 +407,30 @@ const Hydrogen = {
     this.clearResultBubbles();
 
     kernel.restart(() => this.runAll(breakpoints));
+  },
+
+  toggleBubble() {
+    const { editor } = store;
+    const [startRow, endRow] = editor.getLastSelection().getBufferRowRange();
+
+    for (let row = startRow; row <= endRow; row++) {
+      let destroyed = false;
+
+      _.forEach(this.markerBubbleMap, (bubble: ResultView) => {
+        const { marker } = bubble;
+        if (marker.getStartBufferPosition().row === row) {
+          bubble.destroy();
+          delete this.markerBubbleMap[marker.id];
+          if (!destroyed) {
+            destroyed = true;
+          }
+        }
+      });
+
+      if (!destroyed) {
+        this.insertResultBubble(editor, row, true);
+      }
+    }
   },
 
   clearBubblesOnRow(row: number) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -411,6 +411,7 @@ const Hydrogen = {
 
   toggleBubble() {
     const { editor } = store;
+    if (!editor) return;
     const [startRow, endRow] = editor.getLastSelection().getBufferRowRange();
 
     for (let row = startRow; row <= endRow; row++) {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
       "hydrogen:run-all-above",
       "hydrogen:run-cell",
       "hydrogen:run-cell-and-move-down",
-      "hydrogen:restart-kernel-and-re-evaluate-bubbles"
+      "hydrogen:restart-kernel-and-re-evaluate-bubbles",
+      "hydrogen:toggle-bubble"
     ]
   },
   "scripts": {

--- a/types/atom.js.flow
+++ b/types/atom.js.flow
@@ -832,6 +832,7 @@ declare class atom$TextEditor extends atom$Model {
   getCursorScreenPosition(): atom$Point,
   getCursorScreenPositions(): Array<atom$Point>,
   getLastCursor(): atom$Cursor,
+  getLastSelection(): atom$Selection,
   moveToBeginningOfLine(): void,
   moveToEndOfLine(): void,
   moveToBottom(): void,
@@ -1893,6 +1894,7 @@ declare class atom$Selection {
       undo?: boolean,
     },
   ): string,
+  getBufferRowRange(): [number, number]
 }
 
 declare class atom$LanguageMode {


### PR DESCRIPTION
~~Code is very rough state, but want to know how team feels about this.~~

![toggle-bubble](https://user-images.githubusercontent.com/155205/27345223-d8159574-5623-11e7-9d6a-db56a5738e60.gif)


# What this PR do?

Add new command `hydrogen:toggle-bubble`

This command allow manually add/remove bubble(outlet of code evaluation).

- If selection was empty, toggle bubble at current cursor line.
- If executed with selection, toggle bubble at each line of selected lines.
- What toggle means is
  - Add bubble at line if line have no bubble.
  - Remove bubble from line if line have bubble.

# Motivation

Currently there is no way to add bubble **without evaluating code**.
So If I tried to place bubble where I want, I have to execute code, then frequently see `duplicate declaration of variable` like error in bubble.

e.g. `let`, `const` in JavaScript cannot be executed in same scope.

This can be avoided if user super carefully execute code, but I don't want to.

Instead, I want to

- Place bubble before evaluating code.
- Then execute from clean state(`restart-kernel-and-re-evaluate-bubbles`) and update bubbles.

This workflow have no mess, no duplicate declaration error, I prefer this workflow at least in small code snippet.

# TODO

- [x] Use better icon for empty bubble(Just added and not yet evaluated state). I picked `zap` icon
