### PR TITLE
Hide open-in-editor, use ctrl-click instead

### DIFF
--- a/lib/components/result-view/result-view.js
+++ b/lib/components/result-view/result-view.js
@@ -3,7 +3,7 @@
 import { CompositeDisposable } from "atom";
 import React from "react";
 import { observer } from "mobx-react";
-import { action, observable, toJS } from "mobx";
+import { action, observable, toJS, computed } from "mobx";
 import Display, {
   DEFAULT_SCROLL_HEIGHT
 } from "@nteract/display-area/lib/display";
@@ -28,10 +28,29 @@ class ResultViewComponent extends React.Component {
   containerTooltip = new CompositeDisposable();
   buttonTooltip = new CompositeDisposable();
   expanded: IObservableValue<boolean> = observable(false);
+  ctrlHovering: IObservableValue<boolean> = observable(false);
 
   getAllText = () => {
     if (!this.el) return "";
     return this.el.innerText ? this.el.innerText.trim() : "";
+  };
+
+  handleClick = (event: MouseEvent) => {
+    if (this.ctrlHovering.get()) {
+      this.openInEditor();
+    } else {
+      this.copyToClipboard();
+    }
+  };
+
+  @action
+  handleButtonMouseOver = (event: MouseEvent) => {
+    this.ctrlHovering.set(event.ctrlKey || event.metaKey);
+  };
+
+  @action
+  handleButtonMouseLeave = (event: MouseEvent) => {
+    this.ctrlHovering.set(false);
   };
 
   copyToClipboard = () => {
@@ -45,11 +64,20 @@ class ResultViewComponent extends React.Component {
 
   addCopyTooltip = (element: ?HTMLElement, comp: atom$CompositeDisposable) => {
     if (!element || !comp.disposables || comp.disposables.size > 0) return;
+
+    // the title argument to tooltips.add is a function that returns the title
     comp.add(
       atom.tooltips.add(element, {
-        title: this.props.store.executionCount
-          ? `Copy to clipboard (Out[${this.props.store.executionCount}])`
-          : "Copy to clipboard"
+        title: () => {
+          const titleText = this.ctrlHovering.get()
+            ? "Copy output into new editor"
+            : "Copy to clipboard";
+
+          const executionCount = this.props.store.executionCount;
+          return executionCount
+            ? `${titleText}(Out[${executionCount}])`
+            : titleText;
+        }
       })
     );
   };
@@ -141,13 +169,13 @@ class ResultViewComponent extends React.Component {
               <div className="icon icon-x" onClick={this.props.destroy} />
               <div style={{ flex: 1, minHeight: "0.25em" }} />
               <div
-                className="icon icon-clippy"
-                onClick={this.copyToClipboard}
+                className={`icon ${this.ctrlHovering.get()
+                  ? "icon-file-symlink-file"
+                  : "icon-clippy"}`}
+                onClick={this.handleClick}
+                onMouseLeave={this.handleButtonMouseLeave}
+                onMouseOver={this.handleButtonMouseOver}
                 ref={this.addCopyButtonTooltip}
-              />
-              <div
-                className="icon icon-file-symlink-file"
-                onClick={this.openInEditor}
               />
               {this.el && this.el.scrollHeight > DEFAULT_SCROLL_HEIGHT
                 ? <div

--- a/types/atom.js.flow
+++ b/types/atom.js.flow
@@ -649,8 +649,10 @@ declare class atom$ThemeManager {
 
 type atom$TooltipsPlacementOption = 'top' | 'bottom' | 'left' | 'right' | 'auto';
 
+// https://atom.io/docs/api/v1.18.0/TooltipManager#instance-add
+// if `title` is a function, `this` will be bound to the tooltip target element
 type atom$TooltipsAddOptions = {
-  title: string,
+  title: string | () => string,
   keyBindingCommand?: string,
   keyBindingTarget?: HTMLElement,
   animation?: boolean,


### PR DESCRIPTION
See #797. 

I could not figure out how to trigger this with `onkeydown` if I was already hovering and just press `ctrl`. So you have to hold ctrl while you mouseover to trigger.

![ctrl-click-open mp4](https://user-images.githubusercontent.com/10860657/28648990-3ed9c878-7237-11e7-9353-54cafd259cd9.gif)


It works pretty well for me other than that. Hoping to get some feedback!

Closes #797 