### PR TITLE
add hot-reload-package command to boost dev-workflow

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -44,7 +44,8 @@ import {
   renderDevTools,
   INSPECTOR_URI,
   WATCHES_URI,
-  OUTPUT_AREA_URI
+  OUTPUT_AREA_URI,
+  hotReloadPackage
 } from "./utils";
 
 import type Kernel from "./kernel";
@@ -127,6 +128,14 @@ const Hydrogen = {
         "hydrogen:clear-results": () => this.clearResultBubbles()
       })
     );
+
+    if (atom.inDevMode()) {
+      store.subscriptions.add(
+        atom.commands.add("atom-workspace", {
+          "hydrogen:hot-reload-package": () => hotReloadPackage()
+        })
+      );
+    }
 
     store.subscriptions.add(
       atom.workspace.getCenter().observeActivePaneItem(item => {

--- a/lib/main.js
+++ b/lib/main.js
@@ -211,6 +211,7 @@ const Hydrogen = {
 
   deactivate() {
     store.dispose();
+    this.clearResultBubbles();
   },
 
   provideHydrogen() {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -173,8 +173,8 @@ export function hotReloadPackage() {
   atom.packages.deactivatePackage(packName);
   atom.packages.unloadPackage(packName);
 
-  // Remove require cache to re-require on activation.
-  // But don't re-require zeromq native module, it cannot re-requireable.
+  // Delete require cache to re-require on activation.
+  // But except zeromq native module which is not re-requireable.
   const packageLibsExceptZeromq = filePath =>
     filePath.startsWith(packPathPrefix) &&
     !filePath.startsWith(zeromqPathPrefix);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -165,6 +165,7 @@ export function deprecationNote() {
 export function hotReloadPackage() {
   const packName = "Hydrogen";
   const packPath = atom.packages.resolvePackagePath(packName);
+  if (!packPath) return;
   const packPathPrefix = packPath + path.sep;
   const zeromqPathPrefix =
     path.join(packPath, "node_modules", "zeromq") + path.sep;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -161,3 +161,29 @@ export function deprecationNote() {
     ]
   });
 }
+
+export function hotReloadPackage() {
+  const packName = "Hydrogen";
+  const packPath = atom.packages.resolvePackagePath(packName);
+  const packPathPrefix = packPath + path.sep;
+  const zeromqPathPrefix =
+    path.join(packPath, "node_modules", "zeromq") + path.sep;
+
+  console.info(`deactivating ${packName}`);
+  atom.packages.deactivatePackage(packName);
+  atom.packages.unloadPackage(packName);
+
+  // Remove require cache to re-require on activation.
+  // But don't re-require zeromq native module, it cannot re-requireable.
+  const packageLibsExceptZeromq = filePath =>
+    filePath.startsWith(packPathPrefix) &&
+    !filePath.startsWith(zeromqPathPrefix);
+
+  Object.keys(require.cache)
+    .filter(packageLibsExceptZeromq)
+    .forEach(filePath => delete require.cache[filePath]);
+
+  atom.packages.loadPackage(packName);
+  atom.packages.activatePackage(packName);
+  console.info(`activated ${packName}`);
+}

--- a/lib/zmq-kernel.js
+++ b/lib/zmq-kernel.js
@@ -429,7 +429,7 @@ export default class ZMQKernel extends Kernel {
 
     if (this.kernelProcess) {
       this._kill();
-      fs.unlink(this.connectionFile);
+      fs.unlinkSync(this.connectionFile);
     }
 
     this.shellSocket.close();


### PR DESCRIPTION
## Demo

In this demo, changing `icon-check` to different one **without reloading Atom**.
workflow is

1. change icon def
2. invoke `hydrogen:hot-reload-package` via keymap( I use `f8` ).
3. `hydrogen:run-all` to see changed icon
4. repeat till I could find better icon etc..

![hot-reload](https://user-images.githubusercontent.com/155205/27369170-bda58514-5691-11e7-9ff6-ec18ecb30c5e.gif)


## What this PR do

- Add new command `hydrogen:hot-reload-package`.
- This command is only available when atom is launched in dev-mode.
- This command allow reload hydrogen package without reloading Atom itself.
  - This is faster, so out dev speed would get faster and more pleasant.

### special note

I changed `fs.unlink` used in `ZMQKernel::destroy`, to avoid following warning.

`internal/process/warning.js:21 (node:58539) DeprecationWarning: Calling an asynchronous function without callback is deprecated.`

- This warning was already there(NOT introduced by this PR, so I just fixed it).
- This is nodev-v7 specific error, and atom-beta use node-v7, you can reproduce it by simply disable package via setting-view.
