### PR TITLE
Fix typo

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -6,7 +6,7 @@
   * [Getting Started](docs/Usage/GettingStarted.md)
   * [Examples](docs/Usage/Examples.md)
   * [Remote Kernels](docs/Usage/RemoteKernelConnection.md)
-  * [Custom Kernel Connction (deprecated)](docs/Usage/CustomKernelConnection.md)
+  * [Custom Kernel Connection (deprecated)](docs/Usage/CustomKernelConnection.md)
 * [Troubleshooting Guide](docs/Troubleshooting.md)
 * [Style Customization](docs/StyleCustomization.md)
 * [Plugin API](docs/PluginAPI.md)


### PR DESCRIPTION
Just a quick fix, nothing to see here. Actually, we should probably start talking about when we will remove all the deprecated kernel connection code from the repo.