### PR TITLE
Ensure that all sockets are connected after kernel restart

### DIFF
--- a/lib/zmq-kernel.js
+++ b/lib/zmq-kernel.js
@@ -102,6 +102,10 @@ export default class ZMQKernel extends Kernel {
     this.ioSocket.on("message", this.onIOMessage.bind(this));
     this.stdinSocket.on("message", this.onStdinMessage.bind(this));
 
+    this.monitor(done);
+  }
+
+  monitor(done: ?Function) {
     try {
       let socketNames = ["shellSocket", "controlSocket", "ioSocket"];
 
@@ -168,6 +172,7 @@ export default class ZMQKernel extends Kernel {
 
   restart(onRestarted: ?Function) {
     if (this.kernelProcess) {
+      this.setExecutionState("restarting");
       this.shutdown(true);
       this._kill();
       const { spawn } = launchSpecFromConnectionInfo(
@@ -177,14 +182,14 @@ export default class ZMQKernel extends Kernel {
         this.options
       );
       this.kernelProcess = spawn;
-      this.setExecutionState("idle");
+      this.monitor(() => {
+        if (onRestarted) onRestarted(this);
+      });
+    } else {
+      log("ZMQKernel: restart ignored:", this);
+      atom.notifications.addWarning("Cannot restart this kernel");
       if (onRestarted) onRestarted(this);
-      return;
     }
-
-    log("ZMQKernel: restart ignored:", this);
-    atom.notifications.addWarning("Cannot restart this kernel");
-    if (onRestarted) onRestarted(this);
   }
 
   // onResults is a callback that may be called multiple times

--- a/lib/zmq-kernel.js
+++ b/lib/zmq-kernel.js
@@ -172,6 +172,9 @@ export default class ZMQKernel extends Kernel {
 
   restart(onRestarted: ?Function) {
     if (this.kernelProcess) {
+      if (this.executionState === "restarting") {
+        return;
+      }
       this.setExecutionState("restarting");
       this.shutdown(true);
       this._kill();


### PR DESCRIPTION
This will considerably slow down the kernel restart, but ensures that all sockets are connected after restarting. We still keep our old connection file though.

This fixes https://github.com/nteract/hydrogen/pull/877#issuecomment-309189724