### PR TITLE
Enable/disable logging without reload

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -82,6 +82,16 @@ const Hydrogen = {
     );
 
     store.subscriptions.add(
+      atom.config.onDidChange("Hydrogen.debug", ({ newValue, oldValue }) => {
+        try {
+          require("mobx-react-devtools").setLogEnabled(newValue);
+        } catch (e) {
+          log("Could not enable dev tools", e);
+        }
+      })
+    );
+
+    store.subscriptions.add(
       atom.commands.add("atom-text-editor:not([mini])", {
         "hydrogen:run": () => this.run(),
         "hydrogen:run-all": () => this.runAll(),

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -121,12 +121,14 @@ export function log(...message: Array<any>) {
 }
 
 export function renderDevTools() {
-  if (atom.config.get("Hydrogen.debug")) {
+  const logEnabled = atom.config.get("debug");
+
+  if (logEnabled) {
     try {
       const devTools = require("mobx-react-devtools");
       const div = document.createElement("div");
       document.getElementsByTagName("body")[0].appendChild(div);
-      devTools.setLogEnabled(true);
+      devTools.setLogEnabled(logEnabled);
       ReactDOM.render(<devTools.default noPanel />, div);
     } catch (e) {
       log("Could not enable dev tools", e);


### PR DESCRIPTION
Follow up to #874, all logging can be toggled via config w/o restarting atom.