### PR TITLE
Revert "Fix Travis for Atom 1.19 beta"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,3 @@ env:
   matrix:
     - ATOM_CHANNEL=stable
     - ATOM_CHANNEL=beta
-
-addons:
-  apt:
-    sources:
-    - ubuntu-toolchain-r-test
-    packages:
-    - g++-6


### PR DESCRIPTION
This reverts commit bbaaaf8b87af682a1ef843ebc51169d92ee0d5d4.

Since Atom 1.19-beta2 this isn't necessary anymore