### PR TITLE
Support characters width non default width

### DIFF
--- a/lib/components/result-view/index.js
+++ b/lib/components/result-view/index.js
@@ -40,9 +40,11 @@ export default class ResultView {
 
     this.outputStore = new OutputStore();
     this.outputStore.updatePosition({
-      lineLength: editor.getBuffer().lineLengthForRow(row),
+      lineLength: editor.element.pixelPositionForBufferPosition([row, Infinity])
+        .left,
       lineHeight: editor.getLineHeightInPixels(),
-      editorWidth: editor.getEditorWidthInChars()
+      editorWidth: editor.element.getWidth(),
+      charWidth: editor.getDefaultCharWidth()
     });
 
     editor.decorateMarker(this.marker, {
@@ -56,7 +58,12 @@ export default class ResultView {
         markerStore.delete(this.marker.id);
       } else {
         this.outputStore.updatePosition({
-          lineLength: this.marker.getStartBufferPosition().column
+          lineLength: editor.element.pixelPositionForBufferPosition(
+            this.marker.getStartBufferPosition()
+          ).left,
+          lineHeight: editor.getLineHeightInPixels(),
+          editorWidth: editor.element.getWidth(),
+          charWidth: editor.getDefaultCharWidth()
         });
       }
     });

--- a/lib/components/result-view/result-view.js
+++ b/lib/components/result-view/result-view.js
@@ -105,7 +105,7 @@ class ResultViewComponent extends React.Component<Props> {
     const { outputs, status, isPlain, position } = this.props.store;
 
     const inlineStyle = {
-      marginLeft: `${position.lineLength + 1}ch`,
+      marginLeft: `${position.lineLength + position.charWidth}px`,
       marginTop: `-${position.lineHeight}px`
     };
 

--- a/lib/store/output.js
+++ b/lib/store/output.js
@@ -71,14 +71,18 @@ export default class OutputStore {
   position = {
     lineHeight: 0,
     lineLength: 0,
-    editorWidth: 0
+    editorWidth: 0,
+    charWidth: 0
   };
 
   @computed
   get isPlain(): boolean {
     if (this.outputs.length !== 1) return false;
 
-    const availableSpace = this.position.editorWidth - this.position.lineLength;
+    const availableSpace = Math.floor(
+      (this.position.editorWidth - this.position.lineLength) /
+        this.position.charWidth
+    );
     if (availableSpace <= 0) return false;
 
     const output = this.outputs[0];

--- a/spec/store/output-spec.js
+++ b/spec/store/output-spec.js
@@ -163,7 +163,8 @@ describe("OutputStore", () => {
       expect(store.position).toEqual({
         lineHeight: 10,
         lineLength: 0,
-        editorWidth: 0
+        editorWidth: 0,
+        charWidth: 0
       });
     });
     it("checks if output lineLength position gets updated", () => {
@@ -171,7 +172,8 @@ describe("OutputStore", () => {
       expect(store.position).toEqual({
         lineHeight: 0,
         lineLength: 10,
-        editorWidth: 0
+        editorWidth: 0,
+        charWidth: 0
       });
     });
     it("checks if output editorWidth position gets updated", () => {
@@ -179,19 +181,22 @@ describe("OutputStore", () => {
       expect(store.position).toEqual({
         lineHeight: 0,
         lineLength: 0,
-        editorWidth: 10
+        editorWidth: 10,
+        charWidth: 0
       });
     });
     it("checks if all output positions get updated", () => {
       store.updatePosition({
         lineHeight: 10,
         lineLength: 10,
-        editorWidth: 10
+        editorWidth: 10,
+        charWidth: 12
       });
       expect(store.position).toEqual({
         lineHeight: 10,
         lineLength: 10,
-        editorWidth: 10
+        editorWidth: 10,
+        charWidth: 12
       });
     });
   });

--- a/types/atom.js.flow
+++ b/types/atom.js.flow
@@ -1064,6 +1064,8 @@ declare class atom$TextEditorElement extends HTMLElement {
   // `undefined` means no explicit width. `null` sets a zero width (which is almost certainly a
   // mistake) so we don't allow it.
   setWidth(width: number | void): void,
+
+  getWidth(): number,
 }
 
 declare class atom$ViewProvider {


### PR DESCRIPTION
This will properly determine the placement of inline results when using non default width characters like chinese:
<img width="513" alt="chinese" src="https://user-images.githubusercontent.com/13285808/30030394-48b47472-918d-11e7-93fa-11c3534bfe98.png">

Only drawback of this approach is that we are using `pixelPositionForBufferPosition` now. Atom states that calling this may cause a synchronous DOM update:

> Be aware that calling this method with a column that does not translate to column 0 on screen could cause a synchronous DOM update in order to measure the requested horizontal pixel position if it isn't already cached.

I don't know if this is a problem for our use case, but we should be aware of it.

Fixes #930 