### PR TITLE
Update Plugin API

### DIFF
--- a/lib/kernel.js
+++ b/lib/kernel.js
@@ -90,12 +90,32 @@ export default class Kernel {
     throw new Error("Kernel: restart method not implemented");
   }
 
-  execute(code: string, onResults: Function) {
-    throw new Error("Kernel: execute method not implemented");
+  _execute(code: string, callWatches: boolean, onResults: ?Function) {
+    throw new Error("Kernel: _execute method not implemented");
   }
 
-  executeWatch(code: string, onResults: Function) {
-    throw new Error("Kernel: executeWatch method not implemented");
+  executeMaybeWatch(code: string, callWatches: boolean, onResults: ?Function) {
+    let cancelled = false;
+    this.emitter.emit("will-execute", {
+      code: code,
+      callWatches: callWatches,
+      onResults: onResults,
+      cancel: () => {
+        cancelled = true;
+      }
+    });
+
+    if (!cancelled) {
+      this._execute(code, callWatches, onResults);
+    }
+  }
+
+  execute(code: string, onResults: ?Function) {
+    this.executeMaybeWatch(code, true, onResults);
+  }
+
+  executeWatch(code: string, onResults: ?Function) {
+    this.executeMaybeWatch(code, false, onResults);
   }
 
   complete(code: string, onResults: Function) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,12 +1,6 @@
 /* @flow */
 
-import {
-  Emitter,
-  CompositeDisposable,
-  Disposable,
-  Point,
-  TextEditor
-} from "atom";
+import { CompositeDisposable, Disposable, Point, TextEditor } from "atom";
 
 import _ from "lodash";
 import { autorun } from "mobx";
@@ -56,8 +50,6 @@ const Hydrogen = {
   markerBubbleMap: null,
 
   activate() {
-    this.emitter = new Emitter();
-
     this.markerBubbleMap = {};
 
     let skipLanguageMappingsChange = false;
@@ -204,10 +196,6 @@ const Hydrogen = {
     );
 
     renderDevTools();
-
-    autorun(() => {
-      this.emitter.emit("did-change-kernel", store.kernel);
-    });
   },
 
   deactivate() {

--- a/lib/plugin-api/hydrogen-kernel.js
+++ b/lib/plugin-api/hydrogen-kernel.js
@@ -28,12 +28,56 @@ export default class HydrogenKernel {
   }
 
   /*
+   * The language of the kernel, as specified in its kernelspec
+   */
+  get language(): string {
+    return this._kernel.language;
+  }
+
+  /*
+   * The display name of the kernel, as specified in its kernelspec
+   */
+  get displayName(): string {
+    return this._kernel.displayName;
+  }
+
+  /*
    * Calls your callback when the kernel has been destroyed.
    * @param {Function} Callback
    */
   onDidDestroy(callback: Function): void {
     this._assertNotDestroyed();
     this._kernel.emitter.on("did-destroy", callback);
+  }
+
+  /*
+   * Calls your callback when the kernel is about to execute code.
+   * @param {Function} Callback. Receives a single event object with the following keys:
+   *   * code {string}: code to be executed
+   *   * callWatches {boolean}: if true, this execution is user-initiated and will
+   *       trigger watches.
+   *   * onResults {?Function}: Note that the signature of this function should
+   *       not be considered a part of the public plugin API and is subject to
+   *       change without notice. It is provided only for passing to execute()
+   *   * cancel {Function}: call this to cancel execution of the given code.
+   */
+  onWillExecute(callback: Function): void {
+    this._assertNotDestroyed();
+    this._kernel.emitter.on("will-execute", callback);
+  }
+
+  /*
+   * Executes code in the kernel
+   * @param {string} code. Code to be executed
+   * @param {boolean} callWatches. If true, this execution is treated as a
+   *   user-initiated event and will trigger watches.
+   * @param {?Function} onResults. Note that the signature of this function should
+   *   not be considered a part of the public plugin API and is subject to change
+   *   without notice. You can, however, pass in functions received from onWillExecute
+   */
+  execute(code: string, callWatches: boolean, onResults: ?Function): void {
+    this._assertNotDestroyed();
+    this._kernel.executeMaybeWatch(code, callWatches, onResults);
   }
 
   /*

--- a/lib/plugin-api/hydrogen-provider.js
+++ b/lib/plugin-api/hydrogen-provider.js
@@ -1,5 +1,7 @@
 /* @flow */
 
+import { reaction } from "mobx";
+
 import store from "./../store";
 import type Kernel from "./../kernel";
 import type ZMQKernel from "./../zmq-kernel.js";
@@ -19,11 +21,9 @@ import type ZMQKernel from "./../zmq-kernel.js";
  */
 export default class HydrogenProvider {
   _hydrogen: any;
-  _happy: boolean;
 
   constructor(_hydrogen: any) {
     this._hydrogen = _hydrogen;
-    this._happy = true;
   }
 
   /*
@@ -31,12 +31,32 @@ export default class HydrogenProvider {
    * @param {Function} Callback
    */
   onDidChangeKernel(callback: Function) {
-    this._hydrogen.emitter.on("did-change-kernel", (kernel: ?Kernel) => {
-      if (kernel) {
-        return callback(kernel.getPluginWrapper());
+    reaction(
+      () => store.kernel,
+      kernel => {
+        if (kernel) {
+          return callback(kernel.getPluginWrapper());
+        }
+        return callback(null);
       }
-      return callback(null);
-    });
+    );
+  }
+
+  /*
+   * Calls your callback whenever a kernel has been newly created or connected to.
+   * @param {Function} Callback
+   */
+  onDidCreateKernel(callback: Function) {
+    reaction(
+      () => store.newKernelEvent,
+      () => {
+        const kernel = store.kernel;
+        if (kernel) {
+          return callback(kernel.getPluginWrapper());
+        }
+        return callback(null);
+      }
+    );
   }
 
   /*

--- a/lib/store/index.js
+++ b/lib/store/index.js
@@ -15,6 +15,10 @@ class Store {
   @observable editor = atom.workspace.getActiveTextEditor();
   @observable grammar: ?atom$Grammar;
 
+  // XXX(nikita): I can't find a way to create a stateless event signal in mobx,
+  // so I'm resorting to toggling a boolean whenever a new kernel is created.
+  @observable newKernelEvent: boolean = false;
+
   @computed
   get kernel(): ?Kernel {
     for (let kernel of this.runningKernels.values()) {
@@ -38,6 +42,8 @@ class Store {
     this.runningKernels.set(mappedLanguage, kernel);
     // delete startingKernel since store.kernel now in place to prevent duplicate kernel
     this.startingKernels.delete(kernel.kernelSpec.display_name);
+    // This hack signals to the plugin API that a new kernel has been created
+    this.newKernelEvent = !this.newKernelEvent;
   }
 
   @action

--- a/lib/ws-kernel.js
+++ b/lib/ws-kernel.js
@@ -34,7 +34,7 @@ export default class WSKernel extends Kernel {
     });
   }
 
-  _execute(code: string, callWatches: boolean, onResults: Function) {
+  _execute(code: string, callWatches: boolean, onResults: ?Function) {
     const future = this.session.kernel.requestExecute({ code });
 
     future.onIOPub = (message: Message) => {
@@ -74,14 +74,6 @@ export default class WSKernel extends Kernel {
 
       inputView.attach();
     };
-  }
-
-  execute(code: string, onResults: Function) {
-    this._execute(code, true, onResults);
-  }
-
-  executeWatch(code: string, onResults: Function) {
-    this._execute(code, false, onResults);
   }
 
   complete(code: string, onResults: Function) {

--- a/lib/zmq-kernel.js
+++ b/lib/zmq-kernel.js
@@ -197,7 +197,18 @@ export default class ZMQKernel extends Kernel {
 
   // onResults is a callback that may be called multiple times
   // as results come in from the kernel
-  _execute(code: string, requestId: string, onResults: ?Function) {
+  _execute(code: string, callWatches: boolean, onResults: ?Function) {
+    log("Kernel._execute:", code, callWatches);
+
+    // Note that onIOMessage uses the requestId prefix to determine if watches
+    // should be run or not.
+    let requestId;
+    if (callWatches) {
+      requestId = `execute_${v4()}`;
+    } else {
+      requestId = `watch_${v4()}`;
+    }
+
     const message = this._createMessage("execute_request", requestId);
 
     message.content = {
@@ -211,20 +222,6 @@ export default class ZMQKernel extends Kernel {
     this.executionCallbacks[requestId] = onResults;
 
     this.shellSocket.send(new Message(message));
-  }
-
-  execute(code: string, onResults: ?Function) {
-    log("Kernel.execute:", code);
-
-    const requestId = `execute_${v4()}`;
-    this._execute(code, requestId, onResults);
-  }
-
-  executeWatch(code: string, onResults: Function) {
-    log("Kernel.executeWatch:", code);
-
-    const requestId = `watch_${v4()}`;
-    this._execute(code, requestId, onResults);
   }
 
   complete(code: string, onResults: Function) {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     },
     "hydrogen.provider": {
       "versions": {
-        "1.0.0": "provideHydrogen"
+        "1.1.0": "provideHydrogen"
       }
     }
   },


### PR DESCRIPTION
This is a first step towards making the plugin API more generally useful.

The sample plugin I have in mind is to address #862. The idea is to fix indentation when python code is run: if all lines in the code being run start with identical whitespace, the plugin should strip off that whitespace and run the unindented code instead. As a first step I've created a [plugin](https://github.com/nikitakit/hydrogen-python) that simply prepends a print statement to all python code run (I haven't written the actual whitespace transformation yet because I spent most of today on these plugin API updates).

To implement this plugin the following new features need to be added to the plugin API:
* Detecting when code is about to be executed
* Modifying code to be executed (I have decided to break this up into cancelling the original execution event, followed by issuing a new one from the plugin itself)
* Detecting when a new kernel is created (because listeners for kernel execution should only be attached once)
* Knowing the language of a running kernel

The original plugin implementation relied on atom's Emitters to trigger events for plugin use. Implementing `onDidChangeKernel` and future plugin updates would have required expanding Emitter usage -- but by now hydrogen is already using mobx. So along the way I decided to get rid of one usage of Emitter in favor of hooking into mobx.

Note that I'm not familiar with all of the fancy tools like prettier and flow that have been added to the project, so no idea if this code will pass lint.