### PR TITLE
Only show copy button if there is text to copy

### DIFF
--- a/lib/components/result-view/result-view.js
+++ b/lib/components/result-view/result-view.js
@@ -27,6 +27,7 @@ class ResultViewComponent extends React.Component {
   el: ?HTMLElement;
   containerTooltip = new CompositeDisposable();
   buttonTooltip = new CompositeDisposable();
+  closeTooltip = new CompositeDisposable();
   expanded: IObservableValue<boolean> = observable(false);
 
   getAllText = () => {
@@ -55,16 +56,24 @@ class ResultViewComponent extends React.Component {
     if (!element || !comp.disposables || comp.disposables.size > 0) return;
     comp.add(
       atom.tooltips.add(element, {
-        title: () => {
-          const ctrlOrCmdMessage = `Click to copy,
+        title: `Click to copy,
           ${process.platform === "darwin"
             ? "Cmd"
-            : "Ctrl"}+Click to open in editor`;
+            : "Ctrl"}+Click to open in editor`
+      })
+    );
+  };
 
-          return this.props.store.executionCount
-            ? `${ctrlOrCmdMessage} (Out[${this.props.store.executionCount}])`
-            : ctrlOrCmdMessage;
-        }
+  addCloseButtonTooltip = (
+    element: ?HTMLElement,
+    comp: atom$CompositeDisposable
+  ) => {
+    if (!element || !comp.disposables || comp.disposables.size > 0) return;
+    comp.add(
+      atom.tooltips.add(element, {
+        title: this.props.store.executionCount
+          ? `Close (Out[${this.props.store.executionCount}])`
+          : "Close result"
       })
     );
   };
@@ -153,7 +162,12 @@ class ResultViewComponent extends React.Component {
         {isPlain
           ? null
           : <div className="toolbar">
-              <div className="icon icon-x" onClick={this.props.destroy} />
+              <div
+                className="icon icon-x"
+                onClick={this.props.destroy}
+                ref={ref => this.addCloseButtonTooltip(ref, this.closeTooltip)}
+              />
+
               <div style={{ flex: 1, minHeight: "0.25em" }} />
 
               {this.getAllText().length > 0
@@ -202,6 +216,7 @@ class ResultViewComponent extends React.Component {
   componentWillUnmount() {
     this.containerTooltip.dispose();
     this.buttonTooltip.dispose();
+    this.closeTooltip.dispose();
   }
 }
 

--- a/lib/components/result-view/result-view.js
+++ b/lib/components/result-view/result-view.js
@@ -155,11 +155,15 @@ class ResultViewComponent extends React.Component {
           : <div className="toolbar">
               <div className="icon icon-x" onClick={this.props.destroy} />
               <div style={{ flex: 1, minHeight: "0.25em" }} />
-              <div
-                className="icon icon-clippy"
-                onClick={this.handleClick}
-                ref={this.addCopyButtonTooltip}
-              />
+
+              {this.getAllText().length > 0
+                ? <div
+                    className="icon icon-clippy"
+                    onClick={this.handleClick}
+                    ref={this.addCopyButtonTooltip}
+                  />
+                : null}
+
               {this.el && this.el.scrollHeight > DEFAULT_SCROLL_HEIGHT
                 ? <div
                     className={`icon icon-${this.expanded.get()


### PR DESCRIPTION
This is one of the open items in #796. If there is no `innerText` to copy the copy icon should not show in the result view toolbar.

Since there won't always be an export button anymore, i've also moved the execution count display to a close button tooltip.

~~I tagged as wip because this seems to break the expand button, but wanted to open anyway since im running out of weekend! Free emoji waiting for you if you find the bug.~~ Edit: I dont think this pr has the issue, but I am not sure the expand button is working correctly (possibly just on my machine and possibly only as of atom 1.19, I have the same issue on hydrogen v1.19 release)

![no-copy-if-no-innertext](https://user-images.githubusercontent.com/10860657/29253709-e0ee52c0-804a-11e7-8b3b-7676424ff19c.png)

New tooltip:
![close-button-tooltip](https://user-images.githubusercontent.com/10860657/29253781-e6bbbf16-804b-11e7-9a08-affb78480eb8.png)
