### PR TITLE
Fix devtools error

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -207,7 +207,7 @@ const Hydrogen = {
       })
     );
 
-    renderDevTools();
+    renderDevTools(atom.config.get("Hydrogen.debug") === true);
 
     autorun(() => {
       this.emitter.emit("did-change-kernel", store.kernel);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -140,16 +140,15 @@ export function log(...message: Array<any>) {
 }
 
 export function renderDevTools(enableLogging: boolean = true) {
-  if (atom.config.get("Hydrogen.debug")) {
-    try {
-      const devTools = require("mobx-react-devtools");
-      const div = document.createElement("div");
-      document.getElementsByTagName("body")[0].appendChild(div);
-      devTools.setLogEnabled(enableLogging);
-      ReactDOM.render(<devTools.default noPanel />, div);
-    } catch (e) {
-      log("Could not enable dev tools", e);
-    }
+  if (!atom.devMode) return;
+  try {
+    const devTools = require("mobx-react-devtools");
+    const div = document.createElement("div");
+    document.getElementsByTagName("body")[0].appendChild(div);
+    devTools.setLogEnabled(enableLogging);
+    ReactDOM.render(<devTools.default noPanel />, div);
+  } catch (e) {
+    log("Could not enable dev tools", e);
   }
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -139,7 +139,7 @@ export function log(...message: Array<any>) {
   }
 }
 
-export function renderDevTools(enableLogging: boolean = true) {
+export function renderDevTools(enableLogging: boolean) {
   if (!atom.devMode) return;
   try {
     const devTools = require("mobx-react-devtools");


### PR DESCRIPTION
If logging is disabled in the user's config:

- Disable mobx devtools logging initially.
- Allow toggling it back on without reload.
-----
For non-dev versions of hydrogen, `mobx-react-devtools` was logging an error that only devs should see. 
A user brought this up on #955 for an unrelated issue. This will prevent the require whether or not debug is enabled, since this is a dev dep.
