### PR TITLE
Correctly reflect kernel restart in UI

### DIFF
--- a/lib/components/result-view/index.js
+++ b/lib/components/result-view/index.js
@@ -7,6 +7,7 @@ import { reactFactory } from "./../../utils";
 import ResultViewComponent from "./result-view";
 
 import type OutputStore from "./../../store/output";
+import type Kernel from "./../../kernel";
 
 export default class ResultView {
   element: HTMLElement;
@@ -20,6 +21,7 @@ export default class ResultView {
 
   constructor(
     store: OutputStore,
+    kernel: Kernel,
     marker: atom$Marker,
     showResult: boolean = true
   ) {
@@ -32,6 +34,7 @@ export default class ResultView {
     reactFactory(
       <ResultViewComponent
         store={store}
+        kernel={kernel}
         destroy={this.destroy}
         showResult={showResult}
       />,

--- a/lib/components/result-view/result-view.js
+++ b/lib/components/result-view/result-view.js
@@ -12,7 +12,14 @@ import Status from "./status";
 
 import type { IObservableValue } from "mobx";
 import type OutputStore from "./../../store/output";
-type Props = { store: OutputStore, destroy: Function, showResult: boolean };
+import type Kernel from "./../../kernel";
+
+type Props = {
+  store: OutputStore,
+  kernel: Kernel,
+  destroy: Function,
+  showResult: boolean
+};
 
 @observer
 class ResultViewComponent extends React.Component {
@@ -79,7 +86,15 @@ class ResultViewComponent extends React.Component {
     };
 
     if (outputs.length === 0 || this.props.showResult === false) {
-      return <Status status={status} style={inlineStyle} />;
+      const { executionState } = this.props.kernel;
+      return (
+        <Status
+          status={
+            executionState !== "busy" && status === "running" ? "error" : status
+          }
+          style={inlineStyle}
+        />
+      );
     }
 
     return (

--- a/lib/main.js
+++ b/lib/main.js
@@ -325,6 +325,7 @@ const Hydrogen = {
     const outputStore = this.insertResultBubble(
       store.editor,
       row,
+      kernel,
       !globalOutputStore
     );
 
@@ -342,6 +343,7 @@ const Hydrogen = {
   insertResultBubble(
     editor: atom$TextEditor,
     row: number,
+    kernel: Kernel,
     showResult: boolean
   ) {
     this.clearBubblesOnRow(row);
@@ -361,7 +363,7 @@ const Hydrogen = {
       editorWidth: editor.getEditorWidthInChars()
     });
 
-    const view = new ResultView(outputStore, marker, showResult);
+    const view = new ResultView(outputStore, kernel, marker, showResult);
     const { element } = view;
 
     editor.decorateMarker(marker, {

--- a/lib/ws-kernel.js
+++ b/lib/ws-kernel.js
@@ -29,8 +29,9 @@ export default class WSKernel extends Kernel {
 
   restart(onRestarted: ?Function) {
     const future = this.session.kernel.restart();
-    // $FlowFixMe
-    if (onRestarted) future.then(() => onRestarted(this.session.kernel));
+    future.then(() => {
+      if (onRestarted) onRestarted(this.session.kernel);
+    });
   }
 
   _execute(code: string, callWatches: boolean, onResults: Function) {

--- a/lib/zmq-kernel.js
+++ b/lib/zmq-kernel.js
@@ -177,6 +177,7 @@ export default class ZMQKernel extends Kernel {
         this.options
       );
       this.kernelProcess = spawn;
+      this.setExecutionState("idle");
       if (onRestarted) onRestarted(this);
       return;
     }


### PR DESCRIPTION
A few more kernel restart fixes:
- remote kernels weren't properly restarted: f099f64
- restart wasn't properly reflected in the UI since we don't remove the result bubbles. Fixes #880

## PR
![pr](https://user-images.githubusercontent.com/13285808/27287598-80eda220-5504-11e7-8cec-c9a46b79570f.gif)
## master
![master](https://user-images.githubusercontent.com/13285808/27287597-80e25924-5504-11e7-8755-d2c80a4b99a1.gif)