### PR TITLE
Refactor markers handling

### DIFF
--- a/lib/components/result-view/index.js
+++ b/lib/components/result-view/index.js
@@ -13,6 +13,7 @@ import type Kernel from "./../../kernel";
 export default class ResultView {
   disposer: atom$CompositeDisposable;
   marker: atom$Marker;
+  outputStore: OutputStore;
 
   destroy = () => {
     this.disposer.dispose();
@@ -33,16 +34,13 @@ export default class ResultView {
 
     markerStore.clearOnRow(row);
 
-    const buffer = editor.getBuffer();
-    const lineLength = buffer.lineLengthForRow(row);
+    this.marker = editor.markBufferPosition([row, Infinity], {
+      invalidate: "touch"
+    });
 
-    const point = new Point(row, lineLength);
-    this.marker = editor.markBufferPosition(point, { invalidate: "touch" });
-    const lineHeight = editor.getLineHeightInPixels();
-
-    const outputStore = new OutputStore();
-    outputStore.updatePosition({
-      lineLength: lineLength,
+    this.outputStore = new OutputStore();
+    this.outputStore.updatePosition({
+      lineLength: editor.getBuffer().lineLengthForRow(row),
       lineHeight: editor.getLineHeightInPixels(),
       editorWidth: editor.getEditorWidthInChars()
     });
@@ -57,7 +55,7 @@ export default class ResultView {
       if (!event.isValid) {
         markerStore.delete(this.marker.id);
       } else {
-        outputStore.updatePosition({
+        this.outputStore.updatePosition({
           lineLength: this.marker.getStartBufferPosition().column
         });
       }
@@ -67,7 +65,7 @@ export default class ResultView {
 
     reactFactory(
       <ResultViewComponent
-        store={outputStore}
+        store={this.outputStore}
         kernel={kernel}
         destroy={this.destroy}
         showResult={showResult}
@@ -76,7 +74,5 @@ export default class ResultView {
       null,
       this.disposer
     );
-
-    return outputStore;
   }
 }

--- a/lib/components/result-view/index.js
+++ b/lib/components/result-view/index.js
@@ -44,7 +44,6 @@ export default class ResultView {
     outputStore.updatePosition({
       lineLength: lineLength,
       lineHeight: editor.getLineHeightInPixels(),
-      // $FlowFixMe: Missing flow type
       editorWidth: editor.getEditorWidthInChars()
     });
 

--- a/lib/components/result-view/index.js
+++ b/lib/components/result-view/index.js
@@ -21,7 +21,7 @@ export default class ResultView {
 
   constructor(
     markerStore: MarkerStore,
-    kernel: Kernel,
+    kernel: ?Kernel,
     editor: atom$TextEditor,
     row: number,
     showResult: boolean = true

--- a/lib/components/result-view/index.js
+++ b/lib/components/result-view/index.js
@@ -1,46 +1,83 @@
 /* @flow */
 
-import { CompositeDisposable } from "atom";
+import { CompositeDisposable, Point } from "atom";
 import React from "react";
 
 import { reactFactory } from "./../../utils";
+import OutputStore from "./../../store/output";
 import ResultViewComponent from "./result-view";
 
-import type OutputStore from "./../../store/output";
+import type MarkerStore from "./../../store/markers";
 import type Kernel from "./../../kernel";
 
 export default class ResultView {
-  element: HTMLElement;
   disposer: atom$CompositeDisposable;
   marker: atom$Marker;
 
   destroy = () => {
     this.disposer.dispose();
-    if (this.marker) this.marker.destroy();
+    this.marker.destroy();
   };
 
   constructor(
-    store: OutputStore,
+    markerStore: MarkerStore,
     kernel: Kernel,
-    marker: atom$Marker,
+    editor: atom$TextEditor,
+    row: number,
     showResult: boolean = true
   ) {
-    this.marker = marker;
-    this.element = document.createElement("div");
-    this.element.classList.add("hydrogen", "marker");
+    const element = document.createElement("div");
+    element.classList.add("hydrogen", "marker");
 
     this.disposer = new CompositeDisposable();
 
+    markerStore.clearOnRow(row);
+
+    const buffer = editor.getBuffer();
+    const lineLength = buffer.lineLengthForRow(row);
+
+    const point = new Point(row, lineLength);
+    this.marker = editor.markBufferPosition(point, { invalidate: "touch" });
+    const lineHeight = editor.getLineHeightInPixels();
+
+    const outputStore = new OutputStore();
+    outputStore.updatePosition({
+      lineLength: lineLength,
+      lineHeight: editor.getLineHeightInPixels(),
+      // $FlowFixMe: Missing flow type
+      editorWidth: editor.getEditorWidthInChars()
+    });
+
+    editor.decorateMarker(this.marker, {
+      type: "block",
+      item: element,
+      position: "after"
+    });
+
+    this.marker.onDidChange(event => {
+      if (!event.isValid) {
+        markerStore.delete(this.marker.id);
+      } else {
+        outputStore.updatePosition({
+          lineLength: this.marker.getStartBufferPosition().column
+        });
+      }
+    });
+
+    markerStore.new(this);
+
     reactFactory(
       <ResultViewComponent
-        store={store}
+        store={outputStore}
         kernel={kernel}
         destroy={this.destroy}
         showResult={showResult}
       />,
-      this.element,
+      element,
       null,
       this.disposer
     );
+
+    return outputStore;
   }
 }

--- a/lib/components/result-view/result-view.js
+++ b/lib/components/result-view/result-view.js
@@ -16,7 +16,7 @@ import type Kernel from "./../../kernel";
 
 type Props = {
   store: OutputStore,
-  kernel: Kernel,
+  kernel: ?Kernel,
   destroy: Function,
   showResult: boolean
 };
@@ -86,11 +86,13 @@ class ResultViewComponent extends React.Component {
     };
 
     if (outputs.length === 0 || this.props.showResult === false) {
-      const { executionState } = this.props.kernel;
+      const kernel = this.props.kernel;
       return (
         <Status
           status={
-            executionState !== "busy" && status === "running" ? "error" : status
+            kernel && kernel.executionState !== "busy" && status === "running"
+              ? "error"
+              : status
           }
           style={inlineStyle}
         />

--- a/lib/main.js
+++ b/lib/main.js
@@ -208,7 +208,6 @@ const Hydrogen = {
 
   deactivate() {
     store.dispose();
-    this.clearResultBubbles();
   },
 
   provideHydrogen() {

--- a/lib/main.js
+++ b/lib/main.js
@@ -333,7 +333,7 @@ const Hydrogen = {
       ? kernel.outputStore
       : null;
 
-    const outputStore = new ResultView(
+    const { outputStore } = new ResultView(
       store.markers,
       kernel,
       editor,
@@ -377,7 +377,13 @@ const Hydrogen = {
       const destroyed = markers.clearOnRow(row);
 
       if (!destroyed) {
-        const outputStore = new ResultView(markers, kernel, editor, row, true);
+        const { outputStore } = new ResultView(
+          markers,
+          kernel,
+          editor,
+          row,
+          true
+        );
         outputStore.status = "empty";
       }
     }

--- a/lib/main.js
+++ b/lib/main.js
@@ -370,7 +370,7 @@ const Hydrogen = {
 
   toggleBubble() {
     const { editor, kernel, markers } = store;
-    if (!editor || !kernel) return;
+    if (!editor) return;
     const [startRow, endRow] = editor.getLastSelection().getBufferRowRange();
 
     for (let row = startRow; row <= endRow; row++) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -53,12 +53,8 @@ import type Kernel from "./kernel";
 const Hydrogen = {
   config: Config.schema,
 
-  markerBubbleMap: null,
-
   activate() {
     this.emitter = new Emitter();
-
-    this.markerBubbleMap = {};
 
     let skipLanguageMappingsChange = false;
     store.subscriptions.add(
@@ -126,7 +122,7 @@ const Hydrogen = {
 
     store.subscriptions.add(
       atom.commands.add("atom-workspace", {
-        "hydrogen:clear-results": () => this.clearResultBubbles()
+        "hydrogen:clear-results": () => store.markers.clear()
       })
     );
 
@@ -279,7 +275,7 @@ const Hydrogen = {
 
     if (command === "switch-kernel") {
       if (!payload) return;
-      this.clearResultBubbles();
+      store.markers.clear();
       if (kernel) kernel.destroy();
       kernelManager.startKernel(payload, grammar);
       return;
@@ -296,7 +292,7 @@ const Hydrogen = {
     } else if (command === "restart-kernel") {
       kernel.restart();
     } else if (command === "shutdown-kernel") {
-      this.clearResultBubbles();
+      store.markers.clear();
       // Note that destroy alone does not shut down a WSKernel
       kernel.shutdown();
       kernel.destroy();
@@ -304,25 +300,30 @@ const Hydrogen = {
       // $FlowFixMe Will only be called if remote kernel
       if (kernel instanceof WSKernel) kernel.promptRename();
     } else if (command === "disconnect-kernel") {
-      this.clearResultBubbles();
+      store.markers.clear();
       kernel.destroy();
     }
   },
 
-  createResultBubble(code: string, row: number, editor: atom$TextEditor) {
+  createResultBubble(editor: atom$TextEditor, code: string, row: number) {
     if (!store.grammar) return;
 
     if (store.kernel) {
-      this._createResultBubble(store.kernel, code, row);
+      this._createResultBubble(editor, store.kernel, code, row);
       return;
     }
 
     kernelManager.startKernelFor(store.grammar, editor, (kernel: ZMQKernel) => {
-      this._createResultBubble(kernel, code, row);
+      this._createResultBubble(editor, kernel, code, row);
     });
   },
 
-  _createResultBubble(kernel: Kernel, code: string, row: number) {
+  _createResultBubble(
+    editor: atom$TextEditor,
+    kernel: Kernel,
+    code: string,
+    row: number
+  ) {
     if (atom.workspace.getActivePaneItem() instanceof WatchesPane) {
       kernel.watchesStore.run();
       return;
@@ -333,10 +334,11 @@ const Hydrogen = {
       ? kernel.outputStore
       : null;
 
-    const outputStore = this.insertResultBubble(
-      store.editor,
-      row,
+    const outputStore = new ResultView(
+      store.markers,
       kernel,
+      editor,
+      row,
       !globalOutputStore
     );
 
@@ -351,66 +353,14 @@ const Hydrogen = {
     });
   },
 
-  insertResultBubble(
-    editor: atom$TextEditor,
-    row: number,
-    kernel: Kernel,
-    showResult: boolean
-  ) {
-    this.clearBubblesOnRow(row);
-
-    const buffer = editor.getBuffer();
-    const lineLength = buffer.lineLengthForRow(row);
-
-    const point = new Point(row, lineLength);
-    const marker = editor.markBufferPosition(point, { invalidate: "touch" });
-    const lineHeight = editor.getLineHeightInPixels();
-
-    const outputStore = new OutputStore();
-    outputStore.updatePosition({
-      lineLength: lineLength,
-      lineHeight: editor.getLineHeightInPixels(),
-      // $FlowFixMe: Missing flow type
-      editorWidth: editor.getEditorWidthInChars()
-    });
-
-    const view = new ResultView(outputStore, kernel, marker, showResult);
-    const { element } = view;
-
-    editor.decorateMarker(marker, {
-      type: "block",
-      item: element,
-      position: "after"
-    });
-
-    this.markerBubbleMap[marker.id] = view;
-    marker.onDidChange(event => {
-      log("marker.onDidChange:", marker);
-      if (!event.isValid) {
-        view.destroy();
-        delete this.markerBubbleMap[marker.id];
-      } else {
-        outputStore.updatePosition({
-          lineLength: marker.getStartBufferPosition().column
-        });
-      }
-    });
-    return outputStore;
-  },
-
-  clearResultBubbles() {
-    _.forEach(this.markerBubbleMap, (bubble: ResultView) => bubble.destroy());
-    this.markerBubbleMap = {};
-  },
-
   restartKernelAndReEvaluateBubbles() {
-    const { editor, kernel } = store;
+    const { editor, kernel, markers } = store;
 
     let breakpoints = [];
-    _.forEach(this.markerBubbleMap, (bubble: ResultView) => {
+    markers.markers.forEach((bubble: ResultView) => {
       breakpoints.push(bubble.marker.getBufferRange().start);
     });
-    this.clearResultBubbles();
+    store.markers.clear();
 
     if (!editor || !kernel) {
       this.runAll(breakpoints);
@@ -420,41 +370,18 @@ const Hydrogen = {
   },
 
   toggleBubble() {
-    const { editor } = store;
-    if (!editor) return;
+    const { editor, kernel, markers } = store;
+    if (!editor || !kernel) return;
     const [startRow, endRow] = editor.getLastSelection().getBufferRowRange();
 
     for (let row = startRow; row <= endRow; row++) {
-      let destroyed = false;
-
-      _.forEach(this.markerBubbleMap, (bubble: ResultView) => {
-        const { marker } = bubble;
-        if (marker.getStartBufferPosition().row === row) {
-          bubble.destroy();
-          delete this.markerBubbleMap[marker.id];
-          destroyed = true;
-        }
-      });
+      const destroyed = markers.clearOnRow(row);
 
       if (!destroyed) {
-        const outputStore = this.insertResultBubble(editor, row, true);
+        const outputStore = new ResultView(markers, kernel, editor, row, true);
         outputStore.status = "empty";
       }
     }
-  },
-
-  clearBubblesOnRow(row: number) {
-    log("clearBubblesOnRow:", row);
-    _.forEach(this.markerBubbleMap, (bubble: ResultView) => {
-      const { marker } = bubble;
-      if (!marker) return;
-      const range = marker.getBufferRange();
-      if (range.start.row <= row && row <= range.end.row) {
-        log("clearBubblesOnRow:", row, bubble);
-        bubble.destroy();
-        delete this.markerBubbleMap[marker.id];
-      }
-    });
   },
 
   run(moveDown: boolean = false) {
@@ -470,7 +397,7 @@ const Hydrogen = {
       if (moveDown === true) {
         codeManager.moveDown(editor, row);
       }
-      this.createResultBubble(code, row, editor);
+      this.createResultBubble(editor, code, row);
     }
   },
 
@@ -505,7 +432,7 @@ const Hydrogen = {
       ({ start, end }: { start: atom$Point, end: atom$Point }) => {
         const code = codeManager.getTextInRange(editor, start, end);
         const endRow = codeManager.escapeBlankRows(editor, start.row, end.row);
-        this._createResultBubble(kernel, code, endRow);
+        this._createResultBubble(editor, kernel, code, endRow);
       }
     );
   },
@@ -525,7 +452,7 @@ const Hydrogen = {
     const code = codeManager.getRows(editor, 0, row);
 
     if (code) {
-      this.createResultBubble(code, row);
+      this.createResultBubble(editor, code, row);
     }
   },
 
@@ -540,7 +467,7 @@ const Hydrogen = {
       if (moveDown === true) {
         codeManager.moveDown(editor, endRow);
       }
-      this.createResultBubble(code, endRow);
+      this.createResultBubble(editor, code, endRow);
     }
   },
 
@@ -565,7 +492,7 @@ const Hydrogen = {
   showWSKernelPicker() {
     if (!this.wsKernelPicker) {
       this.wsKernelPicker = new WSKernelPicker((kernel: Kernel) => {
-        this.clearResultBubbles();
+        store.markers.clear();
 
         if (kernel instanceof ZMQKernel) kernel.destroy();
 

--- a/lib/store/index.js
+++ b/lib/store/index.js
@@ -54,6 +54,7 @@ class Store {
   @action
   dispose() {
     this.subscriptions.dispose();
+    this.markers.clear();
     this.runningKernels.forEach(kernel => kernel.destroy());
     this.runningKernels = new Map();
   }

--- a/lib/store/index.js
+++ b/lib/store/index.js
@@ -5,11 +5,13 @@ import { observable, computed, action } from "mobx";
 import { isMultilanguageGrammar, getEmbeddedScope } from "./../utils";
 
 import Config from "./../config";
+import MarkerStore from "./markers";
 import kernelManager from "./../kernel-manager";
 import type Kernel from "./../kernel";
 
 class Store {
   subscriptions = new CompositeDisposable();
+  markers = new MarkerStore();
   @observable startingKernels: Map<string, boolean> = new Map();
   @observable runningKernels: Map<string, Kernel> = new Map();
   @observable editor = atom.workspace.getActiveTextEditor();

--- a/lib/store/markers.js
+++ b/lib/store/markers.js
@@ -1,0 +1,34 @@
+/* @flow */
+
+import type ResultView from "./../components/result-view";
+
+export default class MarkerStore {
+  markers: Map<number, ResultView> = new Map();
+
+  clear() {
+    this.markers.forEach((bubble: ResultView) => bubble.destroy());
+    this.markers.clear();
+  }
+
+  clearOnRow(row: number) {
+    let destroyed = false;
+    this.markers.forEach((bubble: ResultView, key: number) => {
+      const { start, end } = bubble.marker.getBufferRange();
+      if (start.row <= row && row <= end.row) {
+        this.delete(key);
+        destroyed = true;
+      }
+    });
+    return destroyed;
+  }
+
+  new(bubble: ResultView) {
+    this.markers.set(bubble.marker.id, bubble);
+  }
+
+  delete(key: number) {
+    const bubble = this.markers.get(key);
+    if (bubble) bubble.destroy();
+    this.markers.delete(key);
+  }
+}

--- a/spec/store/markers-spec.js
+++ b/spec/store/markers-spec.js
@@ -1,0 +1,73 @@
+"use babel";
+
+import { Range } from "atom";
+
+import MarkerStore from "../../lib/store/markers";
+
+describe("MarkerStore", () => {
+  let store;
+  beforeEach(() => {
+    store = new MarkerStore();
+  });
+
+  it("correctly initializes MarkerStore", () => {
+    expect(store.markers).toEqual(new Map());
+  });
+
+  it("clears markers", () => {
+    const bubble1 = jasmine.createSpyObj("bubble1", ["destroy"]);
+    const bubble2 = jasmine.createSpyObj("bubble2", ["destroy"]);
+
+    store.markers.set(1, bubble1);
+    store.markers.set(2, bubble2);
+    expect(store.markers.size).toEqual(2);
+
+    store.clear();
+
+    expect(bubble1.destroy).toHaveBeenCalled();
+    expect(bubble2.destroy).toHaveBeenCalled();
+    expect(store.markers.size).toEqual(0);
+  });
+
+  it("stores a new marker", () => {
+    const bubble = { marker: { id: 42 } };
+
+    store.new(bubble);
+
+    expect(store.markers.size).toEqual(1);
+    expect(store.markers.get(42)).toEqual(bubble);
+  });
+
+  it("deletes a marker", () => {
+    const bubble1 = jasmine.createSpyObj("bubble1", ["destroy"]);
+    const bubble2 = jasmine.createSpyObj("bubble2", ["destroy"]);
+
+    store.markers.set(1, bubble1);
+    store.markers.set(2, bubble2);
+    expect(store.markers.size).toEqual(2);
+
+    store.delete(2);
+
+    expect(bubble1.destroy).not.toHaveBeenCalled();
+    expect(bubble2.destroy).toHaveBeenCalled();
+    expect(store.markers.size).toEqual(1);
+    expect(store.markers.get(1)).toEqual(bubble1);
+  });
+
+  it("clears bubble on row", () => {
+    const bubble = {
+      marker: { getBufferRange: () => new Range([5, 1], [5, 3]) }
+    };
+
+    spyOn(store, "delete");
+
+    store.markers.set(1, bubble);
+    expect(store.markers.size).toEqual(1);
+
+    expect(store.clearOnRow(20)).toEqual(false);
+    expect(store.delete).not.toHaveBeenCalled();
+
+    expect(store.clearOnRow(5)).toEqual(true);
+    expect(store.delete).toHaveBeenCalledWith(1);
+  });
+});

--- a/types/atom.js.flow
+++ b/types/atom.js.flow
@@ -953,6 +953,7 @@ declare class atom$TextEditor extends atom$Model {
   // Undocumented Methods
   getDefaultCharWidth(): number,
   getLineHeightInPixels(): number,
+  getEditorWidthInChars(): number,
   moveToTop(): void,
   tokenForBufferPosition(position: atom$Point | [?number, ?number]): atom$Token,
   onDidConflict(callback: () => void): IDisposable,


### PR DESCRIPTION
In an attempt at fixing https://github.com/atom/atom/issues/14836 and https://github.com/atom/atom/pull/14844 in Hydrogen using Reacts `onDidUpdate` handler, some refactors where necessary.

This moves all the marker handling to `store/markers.js` and adds tests for it.
All storage is now handled by `store/` which means we can move functionality out of `main.js` into separate files. This makes it possible to better test the codebase.