### PR TITLE
Plugin API: export getCurrentCell and findCodeBlock from codeManager

### DIFF
--- a/docs/PluginAPI.md
+++ b/docs/PluginAPI.md
@@ -30,6 +30,26 @@ Get the `HydrogenKernel` of the currently active text editor.
 
 * **Class** `HydrogenKernel`
 
+## getCellRange()
+
+Get the `atom$Range` that will run if `hydrogen:run-cell` is called.
+`null` is returned if no active text editor.
+
+### Return:
+
+* **Class** `atom$Range`
+
+## getCodeBlockRange()
+
+Get the `atom$Range` that will run if `hydrogen:run` is called.
+`null` is returned if no active text editor.
+
+### Return:
+
+* **Class** `atom$Range`
+
+--------
+
 <!-- End lib/plugin-api/hydrogen-provider.js -->
 
 <!-- Start lib/plugin-api/hydrogen-kernel.js -->

--- a/docs/PluginAPI.md
+++ b/docs/PluginAPI.md
@@ -39,15 +39,6 @@ Get the `atom$Range` that will run if `hydrogen:run-cell` is called.
 
 * **Class** `atom$Range`
 
-## getCodeBlockRange()
-
-Get the `atom$Range` that will run if `hydrogen:run` is called.
-`null` is returned if no active text editor.
-
-### Return:
-
-* **Class** `atom$Range`
-
 --------
 
 <!-- End lib/plugin-api/hydrogen-provider.js -->

--- a/lib/plugin-api/hydrogen-provider.js
+++ b/lib/plugin-api/hydrogen-provider.js
@@ -3,6 +3,7 @@
 import store from "./../store";
 import type Kernel from "./../kernel";
 import type ZMQKernel from "./../zmq-kernel.js";
+import { getCurrentCell, findCodeBlock } from "./../code-manager";
 /**
  * @version 1.0.0
  *
@@ -51,4 +52,28 @@ export default class HydrogenProvider {
 
     return store.kernel.getPluginWrapper();
   }
+
+  /*
+   * Get the `atom$Range` that will run if `hydrogen:run-cell` is called.
+   * `null` is returned if no active text editor.
+   * @return {Class} `atom$Range`
+   */
+  getCellRange() {
+    if (!store.editor) return null;
+    return getCurrentCell(store.editor);
+  }
+
+  /*
+   * Get the `atom$Range` that will run if `hydrogen:run` is called.
+   * `null` is returned if no active text editor.
+   * @return {Class} `atom$Range`
+   */
+  getCodeBlockRange() {
+    if (!store.editor) return null;
+    return findCodeBlock(store.editor);
+  }
+
+  /*
+  *--------
+  */
 }

--- a/lib/plugin-api/hydrogen-provider.js
+++ b/lib/plugin-api/hydrogen-provider.js
@@ -58,7 +58,7 @@ export default class HydrogenProvider {
    * `null` is returned if no active text editor.
    * @return {Class} `atom$Range`
    */
-  getCellRange() {
+  getCellRange(editor: ?atom$TextEditor) {
     if (!store.editor) return null;
     return getCurrentCell(store.editor);
   }

--- a/lib/plugin-api/hydrogen-provider.js
+++ b/lib/plugin-api/hydrogen-provider.js
@@ -3,7 +3,7 @@
 import store from "./../store";
 import type Kernel from "./../kernel";
 import type ZMQKernel from "./../zmq-kernel.js";
-import { getCurrentCell, findCodeBlock } from "./../code-manager";
+import { getCurrentCell } from "./../code-manager";
 /**
  * @version 1.0.0
  *
@@ -61,16 +61,6 @@ export default class HydrogenProvider {
   getCellRange() {
     if (!store.editor) return null;
     return getCurrentCell(store.editor);
-  }
-
-  /*
-   * Get the `atom$Range` that will run if `hydrogen:run` is called.
-   * `null` is returned if no active text editor.
-   * @return {Class} `atom$Range`
-   */
-  getCodeBlockRange() {
-    if (!store.editor) return null;
-    return findCodeBlock(store.editor);
   }
 
   /*

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     },
     "hydrogen.provider": {
       "versions": {
-        "1.0.0": "provideHydrogen"
+        "1.1.0": "provideHydrogen"
       }
     }
   },


### PR DESCRIPTION
I think we can/should export `getCurrentCell` (returns range used in `hydrogen:run-cell`) to the api. This can be done very simply and probably wont take much to maintain.

For example this would enable a package like [hydrogen-show (a work in progress)](https://github.com/BenRussert/hydrogen-show/) to help new users understand what will run  #130, #934, #904. This plugin is a small step for an idea I have to create some sort of tutorial mode for #702 :smile: 

Edit: I will come back to the `findCodeBlock` part later, this doesnt return a range so I'll rethink that in another PR.

hydrogen show example:
![hydrogen-show-demo1 mp4](https://user-images.githubusercontent.com/10860657/29738399-13295a50-89e7-11e7-83f4-c1b4cd38877c.gif)