### PR TITLE
External Output: Add scrolling list view

### DIFF
--- a/lib/components/output-area.js
+++ b/lib/components/output-area.js
@@ -2,13 +2,15 @@
 
 import { CompositeDisposable } from "atom";
 import React from "react";
+import { action, observable } from "mobx";
 import { observer } from "mobx-react";
-import { toJS } from "mobx";
 
 import History from "./result-view/history";
+import ScrollList from "./result-view/list";
 import { OUTPUT_AREA_URI } from "./../utils";
 
 import typeof store from "../store";
+import type { IObservableValue } from "mobx";
 
 const EmptyMessage = () => {
   return (
@@ -18,20 +20,23 @@ const EmptyMessage = () => {
   );
 };
 
-const OutputArea = observer(({ store: { kernel } }: { store: store }) => {
-  if (!kernel) {
-    if (atom.config.get("Hydrogen.outputAreaDock")) {
-      return <EmptyMessage />;
-    } else {
-      atom.workspace.hide(OUTPUT_AREA_URI);
-      return null;
-    }
-  }
+@observer
+class OutputArea extends React.Component<{ store: store }> {
+  showHistory: IObservableValue<boolean> = observable(true);
+  @action
+  setHistory = () => {
+    this.showHistory.set(true);
+  };
 
-  const handleClick = () => {
+  @action
+  setScrollList = () => {
+    this.showHistory.set(false);
+  };
+
+  handleClick = () => {
+    const kernel = this.props.store.kernel;
     if (!kernel || !kernel.outputStore) return;
-    //convert output to a plain js object
-    const output = toJS(kernel.outputStore.outputs[kernel.outputStore.index]);
+    const output = kernel.outputStore.outputs[kernel.outputStore.index];
     // check for a text property and fall back to data["text/plain"]
     const textOrBundle = output.text || output.data["text/plain"];
     if (textOrBundle) {
@@ -42,34 +47,63 @@ const OutputArea = observer(({ store: { kernel } }: { store: store }) => {
     }
   };
 
-  return (
-    <div className="sidebar output-area">
-      {kernel.outputStore.outputs.length > 0 ? (
-        <div
-          style={{
-            left: "100%",
-            transform: "translateX(-100%)",
-            position: "relative",
-            flex: "0 0 auto",
-            width: "fit-content"
-          }}
-        >
-          <div className="btn icon icon-clippy" onClick={handleClick}>
-            Copy
+  render() {
+    const kernel = this.props.store.kernel;
+
+    if (!kernel) {
+      if (atom.config.get("Hydrogen.outputAreaDock")) {
+        return <EmptyMessage />;
+      } else {
+        atom.workspace.hide(OUTPUT_AREA_URI);
+        return null;
+      }
+    }
+    return (
+      <div className="sidebar output-area">
+        {kernel.outputStore.outputs.length > 0 ? (
+          <div className="block">
+            <div className="btn-group">
+              <button
+                className={`btn icon icon-clock${this.showHistory.get()
+                  ? " selected"
+                  : ""}`}
+                onClick={this.setHistory}
+              />
+              <button
+                className={`btn icon icon-three-bars${!this.showHistory.get()
+                  ? " selected"
+                  : ""}`}
+                onClick={this.setScrollList}
+              />
+            </div>
+            <div style={{ float: "right" }}>
+              {this.showHistory.get() ? (
+                <button
+                  className="btn icon icon-clippy"
+                  onClick={this.handleClick}
+                >
+                  Copy
+                </button>
+              ) : null}
+              <button
+                className="btn icon icon-trashcan"
+                onClick={kernel.outputStore.clear}
+              >
+                Clear
+              </button>
+            </div>
           </div>
-          <div
-            className="btn icon icon-trashcan"
-            onClick={kernel.outputStore.clear}
-          >
-            Clear
-          </div>
-        </div>
-      ) : (
-        <EmptyMessage />
-      )}
-      <History store={kernel.outputStore} />
-    </div>
-  );
-});
+        ) : (
+          <EmptyMessage />
+        )}
+        {this.showHistory.get() ? (
+          <History store={kernel.outputStore} />
+        ) : (
+          <ScrollList outputs={kernel.outputStore.outputs} />
+        )}
+      </div>
+    );
+  }
+}
 
 export default OutputArea;

--- a/lib/components/result-view/list.js
+++ b/lib/components/result-view/list.js
@@ -1,0 +1,55 @@
+/* @flow */
+
+import React from "react";
+import { observer } from "mobx-react";
+import { toJS } from "mobx";
+import { Display } from "@nteract/display-area";
+import { transforms, displayOrder } from "./transforms";
+
+import type { IObservableArray } from "mobx";
+
+type Props = { outputs: IObservableArray<Object> };
+
+@observer
+class ScrollList extends React.Component<Props> {
+  el: ?HTMLElement;
+
+  scrollToBottom() {
+    if (!this.el) return;
+    const scrollHeight = this.el.scrollHeight;
+    const height = this.el.clientHeight;
+    const maxScrollTop = scrollHeight - height;
+    this.el.scrollTop = maxScrollTop > 0 ? maxScrollTop : 0;
+  }
+
+  componentDidUpdate() {
+    this.scrollToBottom();
+  }
+
+  componentDidMount() {
+    this.scrollToBottom();
+  }
+
+  render() {
+    if (this.props.outputs.length === 0) return null;
+    return (
+      <div
+        className="scroll-list multiline-container"
+        ref={el => {
+          this.el = el;
+        }}
+      >
+        <Display
+          outputs={toJS(this.props.outputs)}
+          displayOrder={displayOrder}
+          transforms={transforms}
+          theme="light"
+          models={{}}
+          expanded={true}
+        />
+      </div>
+    );
+  }
+}
+
+export default ScrollList;

--- a/lib/components/result-view/list.js
+++ b/lib/components/result-view/list.js
@@ -35,6 +35,9 @@ class ScrollList extends React.Component<Props> {
     return (
       <div
         className="scroll-list multiline-container"
+        style={{
+          fontSize: atom.config.get(`Hydrogen.outputAreaFontSize`) || "inherit"
+        }}
         ref={el => {
           this.el = el;
         }}

--- a/styles/hydrogen.less
+++ b/styles/hydrogen.less
@@ -232,6 +232,12 @@ svg:first-child {
   .multiline-container {
     flex: 0 1 auto;
   }
+  .scroll-list {
+    .cell_display {
+      height: 100%;
+      padding: 0;
+    }
+  }
 }
 
 // -------------- Watches -----------------


### PR DESCRIPTION
As mentioned by @ivanov in https://github.com/nteract/hydrogen/pull/825#issuecomment-304947011 it would be nice to have a single page where output is appended at the bottom. Somehow I forgot to follow up on this idea 😉 

This PR allows users of the external output panel to switch between two modes. One can either flip back and forth between outputs or have a single page where output is appended at the bottom and scrolled into view:
![scroll](https://user-images.githubusercontent.com/13285808/30063620-9de1e71e-924f-11e7-8345-8a3291f0e0aa.gif)
