### PR TITLE
Fix issue breaking remove-watch when called from command palette

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -45,7 +45,8 @@ import {
   INSPECTOR_URI,
   WATCHES_URI,
   OUTPUT_AREA_URI,
-  hotReloadPackage
+  hotReloadPackage,
+  openOrShowDock
 } from "./utils";
 
 import type Kernel from "./kernel";
@@ -104,13 +105,13 @@ const Hydrogen = {
         "hydrogen:add-watch": () => {
           if (store.kernel) {
             store.kernel.watchesStore.addWatchFromEditor(store.editor);
-            atom.workspace.open(WATCHES_URI, { searchAllPanes: true });
+            openOrShowDock(WATCHES_URI);
           }
         },
         "hydrogen:remove-watch": () => {
           if (store.kernel) {
             store.kernel.watchesStore.removeWatch();
-            atom.workspace.open(WATCHES_URI, { searchAllPanes: true });
+            openOrShowDock(WATCHES_URI);
           }
         },
         "hydrogen:update-kernels": () => kernelManager.updateKernelSpecs(),

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -37,6 +37,21 @@ export function focus(item: ?mixed) {
   }
 }
 
+export function openOrShowDock(URI: string) {
+  // atom.workspace.open(URI) will activate/focus the dock by default
+  // dock.toggle() or dock.show() will leave focus wherever it was
+
+  // this function is basically workspace.open, except it
+  // will not focus the pane if there is an open instance of that view
+
+  const dock = atom.workspace.paneContainerForURI(URI);
+  if (!dock) {
+    atom.workspace.open(URI, { searchAllPanes: true });
+  } else {
+    dock.show();
+  }
+}
+
 export function grammarToLanguage(grammar: ?atom$Grammar) {
   if (!grammar) return null;
   const grammarLanguage = grammar.name.toLowerCase();


### PR DESCRIPTION
If you are working in an editor and call `hydrogen:remove-watch` the dock will open and focus, canceling the watch picker before you have a chance to use it.

This will fix that issue by only "showing" the dock (this won't alter focus, only visibility). 

If no watch pane has been initialized ,`hydrogen:remove-watch` will still open and focus as usual.