### PR TITLE
Dont prevent adding a watch even if it is blank, fix #936

### DIFF
--- a/lib/components/watch-sidebar/watch.js
+++ b/lib/components/watch-sidebar/watch.js
@@ -1,11 +1,13 @@
 /* @flow */
 
 import React from "react";
+import { observer } from "mobx-react";
 
 import History from "./../result-view/history";
 import type WatchStore from "./../../store/watch";
 
-export default class Watch extends React.Component {
+@observer
+class Watch extends React.Component {
   props: { store: WatchStore };
   container: HTMLElement;
 
@@ -29,3 +31,5 @@ export default class Watch extends React.Component {
     );
   }
 }
+
+export default Watch;

--- a/lib/main.js
+++ b/lib/main.js
@@ -110,7 +110,8 @@ const Hydrogen = {
         "hydrogen:remove-watch": () => {
           if (store.kernel) {
             store.kernel.watchesStore.removeWatch();
-            atom.workspace.open(WATCHES_URI, { searchAllPanes: true });
+            const dock = atom.workspace.paneContainerForURI(WATCHES_URI);
+            if (dock) dock.show();
           }
         },
         "hydrogen:update-kernels": () => kernelManager.updateKernelSpecs(),

--- a/lib/main.js
+++ b/lib/main.js
@@ -45,7 +45,8 @@ import {
   INSPECTOR_URI,
   WATCHES_URI,
   OUTPUT_AREA_URI,
-  hotReloadPackage
+  hotReloadPackage,
+  openOrShowDock
 } from "./utils";
 
 import type Kernel from "./kernel";
@@ -104,14 +105,13 @@ const Hydrogen = {
         "hydrogen:add-watch": () => {
           if (store.kernel) {
             store.kernel.watchesStore.addWatchFromEditor(store.editor);
-            atom.workspace.open(WATCHES_URI, { searchAllPanes: true });
+            openOrShowDock(WATCHES_URI);
           }
         },
         "hydrogen:remove-watch": () => {
           if (store.kernel) {
             store.kernel.watchesStore.removeWatch();
-            const dock = atom.workspace.paneContainerForURI(WATCHES_URI);
-            if (dock) dock.show();
+            openOrShowDock(WATCHES_URI);
           }
         },
         "hydrogen:update-kernels": () => kernelManager.updateKernelSpecs(),

--- a/lib/store/watch.js
+++ b/lib/store/watch.js
@@ -18,7 +18,8 @@ export default class WatchStore {
     this.editor = new TextEditor({
       softWrapped: true,
       grammar: this.kernel.grammar,
-      lineNumberGutterVisible: false
+      lineNumberGutterVisible: false,
+      placeholderText: `Enter ${kernel.displayName} code`
     });
     this.editor.moveToTop();
     this.editor.element.classList.add("watch-input");

--- a/lib/store/watch.js
+++ b/lib/store/watch.js
@@ -40,7 +40,7 @@ export default class WatchStore {
     this.editor.setText(code);
   };
 
-  getCode = () => {
+  getCode = (): string => {
     return this.editor.getText();
   };
 

--- a/lib/store/watches.js
+++ b/lib/store/watches.js
@@ -65,6 +65,14 @@ export default class WatchesStore {
     const watchPickerItems =
       watches.length > 0 ? [...watches, ...commands] : [];
 
+    const previouslyFocusedElement = document.activeElement;
+
+    const cancelSelection = () => {
+      modalPanel.destroy();
+      if (previouslyFocusedElement) previouslyFocusedElement.focus();
+      watchesPicker.destroy();
+    };
+
     const watchesPicker = new SelectListView({
       // keep commands at bottom to prevent accidental selection
       items: watchPickerItems,
@@ -98,17 +106,15 @@ export default class WatchesStore {
         else if (previouslyFocusedElement) previouslyFocusedElement.focus();
       },
       filterKeyForItem: item => item.name,
-      didCancelSelection: () => {
-        modalPanel.destroy();
-        if (previouslyFocusedElement) previouslyFocusedElement.focus();
-        watchesPicker.destroy();
-      },
+      didCancelSelection: () => cancelSelection(),
+      didConfirmEmptySelection: () => cancelSelection(),
       emptyMessage: "There are no watches to remove!"
     });
-    const previouslyFocusedElement = document.activeElement;
+
     const modalPanel = atom.workspace.addModalPanel({
       item: watchesPicker
     });
+
     watchesPicker.focus();
   };
 

--- a/lib/store/watches.js
+++ b/lib/store/watches.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { action, observable } from "mobx";
+import { action, observable, IObservableArray } from "mobx";
 import SelectListView from "atom-select-list";
 
 import WatchStore from "./watch";
@@ -10,13 +10,12 @@ import typeof store from "./index";
 
 export default class WatchesStore {
   kernel: Kernel;
-  @observable watches: Array<WatchStore> = [];
+  watches: IObservableArray<WatchStore>;
 
   constructor(kernel: Kernel) {
     this.kernel = kernel;
-
+    this.watches = observable([]);
     this.kernel.addWatchCallback(this.run);
-    this.addWatch();
   }
 
   @action
@@ -28,7 +27,7 @@ export default class WatchesStore {
 
   @action
   addWatch = () => {
-    this.createWatch().focus();
+    this.createWatch();
   };
 
   @action
@@ -53,13 +52,11 @@ export default class WatchesStore {
         type: "command"
       }
     ];
-    const watches = this.watches
-      .map((v, k) => ({
-        name: v.getCode(),
-        value: k,
-        type: "watch"
-      }))
-      .filter(obj => obj.value !== 0 || obj.name !== "");
+    const watches = this.watches.map((v, k) => ({
+      name: v.getCode(),
+      value: k,
+      type: "watch"
+    }));
 
     // give empty list if no watches to remove
     const watchPickerItems =
@@ -102,8 +99,7 @@ export default class WatchesStore {
         }
         modalPanel.destroy();
         watchesPicker.destroy();
-        if (this.watches.length === 0) this.addWatch();
-        else if (previouslyFocusedElement) previouslyFocusedElement.focus();
+        if (previouslyFocusedElement) previouslyFocusedElement.focus();
       },
       filterKeyForItem: item => item.name,
       didCancelSelection: () => cancelSelection(),
@@ -125,8 +121,6 @@ export default class WatchesStore {
 
   @action
   removeAll = () => {
-    // always keep one
-    this.watches.splice(1);
-    this.watches[0].setCode("");
+    this.watches.clear();
   };
 }

--- a/lib/store/watches.js
+++ b/lib/store/watches.js
@@ -70,10 +70,18 @@ export default class WatchesStore {
       items: watchPickerItems,
       elementForItem: item => {
         const element = document.createElement("li");
-        element.textContent = item.name || "<empty>";
+        element.textContent =
+          item.type === "watch" ? item.name || "<empty>" : "";
         if (item.type === "command") {
           const div = document.createElement("div");
-          div.classlist.add("icon icon-x");
+          div.classList.add(
+            "primary-line",
+            "status-removed",
+            "icon",
+            "icon-diff-removed"
+          );
+          div.textContent = item.name;
+          element.appendChild(div);
         }
 
         return element;

--- a/lib/store/watches.js
+++ b/lib/store/watches.js
@@ -27,7 +27,7 @@ export default class WatchesStore {
 
   @action
   addWatch = () => {
-    this.createWatch();
+    this.createWatch().focus();
   };
 
   @action
@@ -35,8 +35,11 @@ export default class WatchesStore {
     if (!editor) return;
     const watchText = editor.getSelectedText();
     if (!watchText) {
+      // if no code selected, focus the watch editor to input code there
+      // TODO: make this actually focus the watch editor input with a cursor
       this.addWatch();
     } else {
+      // if adding watch while code selected, add the watch and return to editor
       const watch = this.createWatch();
       watch.setCode(watchText);
       watch.run();
@@ -64,7 +67,7 @@ export default class WatchesStore {
 
     const previouslyFocusedElement = document.activeElement;
 
-    const cancelSelection = () => {
+    const cleanUp = () => {
       modalPanel.destroy();
       if (previouslyFocusedElement) previouslyFocusedElement.focus();
       watchesPicker.destroy();
@@ -97,13 +100,11 @@ export default class WatchesStore {
         } else {
           if (item.name === "Remove All") this.removeAll();
         }
-        modalPanel.destroy();
-        watchesPicker.destroy();
-        if (previouslyFocusedElement) previouslyFocusedElement.focus();
+        cleanUp();
       },
       filterKeyForItem: item => item.name,
-      didCancelSelection: () => cancelSelection(),
-      didConfirmEmptySelection: () => cancelSelection(),
+      didCancelSelection: () => cleanUp(),
+      didConfirmEmptySelection: () => cleanUp(),
       emptyMessage: "There are no watches to remove!"
     });
 

--- a/lib/store/watches.js
+++ b/lib/store/watches.js
@@ -21,13 +21,9 @@ export default class WatchesStore {
 
   @action
   createWatch = () => {
-    const lastWatch = this.watches[this.watches.length - 1];
-    if (!lastWatch || lastWatch.getCode().replace(/\s/g, "") !== "") {
-      const watch = new WatchStore(this.kernel);
-      this.watches.push(watch);
-      return watch;
-    }
-    return lastWatch;
+    const watch = new WatchStore(this.kernel);
+    this.watches.push(watch);
+    return watch;
   };
 
   @action

--- a/lib/store/watches.js
+++ b/lib/store/watches.js
@@ -46,28 +46,50 @@ export default class WatchesStore {
 
   @action
   removeWatch = () => {
+    const commands = [
+      {
+        name: "Remove All",
+        value: -1,
+        type: "command"
+      }
+    ];
     const watches = this.watches
       .map((v, k) => ({
         name: v.getCode(),
-        value: k
+        value: k,
+        type: "watch"
       }))
       .filter(obj => obj.value !== 0 || obj.name !== "");
 
+    // give empty list if no watches to remove
+    const watchPickerItems =
+      watches.length > 0 ? [...watches, ...commands] : [];
+
     const watchesPicker = new SelectListView({
-      items: watches,
-      elementForItem: watch => {
+      // keep commands at bottom to prevent accidental selection
+      items: watchPickerItems,
+      elementForItem: item => {
         const element = document.createElement("li");
-        element.textContent = watch.name || "<empty>";
+        element.textContent = item.name || "<empty>";
+        if (item.type === "command") {
+          const div = document.createElement("div");
+          div.classlist.add("icon icon-x");
+        }
+
         return element;
       },
-      didConfirmSelection: watch => {
-        this.watches.splice(watch.value, 1);
+      didConfirmSelection: item => {
+        if (item.type === "watch") {
+          this.watches.splice(item.value, 1);
+        } else {
+          if (item.name === "Remove All") this.removeAll();
+        }
         modalPanel.destroy();
         watchesPicker.destroy();
         if (this.watches.length === 0) this.addWatch();
         else if (previouslyFocusedElement) previouslyFocusedElement.focus();
       },
-      filterKeyForItem: watch => watch.name,
+      filterKeyForItem: item => item.name,
       didCancelSelection: () => {
         modalPanel.destroy();
         if (previouslyFocusedElement) previouslyFocusedElement.focus();
@@ -85,5 +107,12 @@ export default class WatchesStore {
   @action
   run = () => {
     this.watches.forEach(watch => watch.run());
+  };
+
+  @action
+  removeAll = () => {
+    // always keep one
+    this.watches.splice(1);
+    this.watches[0].setCode("");
   };
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -37,6 +37,31 @@ export function focus(item: ?mixed) {
   }
 }
 
+export function openOrShowDock(URI: string) {
+  // atom.workspace.toggle(DOCK_VIEW_URI) will activate/focus the dock by default
+  // This is an issue when:
+  //   -- calling commands from the palette (prevents picker modals from opening)
+  //   -- calling commands from a button click
+  //   -- a function/command has its own focus logic (see watch.focus(), etc)
+  // dock.toggle() or dock.show() will leave focus wherever it was, fixing the problem
+
+  const dock = atom.workspace.paneContainerForURI(URI);
+  if (!dock) {
+    // open view if not yet opened
+    atom.workspace.open(WATCHES_URI, { searchAllPanes: true });
+  } else {
+    // show the dock, does nothing if already visible
+    dock.show();
+  }
+}
+
+export function openOrShow(item: ?mixed) {
+  if (item) {
+    const editorPane = atom.workspace.paneForItem(item);
+    if (editorPane) editorPane.activate();
+  }
+}
+
 export function grammarToLanguage(grammar: ?atom$Grammar) {
   if (!grammar) return null;
   const grammarLanguage = grammar.name.toLowerCase();

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -55,13 +55,6 @@ export function openOrShowDock(URI: string) {
   }
 }
 
-export function openOrShow(item: ?mixed) {
-  if (item) {
-    const editorPane = atom.workspace.paneForItem(item);
-    if (editorPane) editorPane.activate();
-  }
-}
-
 export function grammarToLanguage(grammar: ?atom$Grammar) {
   if (!grammar) return null;
   const grammarLanguage = grammar.name.toLowerCase();


### PR DESCRIPTION
This should fix #936 by allowing blank watches to be added in the way they are being prevented now. 

IIRC what we were doing before here was making sure at least one watch is always there, blank or not. Let me know if you see another issue that will come up by changing this.

The issue brought up in #936:

![hydrogen-watch-issue mp4](https://user-images.githubusercontent.com/10860657/29746717-cf3a771c-8aa8-11e7-88ee-6671600d4272.gif)
