### PR TITLE
Revert "fix(package): update @jupyterlab/services to version 0.46.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     ]
   },
   "dependencies": {
-    "@jupyterlab/services": "^0.46.0",
+    "@jupyterlab/services": "^0.42.0",
     "@nteract/commutable": "^1.1.4",
     "@nteract/display-area": "^1.3.1",
     "@nteract/transform-plotly": "^1.2.0",


### PR DESCRIPTION
I just tried to connect to a remote kernel on `master`. Since #879 this is broken.

I don't have time to look into that right now, so this PR reverts the commit until one finds time to look at the changes in `@jupyterlab/services`.