### PR TITLE
Add config option for outputArea fontsize.

### DIFF
--- a/lib/components/result-view/history.js
+++ b/lib/components/result-view/history.js
@@ -47,7 +47,9 @@ const History = observer(({ store }: { store: OutputStore }) => {
       </div>
       <div
         className="multiline-container"
-        style={{ fontSize: atom.config.get(`Hydrogen.outputAreaFontSize`) }}
+        style={{
+          fontSize: atom.config.get(`Hydrogen.outputAreaFontSize`) || "inherit"
+        }}
       >
         <Output
           output={toJS(output)}

--- a/lib/components/result-view/history.js
+++ b/lib/components/result-view/history.js
@@ -45,7 +45,10 @@ const History = observer(({ store }: { store: OutputStore }) => {
           onClick={store.incrementIndex}
         />
       </div>
-      <div className="multiline-container">
+      <div
+        className="multiline-container"
+        style={{ fontSize: atom.config.get(`Hydrogen.outputAreaFontSize`) }}
+      >
         <Output
           output={toJS(output)}
           displayOrder={displayOrder}

--- a/lib/config.js
+++ b/lib/config.js
@@ -30,6 +30,13 @@ const Config = {
       type: "boolean",
       default: true
     },
+    outputAreaFontSize: {
+      title: "Change fontsize of Output area",
+      includeTitle: false,
+      description: "Change the fontsize of the Output area.",
+      type: "string",
+      default: "inherit"
+    },
     debug: {
       title: "Enable Debug Messages",
       includeTitle: false,

--- a/lib/config.js
+++ b/lib/config.js
@@ -31,12 +31,12 @@ const Config = {
       default: true
     },
     outputAreaFontSize: {
-      title: "Change fontsize of Output area",
+      title: "Output area fontsize",
       includeTitle: false,
       description: "Change the fontsize of the Output area.",
       type: "integer",
-      minimum: 1,
-      default: undefined
+      minimum: 0,
+      default: 0
     },
     debug: {
       title: "Enable Debug Messages",

--- a/lib/config.js
+++ b/lib/config.js
@@ -34,7 +34,7 @@ const Config = {
       title: "Change fontsize of Output area",
       includeTitle: false,
       description: "Change the fontsize of the Output area.",
-      type: "string",
+      type: "integer",
       default: "inherit"
     },
     debug: {

--- a/lib/config.js
+++ b/lib/config.js
@@ -35,7 +35,8 @@ const Config = {
       includeTitle: false,
       description: "Change the fontsize of the Output area.",
       type: "integer",
-      default: "inherit"
+      minimum: 1,
+      default: undefined
     },
     debug: {
       title: "Enable Debug Messages",


### PR DESCRIPTION
Resolve #971 

Hello,

I added a new config option for the fontsize in the output area. You can change the size by changing the default to 14 for example.

Cheers