### PR TITLE
Added copy to clipboard button to external output area

### DIFF
--- a/lib/components/output-area.js
+++ b/lib/components/output-area.js
@@ -4,7 +4,6 @@ import { CompositeDisposable } from "atom";
 import React from "react";
 import { observer } from "mobx-react";
 import { toJS } from "mobx";
-import _ from "lodash";
 
 import History from "./result-view/history";
 import { OUTPUT_AREA_URI } from "./../utils";
@@ -17,11 +16,6 @@ const EmptyMessage = () => {
       <li>No output to display</li>
     </ul>
   );
-};
-
-const buttonStyle = {
-  flex: "0 0 auto",
-  width: "fit-content"
 };
 
 const OutputArea = observer(({ store: { kernel } }: { store: store }) => {
@@ -39,11 +33,13 @@ const OutputArea = observer(({ store: { kernel } }: { store: store }) => {
     //convert output to a plain js object
     const output = toJS(kernel.outputStore.outputs[kernel.outputStore.index]);
     // check for a text property and fall back to data["text/plain"]
-    const textOrBundle = _.has(output, "text")
-      ? output.text
-      : output.data["text/plain"];
-    atom.clipboard.write(textOrBundle);
-    atom.notifications.addSuccess("Copied to clipboard");
+    const textOrBundle = output.text || output.data["text/plain"];
+    if (textOrBundle) {
+      atom.clipboard.write(textOrBundle);
+      atom.notifications.addSuccess("Copied to clipboard");
+    } else {
+      atom.notifications.addWarning("Nothing to copy");
+    }
   };
 
   return (
@@ -53,20 +49,17 @@ const OutputArea = observer(({ store: { kernel } }: { store: store }) => {
           style={{
             left: "100%",
             transform: "translateX(-100%)",
-            position: "relative"
+            position: "relative",
+            flex: "0 0 auto",
+            width: "fit-content"
           }}
         >
-          <div
-            className="btn icon icon-clippy"
-            onClick={handleClick}
-            style={{ buttonStyle }}
-          >
+          <div className="btn icon icon-clippy" onClick={handleClick}>
             Copy
           </div>
           <div
             className="btn icon icon-trashcan"
             onClick={kernel.outputStore.clear}
-            style={{ buttonStyle }}
           >
             Clear
           </div>

--- a/lib/components/output-area.js
+++ b/lib/components/output-area.js
@@ -3,6 +3,8 @@
 import { CompositeDisposable } from "atom";
 import React from "react";
 import { observer } from "mobx-react";
+import { toJS } from "mobx"; 
+import _ from "lodash"; 
 
 import History from "./result-view/history";
 import { OUTPUT_AREA_URI } from "./../utils";
@@ -17,6 +19,11 @@ const EmptyMessage = () => {
   );
 };
 
+const buttonStyle = {
+  flex: "0 0 auto",
+  width: "fit-content"
+};
+
 const OutputArea = observer(({ store: { kernel } }: { store: store }) => {
   if (!kernel) {
     if (atom.config.get("Hydrogen.outputAreaDock")) {
@@ -27,21 +34,41 @@ const OutputArea = observer(({ store: { kernel } }: { store: store }) => {
     }
   }
 
+  const handleClick = () => {
+    if (!kernel || !kernel.outputStore) return;
+    //convert output to a plain js object
+    const output = toJS(kernel.outputStore.outputs[kernel.outputStore.index]);
+    // check for a text property and fall back to data["text/plain"]
+    const textOrBundle = _.has(output, "text")
+      ? output.text
+      : output.data["text/plain"];
+    atom.clipboard.write(textOrBundle);
+    atom.notifications.addSuccess("Copied to clipboard");
+  };
+
   return (
     <div className="sidebar output-area">
       {kernel.outputStore.outputs.length > 0 ? (
-        <div
-          className="btn icon icon-trashcan"
-          onClick={kernel.outputStore.clear}
-          style={{
+        <div style={{
             left: "100%",
             transform: "translateX(-100%)",
             position: "relative",
-            flex: "0 0 auto",
-            width: "fit-content"
-          }}
+            }}
+        >
+        <div
+          className="btn icon icon-clippy"
+          onClick={handleClick}
+          style={{buttonStyle}}
+        >
+          Copy
+        </div>
+        <div
+          className="btn icon icon-trashcan"
+          onClick={kernel.outputStore.clear}
+          style={{buttonStyle}}
         >
           Clear
+        </div>
         </div>
       ) : (
         <EmptyMessage />

--- a/lib/components/output-area.js
+++ b/lib/components/output-area.js
@@ -59,25 +59,26 @@ const OutputArea = observer(({ store: { kernel } }: { store: store }) => {
           <div
             className="btn icon icon-clippy"
             onClick={function() {
-              atom.clipboard.write(
-                kernel.outputStore.outputs[kernel.outputStore.index].text.trim()
+              if (!kernel || !kernel.outputStore) return;
+              // output should be converted to a plain js object first:
+              const output = toJS(
+                kernel.outputStore.outputs[kernel.outputStore.index]
               );
+              const textOrBundle = _.has(output, "text")
+                ? output.text
+                : output.data["text/plain"];
+
+              atom.clipboard.write(textOrBundle);
               atom.notifications.addSuccess("Copied to clipboard");
             }}
-            style={{
-              flex: "0 0 auto",
-              width: "fit-content"
-            }}
+            style={{ buttonStyle }}
           >
             Copy
           </div>
           <div
             className="btn icon icon-trashcan"
             onClick={kernel.outputStore.clear}
-            style={{
-              flex: "0 0 auto",
-              width: "fit-content"
-            }}
+            style={{ buttonStyle }}
           >
             Clear
           </div>

--- a/lib/components/output-area.js
+++ b/lib/components/output-area.js
@@ -3,8 +3,8 @@
 import { CompositeDisposable } from "atom";
 import React from "react";
 import { observer } from "mobx-react";
-import { toJS } from "mobx"; 
-import _ from "lodash"; 
+import { toJS } from "mobx";
+import _ from "lodash";
 
 import History from "./result-view/history";
 import { OUTPUT_AREA_URI } from "./../utils";
@@ -49,26 +49,38 @@ const OutputArea = observer(({ store: { kernel } }: { store: store }) => {
   return (
     <div className="sidebar output-area">
       {kernel.outputStore.outputs.length > 0 ? (
-        <div style={{
+        <div
+          style={{
             left: "100%",
             transform: "translateX(-100%)",
-            position: "relative",
+            position: "relative"
+          }}
+        >
+          <div
+            className="btn icon icon-clippy"
+            onClick={function() {
+              atom.clipboard.write(
+                kernel.outputStore.outputs[kernel.outputStore.index].text.trim()
+              );
+              atom.notifications.addSuccess("Copied to clipboard");
             }}
-        >
-        <div
-          className="btn icon icon-clippy"
-          onClick={handleClick}
-          style={{buttonStyle}}
-        >
-          Copy
-        </div>
-        <div
-          className="btn icon icon-trashcan"
-          onClick={kernel.outputStore.clear}
-          style={{buttonStyle}}
-        >
-          Clear
-        </div>
+            style={{
+              flex: "0 0 auto",
+              width: "fit-content"
+            }}
+          >
+            Copy
+          </div>
+          <div
+            className="btn icon icon-trashcan"
+            onClick={kernel.outputStore.clear}
+            style={{
+              flex: "0 0 auto",
+              width: "fit-content"
+            }}
+          >
+            Clear
+          </div>
         </div>
       ) : (
         <EmptyMessage />

--- a/lib/components/output-area.js
+++ b/lib/components/output-area.js
@@ -19,7 +19,7 @@ const EmptyMessage = () => {
 };
 
 const OutputArea = observer(({ store: { kernel } }: { store: store }) => {
-  if (!kernel || !kernel.outputStore) {
+  if (!kernel) {
     if (atom.config.get("Hydrogen.outputAreaDock")) {
       return <EmptyMessage />;
     } else {

--- a/lib/components/output-area.js
+++ b/lib/components/output-area.js
@@ -25,7 +25,7 @@ const buttonStyle = {
 };
 
 const OutputArea = observer(({ store: { kernel } }: { store: store }) => {
-  if (!kernel) {
+  if (!kernel || !kernel.outputStore) {
     if (atom.config.get("Hydrogen.outputAreaDock")) {
       return <EmptyMessage />;
     } else {
@@ -58,19 +58,7 @@ const OutputArea = observer(({ store: { kernel } }: { store: store }) => {
         >
           <div
             className="btn icon icon-clippy"
-            onClick={function() {
-              if (!kernel || !kernel.outputStore) return;
-              // output should be converted to a plain js object first:
-              const output = toJS(
-                kernel.outputStore.outputs[kernel.outputStore.index]
-              );
-              const textOrBundle = _.has(output, "text")
-                ? output.text
-                : output.data["text/plain"];
-
-              atom.clipboard.write(textOrBundle);
-              atom.notifications.addSuccess("Copied to clipboard");
-            }}
+            onClick={handleClick}
             style={{ buttonStyle }}
           >
             Copy

--- a/lib/store/watches.js
+++ b/lib/store/watches.js
@@ -68,8 +68,7 @@ export default class WatchesStore {
         this.watches.splice(watch.value, 1);
         modalPanel.destroy();
         watchesPicker.destroy();
-	console.log(this.watches.length);
-        if (this.watches.length == 0) this.addWatch();
+        if (this.watches.length === 0) this.addWatch();
         else if (previouslyFocusedElement) previouslyFocusedElement.focus();
       },
       filterKeyForItem: watch => watch.name,

--- a/lib/store/watches.js
+++ b/lib/store/watches.js
@@ -68,7 +68,8 @@ export default class WatchesStore {
         this.watches.splice(watch.value, 1);
         modalPanel.destroy();
         watchesPicker.destroy();
-        if (this.watches.length === 0) this.addWatch();
+	console.log(this.watches.length);
+        if (this.watches.length == 0) this.addWatch();
         else if (previouslyFocusedElement) previouslyFocusedElement.focus();
       },
       filterKeyForItem: watch => watch.name,


### PR DESCRIPTION
Addressed the feature request in #845. Testing using python scripts gives identical functionality to hydrogen without these changes, the only difference being the added copy to clipboard button.
![2017-08-24-16 40 41](https://user-images.githubusercontent.com/20137270/29692007-ad544d16-88e2-11e7-9434-2ce70c43146f.png)
