### PR TITLE
Don't include stack trace in log messages

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -135,7 +135,7 @@ export function getEditorDirectory(editor: ?atom$TextEditor) {
 
 export function log(...message: Array<any>) {
   if (atom.config.get("Hydrogen.debug")) {
-    console.trace("Hydrogen:", ...message);
+    console.debug("Hydrogen:", ...message);
   }
 }
 


### PR DESCRIPTION
Beginning in Atom 1.19 messages in the dev console are automatically expanded. This means the console is constantly cluttered with stack traces.

This PR reverts back to the old behavior.