### PR TITLE
Display empty message in output view if no kernel running

### DIFF
--- a/lib/components/output-area.js
+++ b/lib/components/output-area.js
@@ -9,10 +9,19 @@ import { OUTPUT_AREA_URI } from "./../utils";
 
 import typeof store from "../store";
 
+function EmptyMessage() {
+  return (
+    <div>
+      <ul className="background-message centered">
+        <li>No output to display</li>
+      </ul>
+    </div>
+  );
+}
+
 const OutputArea = observer(({ store: { kernel } }: { store: store }) => {
   if (!kernel) {
-    atom.workspace.hide(OUTPUT_AREA_URI);
-    return null;
+    return <EmptyMessage />;
   }
   return (
     <div className="sidebar output-area">
@@ -30,9 +39,7 @@ const OutputArea = observer(({ store: { kernel } }: { store: store }) => {
           >
             Clear
           </div>
-        : <ul className="background-message centered">
-            <li>No output to display</li>
-          </ul>}
+        : <EmptyMessage />}
       <History store={kernel.outputStore} />
     </div>
   );


### PR DESCRIPTION
I prefer the right dock to stay open even if I switch to a file w/o a kernel running. In this PR we just display an empty message if no kernel so you can still keep your dock open for other purposes e.g. git integration.

I suppose this is a matter of preference, what do you think?

![keep-dock-open mp4](https://user-images.githubusercontent.com/10860657/27501892-d9ffebd2-5835-11e7-9d80-7384ed44f3bd.gif)
