### PR TITLE
Hide open in editor (simple version)

### DIFF
--- a/lib/components/result-view/result-view.js
+++ b/lib/components/result-view/result-view.js
@@ -56,8 +56,9 @@ class ResultViewComponent extends React.Component {
     comp.add(
       atom.tooltips.add(element, {
         title: this.props.store.executionCount
-          ? `Copy to clipboard (Out[${this.props.store.executionCount}])`
-          : "Copy to clipboard"
+          ? `Click to copy, ctrl/cmd click to open in editor (Out[${this.props
+              .store.executionCount}])`
+          : "Click to copy, ctrl click to open in editor"
       })
     );
   };

--- a/lib/components/result-view/result-view.js
+++ b/lib/components/result-view/result-view.js
@@ -55,10 +55,16 @@ class ResultViewComponent extends React.Component {
     if (!element || !comp.disposables || comp.disposables.size > 0) return;
     comp.add(
       atom.tooltips.add(element, {
-        title: this.props.store.executionCount
-          ? `Click to copy, ctrl/cmd click to open in editor (Out[${this.props
-              .store.executionCount}])`
-          : "Click to copy, ctrl click to open in editor"
+        title: () => {
+          const ctrlOrCmdMessage = `Click to copy,
+          ${process.platform === "darwin"
+            ? "Cmd"
+            : "Ctrl"}+Click to open in editor`;
+
+          return this.props.store.executionCount
+            ? `${ctrlOrCmdMessage} (Out[${this.props.store.executionCount}])`
+            : ctrlOrCmdMessage;
+        }
       })
     );
   };

--- a/lib/components/result-view/result-view.js
+++ b/lib/components/result-view/result-view.js
@@ -34,6 +34,14 @@ class ResultViewComponent extends React.Component {
     return this.el.innerText ? this.el.innerText.trim() : "";
   };
 
+  handleClick = (event: MouseEvent) => {
+    if (event.ctrlKey || event.metaKey) {
+      this.openInEditor();
+    } else {
+      this.copyToClipboard();
+    }
+  };
+
   copyToClipboard = () => {
     atom.clipboard.write(this.getAllText());
     atom.notifications.addSuccess("Copied to clipboard");
@@ -142,12 +150,8 @@ class ResultViewComponent extends React.Component {
               <div style={{ flex: 1, minHeight: "0.25em" }} />
               <div
                 className="icon icon-clippy"
-                onClick={this.copyToClipboard}
+                onClick={this.handleClick}
                 ref={this.addCopyButtonTooltip}
-              />
-              <div
-                className="icon icon-file-symlink-file"
-                onClick={this.openInEditor}
               />
               {this.el && this.el.scrollHeight > DEFAULT_SCROLL_HEIGHT
                 ? <div

--- a/types/atom.js.flow
+++ b/types/atom.js.flow
@@ -650,7 +650,7 @@ declare class atom$ThemeManager {
 type atom$TooltipsPlacementOption = 'top' | 'bottom' | 'left' | 'right' | 'auto';
 
 type atom$TooltipsAddOptions = {
-  title: string,
+  title: string | () => string,
   keyBindingCommand?: string,
   keyBindingTarget?: HTMLElement,
   animation?: boolean,


### PR DESCRIPTION
This is much cleaner if we are not worried about the icon switching.

I am not crazy about the way the tooltip message looks, open to suggestions on that (or anything else)

![simple-ctrl-click mp4](https://user-images.githubusercontent.com/10860657/29197641-aa08a868-7e02-11e7-9346-f6802421d673.gif)

