### PR TITLE
Only focus output area if necessary

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -346,8 +346,17 @@ const Hydrogen = {
       if (globalOutputStore) {
         globalOutputStore.appendOutput(result);
 
-        await atom.workspace.open(OUTPUT_AREA_URI, { searchAllPanes: true });
-        focus(store.editor);
+        if (store.kernel !== kernel) return;
+
+        const container = atom.workspace.paneContainerForURI(OUTPUT_AREA_URI);
+        const pane = atom.workspace.paneForURI(OUTPUT_AREA_URI);
+        if (
+          (container && container.isVisible && !container.isVisible()) ||
+          (pane && pane.itemForURI(OUTPUT_AREA_URI) !== pane.getActiveItem())
+        ) {
+          await atom.workspace.open(OUTPUT_AREA_URI, { searchAllPanes: true });
+          focus(store.editor);
+        }
       }
     });
   },

--- a/types/atom.js.flow
+++ b/types/atom.js.flow
@@ -1159,9 +1159,10 @@ declare class atom$Workspace {
   getActivePane(): atom$Pane,
   activateNextPane(): boolean,
   activatePreviousPane(): boolean,
-  paneForURI(uri: string): atom$Pane,
+  paneForURI(uri: string): ?atom$Pane,
   paneForItem(item: mixed): ?atom$Pane,
   paneContainerForItem(item: mixed): ?atom$Dock | ?atom$WorkspaceCenter,
+  paneContainerForURI(uri: string): ?atom$Dock | ?atom$WorkspaceCenter,
 
   // Panels
   getBottomPanels(): Array<atom$Panel>,


### PR DESCRIPTION
This prevents unnecessary focusing of the external output area.

Previously when receiving results in rapid succession (for example with a progress bar) using the command palette wasn't possibly since it was unfocused once new outputs arrive.

We could make the focusing behavior customizable with the same setting introduced by @BenRussert in #893.