### PR TITLE
Plugin api on start kernel subscription

### DIFF
--- a/docs/PluginAPI.md
+++ b/docs/PluginAPI.md
@@ -4,7 +4,7 @@
 
 ## HydrogenProvider
 
-Version: 1.0.0 
+Version: 1.2.0 
 
 The Plugin API allows you to make Hydrogen awesome.
 You will be able to interact with this class in your Hydrogen Plugin using
@@ -14,13 +14,21 @@ Take a look at our [Example Plugin](https://github.com/lgeiger/hydrogen-example-
 and the [Atom Flight Manual](http://flight-manual.atom.io/hacking-atom/) for
 learning how to interact with Hydrogen in your own plugin.
 
-## onDidChangeKernel(Callback)
+## onDidChangeKernel(Callback(?kernel))
 
 Calls your callback when the kernel has changed.
 
 ### Params:
 
-* **Function** *Callback* 
+* **Function** *Callback(?kernel)* 
+
+## onDidStartKernel(Callback(?kernel))
+
+Calls your callback when a new kernel starts.
+
+### Params:
+
+* **Function** *Callback(?kernel)* 
 
 ## getActiveKernel()
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -9,7 +9,7 @@ import {
 } from "atom";
 
 import _ from "lodash";
-import { autorun } from "mobx";
+import { autorun, reaction } from "mobx";
 import React from "react";
 
 import KernelPicker from "./kernel-picker";
@@ -212,6 +212,17 @@ const Hydrogen = {
     autorun(() => {
       this.emitter.emit("did-change-kernel", store.kernel);
     });
+
+    let previousKernelCount = store.runningKernels.size;
+    reaction(
+      () => store.runningKernels.size,
+      newKernelCount => {
+        if (newKernelCount > previousKernelCount) {
+          this.emitter.emit("did-start-kernel", store.kernel);
+        }
+        previousKernelCount = newKernelCount;
+      }
+    );
   },
 
   deactivate() {

--- a/lib/plugin-api/hydrogen-provider.js
+++ b/lib/plugin-api/hydrogen-provider.js
@@ -6,7 +6,7 @@ import type ZMQKernel from "./../zmq-kernel";
 import type HydrogenKernel from "./hydrogen-kernel";
 import { getCurrentCell } from "./../code-manager";
 /**
- * @version 1.0.0
+ * @version 1.2.0
  *
  *
  * The Plugin API allows you to make Hydrogen awesome.
@@ -30,9 +30,9 @@ export default class HydrogenProvider {
 
   /*
    * Calls your callback when the kernel has changed.
-   * @param {Function} Callback
+   * @param {Function} Callback(?kernel)
    */
-  onDidChangeKernel(callback: Function) {
+  onDidChangeKernel(callback: (kernel: ?HydrogenKernel) => void) {
     this._hydrogen.emitter.on("did-change-kernel", (kernel: ?Kernel) => {
       if (kernel) {
         return callback(kernel.getPluginWrapper());
@@ -42,9 +42,9 @@ export default class HydrogenProvider {
   }
 
   /*
-  * Calls your callback when a new kernel starts.
-  * @param {Function} Callback(?kernel)
-  */
+   * Calls your callback when a new kernel starts.
+   * @param {Function} Callback(?kernel)
+   */
   onDidStartKernel(callback: (kernel: ?HydrogenKernel) => void) {
     this._hydrogen.emitter.on("did-start-kernel", (kernel: ?Kernel) => {
       if (kernel) {
@@ -54,7 +54,6 @@ export default class HydrogenProvider {
     });
   }
 
-  /*
   /*
    * Get the `HydrogenKernel` of the currently active text editor.
    * @return {Class} `HydrogenKernel`
@@ -77,7 +76,6 @@ export default class HydrogenProvider {
     if (!store.editor) return null;
     return getCurrentCell(store.editor);
   }
-
   /*
   *--------
   */

--- a/lib/plugin-api/hydrogen-provider.js
+++ b/lib/plugin-api/hydrogen-provider.js
@@ -72,9 +72,8 @@ export default class HydrogenProvider {
    * `null` is returned if no active text editor.
    * @return {Class} `atom$Range`
    */
-  getCellRange(editor: ?atom$TextEditor) {
-    if (!store.editor) return null;
-    return getCurrentCell(store.editor);
+  getCellRange() {
+    return store.editor ? getCurrentCell(store.editor) : null;
   }
   /*
   *--------

--- a/lib/plugin-api/hydrogen-provider.js
+++ b/lib/plugin-api/hydrogen-provider.js
@@ -2,7 +2,8 @@
 
 import store from "./../store";
 import type Kernel from "./../kernel";
-import type ZMQKernel from "./../zmq-kernel.js";
+import type ZMQKernel from "./../zmq-kernel";
+import type HydrogenKernel from "./hydrogen-kernel";
 import { getCurrentCell } from "./../code-manager";
 /**
  * @version 1.0.0
@@ -40,6 +41,20 @@ export default class HydrogenProvider {
     });
   }
 
+  /*
+  * Calls your callback when a new kernel starts.
+  * @param {Function} Callback(?kernel)
+  */
+  onDidStartKernel(callback: (kernel: ?HydrogenKernel) => void) {
+    this._hydrogen.emitter.on("did-start-kernel", (kernel: ?Kernel) => {
+      if (kernel) {
+        return callback(kernel.getPluginWrapper());
+      }
+      return callback(null);
+    });
+  }
+
+  /*
   /*
    * Get the `HydrogenKernel` of the currently active text editor.
    * @return {Class} `HydrogenKernel`

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     },
     "hydrogen.provider": {
       "versions": {
-        "1.1.0": "provideHydrogen"
+        "1.2.0": "provideHydrogen"
       }
     }
   },


### PR DESCRIPTION
This would add an event callback option to the kernel api in the same pattern as `onDidChangeKernel` except it only fires when a new kernel is started.

I have been working on a plugin that adds highlighting to the current cell for any editor with a running kernel. The way it works (before this PR) is by observing the active text editor, which means a new kernel wont trigger the editor to be highlighted unless you switch away and back to that editor.

Check out [this branch](https://github.com/BenRussert/hydrogen-show/tree/depends-on-hydrogen-api) of the plugin if you want to see an example that depends on this PR, compared to the same repo on master without this api change.