### PR TITLE
Enable change of fontsize in Hydrogen Inspector

### DIFF
--- a/lib/panes/inspector.js
+++ b/lib/panes/inspector.js
@@ -14,6 +14,10 @@ export default class InspectorPane {
 
   constructor(store: store) {
     this.element.classList.add("hydrogen", "inspector");
+    var fontsize = `font-size:${atom.config.get(
+      "Hydrogen.outputAreaFontSize"
+    )}px`;
+    this.element.setAttribute("style", fontsize);
 
     reactFactory(
       <Inspector store={store} />,

--- a/lib/panes/inspector.js
+++ b/lib/panes/inspector.js
@@ -14,6 +14,7 @@ export default class InspectorPane {
 
   constructor(store: store) {
     this.element.classList.add("hydrogen", "inspector");
+    // $FlowFixMe: In this case atom.config will always return an integer here
     var fontsize = `font-size:${atom.config.get(
       "Hydrogen.outputAreaFontSize"
     )}px`;


### PR DESCRIPTION
The fontsize of the Hydrogen Inspector changes according to the fontsize in the output area. 