### PR TITLE
Add margins between items in output area

### DIFF
--- a/styles/hydrogen.less
+++ b/styles/hydrogen.less
@@ -238,6 +238,11 @@ svg:first-child {
       padding: 0;
     }
   }
+
+  div {
+    margin-bottom: 10px;
+    margin-top: 10px;
+  }
 }
 
 // -------------- Watches -----------------

--- a/styles/hydrogen.less
+++ b/styles/hydrogen.less
@@ -236,13 +236,14 @@ svg:first-child {
     .cell_display {
       height: 100%;
       padding: 0;
+
+      > div {
+        margin-bottom: 10px;
+        margin-top: 10px;
+      }
     }
   }
 
-  div {
-    margin-bottom: 10px;
-    margin-top: 10px;
-  }
 }
 
 // -------------- Watches -----------------


### PR DESCRIPTION
Currently, the items in the output area scrolling list view are too close together. This patch adds some margins between the items.

Old:
![margin_old](https://user-images.githubusercontent.com/3406709/30498681-37c6a872-9a1d-11e7-932a-34b535921826.jpg)

New:
![margin_new](https://user-images.githubusercontent.com/3406709/30498688-3c11f760-9a1d-11e7-8e95-94df68c31b04.jpg)
