### PR TITLE
Ctrl-click open in editor for inline results

### DIFF
--- a/lib/components/result-view/result-view.js
+++ b/lib/components/result-view/result-view.js
@@ -118,7 +118,7 @@ class ResultViewComponent extends React.Component {
     return (
       <div
         className={isPlain ? "inline-container" : "multiline-container"}
-        onClick={isPlain ? this.copyToClipboard : false}
+        onClick={isPlain ? this.handleClick : false}
         style={
           isPlain
             ? inlineStyle


### PR DESCRIPTION
This probably should have been part of #941, it just uses `handleClick` so that the tooltip text makes sense and you can copy or export in editor.