### PR TITLE
Prevent duplicate kernel startup

### DIFF
--- a/lib/kernel-manager.js
+++ b/lib/kernel-manager.js
@@ -106,6 +106,12 @@ class KernelManager {
     onStarted: ?(kernel: ZMQKernel) => void
   ) {
     const displayName = kernelSpec.display_name;
+
+    // if kernel startup already in progress don't start additional kernel
+    if (store.startingKernels.get(displayName)) return;
+
+    store.startKernel(displayName);
+
     let currentPath = getEditorDirectory(store.editor);
     let projectPath;
 

--- a/lib/store/index.js
+++ b/lib/store/index.js
@@ -10,7 +10,8 @@ import type Kernel from "./../kernel";
 
 class Store {
   subscriptions = new CompositeDisposable();
-  @observable runningKernels = new Map();
+  @observable startingKernels: Map<string, boolean> = new Map();
+  @observable runningKernels: Map<string, Kernel> = new Map();
   @observable editor = atom.workspace.getActiveTextEditor();
   @observable grammar: ?atom$Grammar;
 
@@ -26,9 +27,17 @@ class Store {
   }
 
   @action
+  startKernel(kernelDisplayName: string) {
+    this.startingKernels.set(kernelDisplayName, true);
+  }
+
+  @action
   newKernel(kernel: Kernel) {
-    const mappedLanguage = Config.getJson("languageMappings")[kernel.language];
-    this.runningKernels.set(mappedLanguage || kernel.language, kernel);
+    const mappedLanguage =
+      Config.getJson("languageMappings")[kernel.language] || kernel.language;
+    this.runningKernels.set(mappedLanguage, kernel);
+    // delete startingKernel since store.kernel now in place to block
+    this.startingKernels.delete(kernel.kernelSpec.display_name);
   }
 
   @action

--- a/spec/store/index-spec.js
+++ b/spec/store/index-spec.js
@@ -118,7 +118,11 @@ describe("Store", () => {
   });
 
   it("should add new kernel", () => {
-    const kernel = { language: "null grammar", foo: "bar" };
+    const kernel = {
+      language: "null grammar",
+      foo: "bar",
+      kernelSpec: { language: "null grammar", display_name: "null grammar" }
+    };
     store.newKernel(kernel);
     expect(store.runningKernels.size).toBe(1);
     expect(store.runningKernels.get("null grammar").language).toBe(


### PR DESCRIPTION
Since we rely on `store.kernel` to indicate if a new kernel should be started `store` needs to be aware af startup pretty much immediately to avoid duplicate kernels. See #870 for a wordier explanation.

The idea here is to somehow fail silently instead of creating dup kernels that may not shut down properly. I would be grateful for feedback!

# To Duplicate: 
- start a new kernel by pressing `ctrl-enter` on 2 or more lines quickly

![example](https://user-images.githubusercontent.com/10860657/27062702-6012f386-4fb2-11e7-90c2-b4f85bc9edce.gif)



 