### PR TITLE
Support multiple independent kernels

### DIFF
--- a/docs/Usage/GettingStarted.md
+++ b/docs/Usage/GettingStarted.md
@@ -88,7 +88,9 @@ You can also access these commands by clicking on the kernel status in the statu
 
 <img src="https://cloud.githubusercontent.com/assets/13285808/16894732/e4e5b4de-4b5f-11e6-8b8e-facf17a7c6c4.png" width=300>
 
-Additionally, if you have two or more kernels for a particular language (grammar), you can select which kernel to use with the "Switch to <kernel>" option in the Kernel Commands menu.
+Additionally, if you have more kernels running, you can open the kernel monitor via **Hydrogen: Toggle Kernel Monitor** to see a list of all running kernels and shut them down if needed:
+
+<img width="802" alt="monitor" src="https://user-images.githubusercontent.com/13285808/30815792-7b685b8a-a214-11e7-863e-f334f03eef0f.png">
 
 ## Multiple kernels inside one rich document
 

--- a/lib/components/kernel-monitor.js
+++ b/lib/components/kernel-monitor.js
@@ -47,7 +47,13 @@ const MonitorSection = observer(({ store, kernels, group }: Props) => (
         .getFilesForKernel(kernel)
         .map(tildify)
         .join(", ");
-      return <Monitor kernel={kernel} files={files} key={files} />;
+      return (
+        <Monitor
+          kernel={kernel}
+          files={files}
+          key={kernel.displayName + files}
+        />
+      );
     })}
   </div>
 ));

--- a/lib/components/kernel-monitor.js
+++ b/lib/components/kernel-monitor.js
@@ -21,10 +21,19 @@ const Monitor = observer(({ kernel, files }: MonitorProps) => {
   };
 
   return (
-    <div>
-      <div>{kernel.displayName}</div>
-      <div>{files}</div>
-      <button className="btn icon icon-trashcan" onClick={destroy} />
+    <div style={{ padding: "5px 10px", display: "flex" }}>
+      <div style={{ flex: 1, whiteSpace: "nowrap" }}>{kernel.displayName}</div>
+      <div
+        style={{
+          padding: "0 10px",
+          textOverflow: "ellipsis",
+          overflow: "hidden",
+          whiteSpace: "nowrap"
+        }}
+      >
+        {files}
+      </div>
+      <div className="icon icon-trashcan" onClick={destroy} />
     </div>
   );
 });
@@ -44,12 +53,19 @@ const MonitorSection = observer(({ store, kernels, group }: Props) => (
 ));
 
 const KernelMonitor = observer(({ store }: { store: store }) => {
+  if (store.runningKernels.length === 0) {
+    return (
+      <ul className="background-message centered">
+        <li>No running kernels</li>
+      </ul>
+    );
+  }
   const grouped = _.groupBy(
     store.runningKernels,
     kernel => kernel.gatewayName || "Local"
   );
   return (
-    <div>
+    <div className="kernel-monitor">
       {_.map(grouped, (kernels, group) => (
         <MonitorSection
           store={store}

--- a/lib/components/kernel-monitor.js
+++ b/lib/components/kernel-monitor.js
@@ -1,0 +1,65 @@
+/* @flow */
+
+import React from "react";
+import { observer } from "mobx-react";
+import { observable } from "mobx";
+import _ from "lodash";
+import tildify from "tildify";
+
+import { KERNEL_MONITOR_URI } from "./../utils";
+
+const displayOrder = ["text/html", "text/markdown", "text/plain"];
+
+import typeof store from "../store";
+import Kernel from "../kernel";
+
+type MonitorProps = { kernel: Kernel, files: string };
+const Monitor = observer(({ kernel, files }: MonitorProps) => {
+  const destroy = () => {
+    kernel.shutdown();
+    kernel.destroy();
+  };
+
+  return (
+    <div>
+      <div>{kernel.displayName}</div>
+      <div>{files}</div>
+      <button className="btn icon icon-trashcan" onClick={destroy} />
+    </div>
+  );
+});
+
+type Props = { store: store, kernels: Array<Kernel>, group: string };
+const MonitorSection = observer(({ store, kernels, group }: Props) => (
+  <div>
+    <header>{group}</header>
+    {kernels.map(kernel => {
+      const files = store
+        .getFilesForKernel(kernel)
+        .map(tildify)
+        .join(", ");
+      return <Monitor kernel={kernel} files={files} key={files} />;
+    })}
+  </div>
+));
+
+const KernelMonitor = observer(({ store }: { store: store }) => {
+  const grouped = _.groupBy(
+    store.runningKernels,
+    kernel => kernel.gatewayName || "Local"
+  );
+  return (
+    <div>
+      {_.map(grouped, (kernels, group) => (
+        <MonitorSection
+          store={store}
+          kernels={kernels}
+          group={group}
+          key={group}
+        />
+      ))}
+    </div>
+  );
+});
+
+export default KernelMonitor;

--- a/lib/existing-kernel-picker.js
+++ b/lib/existing-kernel-picker.js
@@ -15,7 +15,7 @@ function getName(kernel: Kernel) {
   return (
     prefix +
     kernel.displayName +
-    " -- " +
+    " - " +
     store
       .getFilesForKernel(kernel)
       .map(tildify)

--- a/lib/existing-kernel-picker.js
+++ b/lib/existing-kernel-picker.js
@@ -1,0 +1,89 @@
+/* @flow */
+
+import SelectListView from "atom-select-list";
+import store from "./store";
+import _ from "lodash";
+import tildify from "tildify";
+
+import WSKernel from "./ws-kernel";
+import { kernelSpecProvidesGrammar } from "./utils";
+
+import type Kernel from "./kernel";
+
+function getName(kernel: Kernel) {
+  const prefix = kernel instanceof WSKernel ? `${kernel.gatewayName}: ` : "";
+  return (
+    prefix +
+    kernel.displayName +
+    " -- " +
+    store
+      .getFilesForKernel(kernel)
+      .map(tildify)
+      .join(", ")
+  );
+}
+
+export default class ExistingKernelPicker {
+  kernelSpecs: Array<Kernelspec>;
+  selectListView: SelectListView;
+  panel: ?atom$Panel;
+  previouslyFocusedElement: ?HTMLElement;
+  constructor() {
+    this.selectListView = new SelectListView({
+      itemsClassList: ["mark-active"],
+      items: [],
+      filterKeyForItem: kernel => getName(kernel),
+      elementForItem: kernel => {
+        const element = document.createElement("li");
+        element.textContent = getName(kernel);
+        return element;
+      },
+      didConfirmSelection: kernel => {
+        const { filePath, editor, grammar } = store;
+        if (!filePath || !editor || !grammar) return this.cancel();
+        store.newKernel(kernel, filePath, editor, grammar);
+        this.cancel();
+      },
+      didCancelSelection: () => this.cancel(),
+      emptyMessage: "No running kernels for this language."
+    });
+  }
+
+  destroy() {
+    this.cancel();
+    return this.selectListView.destroy();
+  }
+
+  cancel() {
+    if (this.panel != null) {
+      this.panel.destroy();
+    }
+    this.panel = null;
+    if (this.previouslyFocusedElement) {
+      this.previouslyFocusedElement.focus();
+      this.previouslyFocusedElement = null;
+    }
+  }
+
+  attach() {
+    this.previouslyFocusedElement = document.activeElement;
+    if (this.panel == null)
+      this.panel = atom.workspace.addModalPanel({ item: this.selectListView });
+    this.selectListView.focus();
+    this.selectListView.reset();
+  }
+
+  async toggle() {
+    if (this.panel != null) {
+      this.cancel();
+    } else if (store.filePath && store.grammar) {
+      await this.selectListView.update({
+        items: [...store.runningKernels].filter(kernel =>
+          kernelSpecProvidesGrammar(kernel.kernelSpec, store.grammar)
+        )
+      });
+      store.markers.clear();
+      this.attach();
+    }
+  }
+}

--- a/lib/existing-kernel-picker.js
+++ b/lib/existing-kernel-picker.js
@@ -78,7 +78,7 @@ export default class ExistingKernelPicker {
       this.cancel();
     } else if (store.filePath && store.grammar) {
       await this.selectListView.update({
-        items: [...store.runningKernels].filter(kernel =>
+        items: store.runningKernels.filter(kernel =>
           kernelSpecProvidesGrammar(kernel.kernelSpec, store.grammar)
         )
       });

--- a/lib/kernel-manager.js
+++ b/lib/kernel-manager.js
@@ -11,7 +11,7 @@ import ZMQKernel from "./zmq-kernel";
 
 import KernelPicker from "./kernel-picker";
 import store from "./store";
-import { getEditorDirectory, log } from "./utils";
+import { getEditorDirectory, kernelSpecProvidesGrammar, log } from "./utils";
 
 import type { Connection } from "./zmq-kernel";
 
@@ -94,7 +94,7 @@ class KernelManager {
     if (grammar) {
       return this.getAllKernelSpecs(kernelSpecs => {
         const specs = kernelSpecs.filter(spec =>
-          this.kernelSpecProvidesGrammar(spec, grammar)
+          kernelSpecProvidesGrammar(spec, grammar)
         );
 
         return callback(specs);
@@ -123,24 +123,6 @@ class KernelManager {
 
   kernelSpecProvidesLanguage(kernelSpec: Kernelspec, grammarLanguage: string) {
     return kernelSpec.language.toLowerCase() === grammarLanguage.toLowerCase();
-  }
-
-  kernelSpecProvidesGrammar(kernelSpec: Kernelspec, grammar: ?atom$Grammar) {
-    if (!grammar || !grammar.name || !kernelSpec || !kernelSpec.language) {
-      return false;
-    }
-    const grammarLanguage = grammar.name.toLowerCase();
-    const kernelLanguage = kernelSpec.language.toLowerCase();
-    if (kernelLanguage === grammarLanguage) {
-      return true;
-    }
-
-    const mappedLanguage = Config.getJson("languageMappings")[kernelLanguage];
-    if (!mappedLanguage) {
-      return false;
-    }
-
-    return mappedLanguage.toLowerCase() === grammarLanguage;
   }
 
   getKernelSpecsFromSettings() {

--- a/lib/kernel-manager.js
+++ b/lib/kernel-manager.js
@@ -25,6 +25,7 @@ class KernelManager {
   startKernelFor(
     grammar: atom$Grammar,
     editor: atom$TextEditor,
+    filePath: string,
     onStarted: (kernel: ZMQKernel) => void
   ) {
     this.getKernelSpecForGrammar(grammar, kernelSpec => {
@@ -36,13 +37,15 @@ class KernelManager {
         return;
       }
 
-      this.startKernel(kernelSpec, grammar, onStarted);
+      this.startKernel(kernelSpec, grammar, editor, filePath, onStarted);
     });
   }
 
   startKernel(
     kernelSpec: Kernelspec,
     grammar: atom$Grammar,
+    editor: atom$TextEditor,
+    filePath: string,
     onStarted: ?(kernel: ZMQKernel) => void
   ) {
     const displayName = kernelSpec.display_name;
@@ -52,7 +55,7 @@ class KernelManager {
 
     store.startKernel(displayName);
 
-    let currentPath = getEditorDirectory(store.editor);
+    let currentPath = getEditorDirectory(editor);
     let projectPath;
 
     log("KernelManager: startKernel:", displayName);
@@ -73,7 +76,7 @@ class KernelManager {
     };
 
     const kernel = new ZMQKernel(kernelSpec, grammar, options, () => {
-      store.newKernel(kernel);
+      store.newKernel(kernel, filePath, editor, grammar);
       if (onStarted) onStarted(kernel);
     });
   }

--- a/lib/main.js
+++ b/lib/main.js
@@ -106,8 +106,8 @@ const Hydrogen = {
           atom.workspace.toggle(OUTPUT_AREA_URI),
         "hydrogen:toggle-kernel-monitor": () =>
           atom.workspace.toggle(KERNEL_MONITOR_URI),
-        "hydrogen:select-kernel": () => this.showKernelPicker(),
-        "hydrogen:connect-to-remote-kernel": () => this.showWSKernelPicker(),
+        "hydrogen:start-local-kernel": () => this.startZMQKernel(),
+        "hydrogen:connect-to-remote-kernel": () => this.connectToWSKernel(),
         "hydrogen:connect-to-existing-kernel": () =>
           this.connectToExistingKernel(),
         "hydrogen:add-watch": () => {
@@ -512,7 +512,7 @@ const Hydrogen = {
     }
   },
 
-  showKernelPicker() {
+  startZMQKernel() {
     kernelManager.getAllKernelSpecsForGrammar(store.grammar, kernelSpecs => {
       if (this.kernelPicker) {
         this.kernelPicker.kernelSpecs = kernelSpecs;
@@ -532,7 +532,7 @@ const Hydrogen = {
     });
   },
 
-  showWSKernelPicker() {
+  connectToWSKernel() {
     if (!this.wsKernelPicker) {
       this.wsKernelPicker = new WSKernelPicker((kernel: Kernel) => {
         store.markers.clear();

--- a/lib/main.js
+++ b/lib/main.js
@@ -256,10 +256,8 @@ const Hydrogen = {
   showKernelCommands() {
     if (!this.signalListView) {
       this.signalListView = new SignalListView();
-      this.signalListView.onConfirmed = (kernelCommand: {
-        command: string,
-        payload: ?Kernelspec
-      }) => this.handleKernelCommand(kernelCommand);
+      this.signalListView.onConfirmed = (kernelCommand: { command: string }) =>
+        this.handleKernelCommand(kernelCommand);
     }
     this.signalListView.toggle();
   },
@@ -277,19 +275,6 @@ const Hydrogen = {
 
     if (!grammar) {
       atom.notifications.addError("Undefined grammar");
-      return;
-    }
-
-    if (command === "switch-kernel") {
-      if (!payload) return;
-      const editor = store.editor;
-      if (!editor) return;
-      const filePath = editor.getPath();
-      if (!filePath) return;
-      store.markers.clear();
-      if (kernel) kernel.destroy();
-
-      kernelManager.startKernel(payload, grammar, editor, filePath);
       return;
     }
 
@@ -318,18 +303,22 @@ const Hydrogen = {
   },
 
   createResultBubble(editor: atom$TextEditor, code: string, row: number) {
-    const file = editor.getPath();
-    const grammar = store.grammar;
-    if (!grammar || !file) return;
+    const { grammar, filePath, kernel } = store;
+    if (!grammar || !filePath) return;
 
-    if (store.kernel) {
-      this._createResultBubble(editor, store.kernel, code, row);
+    if (kernel) {
+      this._createResultBubble(editor, kernel, code, row);
       return;
     }
 
-    kernelManager.startKernelFor(grammar, editor, file, (kernel: ZMQKernel) => {
-      this._createResultBubble(editor, kernel, code, row);
-    });
+    kernelManager.startKernelFor(
+      grammar,
+      editor,
+      filePath,
+      (kernel: ZMQKernel) => {
+        this._createResultBubble(editor, kernel, code, row);
+      }
+    );
   },
 
   _createResultBubble(
@@ -431,8 +420,8 @@ const Hydrogen = {
   },
 
   runAll(breakpoints: ?Array<atom$Point>) {
-    const { editor, kernel, grammar } = store;
-    if (!editor || !grammar) return;
+    const { editor, kernel, grammar, filePath } = store;
+    if (!editor || !grammar || !filePath) return;
     if (isMultilanguageGrammar(editor.getGrammar())) {
       atom.notifications.addError(
         '"Run All" is not supported for this file type!'
@@ -445,11 +434,14 @@ const Hydrogen = {
       return;
     }
 
-    const file = editor.getPath();
-    if (!file) return;
-    kernelManager.startKernelFor(grammar, editor, file, (kernel: ZMQKernel) => {
-      this._runAll(editor, kernel, breakpoints);
-    });
+    kernelManager.startKernelFor(
+      grammar,
+      editor,
+      filePath,
+      (kernel: ZMQKernel) => {
+        this._runAll(editor, kernel, breakpoints);
+      }
+    );
   },
 
   _runAll(
@@ -509,11 +501,13 @@ const Hydrogen = {
       } else {
         this.kernelPicker = new KernelPicker(kernelSpecs);
 
-        this.kernelPicker.onConfirmed = (kernelSpec: Kernelspec) =>
-          this.handleKernelCommand({
-            command: "switch-kernel",
-            payload: kernelSpec
-          });
+        this.kernelPicker.onConfirmed = (kernelSpec: Kernelspec) => {
+          const { editor, grammar, filePath } = store;
+          if (!editor || !grammar || !filePath) return;
+          store.markers.clear();
+
+          kernelManager.startKernel(kernelSpec, grammar, editor, filePath);
+        };
       }
 
       this.kernelPicker.toggle();
@@ -524,10 +518,8 @@ const Hydrogen = {
     if (!this.wsKernelPicker) {
       this.wsKernelPicker = new WSKernelPicker((kernel: Kernel) => {
         store.markers.clear();
-        const { editor, grammar } = store;
-        if (!editor || !grammar) return;
-        const filePath = editor.getPath();
-        if (!filePath) return;
+        const { editor, grammar, filePath } = store;
+        if (!editor || !grammar || !filePath) return;
 
         if (kernel instanceof ZMQKernel) kernel.destroy();
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -282,9 +282,14 @@ const Hydrogen = {
 
     if (command === "switch-kernel") {
       if (!payload) return;
+      const editor = store.editor;
+      if (!editor) return;
+      const filePath = editor.getPath();
+      if (!filePath) return;
       store.markers.clear();
       if (kernel) kernel.destroy();
-      kernelManager.startKernel(payload, grammar);
+
+      kernelManager.startKernel(payload, grammar, editor, filePath);
       return;
     }
 
@@ -313,14 +318,16 @@ const Hydrogen = {
   },
 
   createResultBubble(editor: atom$TextEditor, code: string, row: number) {
-    if (!store.grammar) return;
+    const file = editor.getPath();
+    const grammar = store.grammar;
+    if (!grammar || !file) return;
 
     if (store.kernel) {
       this._createResultBubble(editor, store.kernel, code, row);
       return;
     }
 
-    kernelManager.startKernelFor(store.grammar, editor, (kernel: ZMQKernel) => {
+    kernelManager.startKernelFor(grammar, editor, file, (kernel: ZMQKernel) => {
       this._createResultBubble(editor, kernel, code, row);
     });
   },
@@ -438,7 +445,9 @@ const Hydrogen = {
       return;
     }
 
-    kernelManager.startKernelFor(grammar, editor, (kernel: ZMQKernel) => {
+    const file = editor.getPath();
+    if (!file) return;
+    kernelManager.startKernelFor(grammar, editor, file, (kernel: ZMQKernel) => {
       this._runAll(editor, kernel, breakpoints);
     });
   },
@@ -515,10 +524,14 @@ const Hydrogen = {
     if (!this.wsKernelPicker) {
       this.wsKernelPicker = new WSKernelPicker((kernel: Kernel) => {
         store.markers.clear();
+        const { editor, grammar } = store;
+        if (!editor || !grammar) return;
+        const filePath = editor.getPath();
+        if (!filePath) return;
 
         if (kernel instanceof ZMQKernel) kernel.destroy();
 
-        store.newKernel(kernel);
+        store.newKernel(kernel, filePath, editor, grammar);
       });
     }
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -14,6 +14,7 @@ import React from "react";
 
 import KernelPicker from "./kernel-picker";
 import WSKernelPicker from "./ws-kernel-picker";
+import ExistingKernelPicker from "./existing-kernel-picker";
 import SignalListView from "./signal-list-view";
 import * as codeManager from "./code-manager";
 
@@ -46,7 +47,8 @@ import {
   WATCHES_URI,
   OUTPUT_AREA_URI,
   hotReloadPackage,
-  openOrShowDock
+  openOrShowDock,
+  kernelSpecProvidesGrammar
 } from "./utils";
 
 import type Kernel from "./kernel";
@@ -102,6 +104,8 @@ const Hydrogen = {
           atom.workspace.toggle(OUTPUT_AREA_URI),
         "hydrogen:select-kernel": () => this.showKernelPicker(),
         "hydrogen:connect-to-remote-kernel": () => this.showWSKernelPicker(),
+        "hydrogen:connect-to-existing-kernel": () =>
+          this.connectToExistingKernel(),
         "hydrogen:add-watch": () => {
           if (store.kernel) {
             store.kernel.watchesStore.addWatchFromEditor(store.editor);
@@ -260,6 +264,13 @@ const Hydrogen = {
         this.handleKernelCommand(kernelCommand);
     }
     this.signalListView.toggle();
+  },
+
+  connectToExistingKernel() {
+    if (!this.existingKernelPicker) {
+      this.existingKernelPicker = new ExistingKernelPicker();
+    }
+    this.existingKernelPicker.toggle();
   },
 
   handleKernelCommand({
@@ -528,7 +539,7 @@ const Hydrogen = {
     }
 
     this.wsKernelPicker.toggle((kernelSpec: Kernelspec) =>
-      kernelManager.kernelSpecProvidesGrammar(kernelSpec, store.grammar)
+      kernelSpecProvidesGrammar(kernelSpec, store.grammar)
     );
   }
 };

--- a/lib/main.js
+++ b/lib/main.js
@@ -25,6 +25,7 @@ import StatusBar from "./components/status-bar";
 import InspectorPane from "./panes/inspector";
 import WatchesPane from "./panes/watches";
 import OutputPane from "./panes/output-area";
+import KernelMonitorPane from "./panes/kernel-monitor";
 
 import { toggleInspector } from "./commands";
 
@@ -46,6 +47,7 @@ import {
   INSPECTOR_URI,
   WATCHES_URI,
   OUTPUT_AREA_URI,
+  KERNEL_MONITOR_URI,
   hotReloadPackage,
   openOrShowDock,
   kernelSpecProvidesGrammar
@@ -69,7 +71,7 @@ const Hydrogen = {
             return;
           }
 
-          if (store.runningKernels.size != 0) {
+          if (store.runningKernels.length != 0) {
             skipLanguageMappingsChange = true;
 
             atom.config.set("Hydrogen.languageMappings", oldValue);
@@ -102,6 +104,8 @@ const Hydrogen = {
         "hydrogen:toggle-watches": () => atom.workspace.toggle(WATCHES_URI),
         "hydrogen:toggle-output-area": () =>
           atom.workspace.toggle(OUTPUT_AREA_URI),
+        "hydrogen:toggle-kernel-monitor": () =>
+          atom.workspace.toggle(KERNEL_MONITOR_URI),
         "hydrogen:select-kernel": () => this.showKernelPicker(),
         "hydrogen:connect-to-remote-kernel": () => this.showWSKernelPicker(),
         "hydrogen:connect-to-existing-kernel": () =>
@@ -192,6 +196,8 @@ const Hydrogen = {
             return new WatchesPane(store);
           case OUTPUT_AREA_URI:
             return new OutputPane(store);
+          case KERNEL_MONITOR_URI:
+            return new KernelMonitorPane(store);
         }
       })
     );
@@ -203,7 +209,8 @@ const Hydrogen = {
           if (
             item instanceof InspectorPane ||
             item instanceof WatchesPane ||
-            item instanceof OutputPane
+            item instanceof OutputPane ||
+            item instanceof KernelMonitorPane
           ) {
             item.destroy();
           }

--- a/lib/panes/kernel-monitor.js
+++ b/lib/panes/kernel-monitor.js
@@ -13,7 +13,7 @@ export default class KernelMonitorPane {
   disposer = new CompositeDisposable();
 
   constructor(store: store) {
-    this.element.classList.add("hydrogen", "kernel-monitor");
+    this.element.classList.add("hydrogen");
 
     reactFactory(
       <KernelMonitor store={store} />,

--- a/lib/panes/kernel-monitor.js
+++ b/lib/panes/kernel-monitor.js
@@ -1,0 +1,38 @@
+/* @flow */
+
+import { CompositeDisposable } from "atom";
+
+import React from "react";
+
+import { reactFactory, KERNEL_MONITOR_URI } from "./../utils";
+import typeof store from "../store";
+import KernelMonitor from "./../components/kernel-monitor";
+
+export default class KernelMonitorPane {
+  element = document.createElement("div");
+  disposer = new CompositeDisposable();
+
+  constructor(store: store) {
+    this.element.classList.add("hydrogen", "kernel-monitor");
+
+    reactFactory(
+      <KernelMonitor store={store} />,
+      this.element,
+      null,
+      this.disposer
+    );
+  }
+
+  getTitle = () => "Hydrogen Kernel Monitor";
+
+  getURI = () => KERNEL_MONITOR_URI;
+
+  getDefaultLocation = () => "bottom";
+
+  getAllowedLocations = () => ["bottom", "left", "right"];
+
+  destroy() {
+    this.disposer.dispose();
+    this.element.remove();
+  }
+}

--- a/lib/signal-list-view.js
+++ b/lib/signal-list-view.js
@@ -1,40 +1,30 @@
 /* @flow */
 
 import SelectListView from "atom-select-list";
-import _ from "lodash";
 
 import WSKernel from "./ws-kernel";
 import kernelManager from "./kernel-manager";
 import { log } from "./utils";
 import store from "./store";
 
-export type KernelCommand = {
-  command: string,
-  payload: ?Kernelspec
-};
+const basicCommands = [
+  { name: "Interrupt", value: "interrupt-kernel" },
+  { name: "Restart", value: "restart-kernel" },
+  { name: "Shut Down", value: "shutdown-kernel" }
+];
+
+const wsKernelCommands = [
+  { name: "Rename session for", value: "rename-kernel" },
+  { name: "Disconnect from", value: "disconnect-kernel" }
+];
 
 export default class SignalListView {
-  basicCommands: Array<Object>;
-  onConfirmed: ?(command: KernelCommand) => void;
+  onConfirmed: ?(command: { command: string }) => void;
   panel: ?atom$Panel;
   previouslyFocusedElement: ?HTMLElement;
   selectListView: SelectListView;
-  switchCommands: Array<Object>;
-  wsKernelCommands: Array<Object>;
 
   constructor() {
-    this.basicCommands = [
-      { name: "Interrupt", value: "interrupt-kernel" },
-      { name: "Restart", value: "restart-kernel" },
-      { name: "Shut Down", value: "shutdown-kernel" }
-    ];
-
-    this.wsKernelCommands = [
-      { name: "Rename session for", value: "rename-kernel" },
-      { name: "Disconnect from", value: "disconnect-kernel" }
-    ];
-
-    this.switchCommands = [{ name: "Switch to", value: "switch-kernel" }];
     this.onConfirmed = null;
     this.selectListView = new SelectListView({
       itemsClassList: ["mark-active"],
@@ -55,46 +45,23 @@ export default class SignalListView {
     });
   }
 
-  _mapCommands(commands: Array<Object>, kernelSpec: Kernelspec) {
-    return commands.map(command => ({
-      name: `${command.name} ${kernelSpec.display_name} kernel`,
-      command: command.value,
-      payload: command.value === "switch-kernel" ? kernelSpec : null
-    }));
-  }
-
   async toggle() {
     if (this.panel != null) {
       this.cancel();
     }
 
-    const grammar = store.grammar;
     const kernel = store.kernel;
-    let listItems = [];
     if (!kernel) return;
+    const commands =
+      kernel instanceof WSKernel
+        ? [...basicCommands, ...wsKernelCommands]
+        : basicCommands;
 
-    if (kernel instanceof WSKernel) {
-      listItems = this._mapCommands(
-        _.union(this.basicCommands, this.wsKernelCommands),
-        kernel.kernelSpec
-      );
-    } else {
-      const otherKernels = kernelManager.getAllKernelSpecsForGrammar(
-        grammar,
-        kernelSpecs => _.without(kernelSpecs, kernel.kernelSpec)
-      );
+    const listItems = commands.map(command => ({
+      name: `${command.name} ${kernel.kernelSpec.display_name} kernel`,
+      command: command.value
+    }));
 
-      if (otherKernels) {
-        listItems = _.union(
-          this._mapCommands(this.basicCommands, kernel.kernelSpec),
-          _.flatMap(otherKernels, otherKernel =>
-            this._mapCommands(this.switchCommands, otherKernel)
-          )
-        );
-      } else {
-        listItems = this._mapCommands(this.basicCommands, kernel.kernelSpec);
-      }
-    }
     await this.selectListView.update({ items: listItems });
     this.attach();
   }

--- a/lib/store/index.js
+++ b/lib/store/index.js
@@ -10,10 +10,12 @@ import MarkerStore from "./markers";
 import kernelManager from "./../kernel-manager";
 import Kernel from "./../kernel";
 
+import type { IObservableArray } from "mobx";
+
 class Store {
   subscriptions = new CompositeDisposable();
   markers = new MarkerStore();
-  runningKernels: Set<Kernel> = new Set();
+  runningKernels: IObservableArray<Kernel> = observable([]);
   @observable kernelMapping: KernelMapping = new Map();
   @observable startingKernels: Map<string, boolean> = new Map();
   @observable editor = atom.workspace.getActiveTextEditor();
@@ -45,14 +47,14 @@ class Store {
     grammar: atom$Grammar
   ) {
     if (isMultilanguageGrammar(editor.getGrammar())) {
-      const old = this.kernelMapping.get(filePath);
-      const newMap = old && old instanceof Kernel === false ? old : {};
-      newMap[grammar.name] = kernel;
-      this.kernelMapping.set(filePath, newMap);
+      this.kernelMapping.merge({ [filePath]: { [grammar.name]: kernel } });
     } else {
       this.kernelMapping.set(filePath, kernel);
     }
-    this.runningKernels.add(kernel);
+    const index = this.runningKernels.findIndex(k => k === kernel);
+    if (index === -1) {
+      this.runningKernels.push(kernel);
+    }
     // delete startingKernel since store.kernel now in place to prevent duplicate kernel
     this.startingKernels.delete(kernel.kernelSpec.display_name);
   }
@@ -70,7 +72,7 @@ class Store {
       }
     );
 
-    this.runningKernels.delete(kernel);
+    this.runningKernels.remove(kernel);
   }
 
   _iterateOverKernels(

--- a/lib/store/index.js
+++ b/lib/store/index.js
@@ -21,12 +21,15 @@ class Store {
 
   @computed
   get kernel(): ?Kernel {
-    if (!this.editor) return null;
-    const filePath = this.editor.getPath();
-    if (!filePath) return null;
-    const kernel = this.kernelMapping[filePath];
+    if (!this.filePath) return null;
+    const kernel = this.kernelMapping[this.filePath];
     if (!kernel || kernel instanceof Kernel) return kernel;
     if (this.grammar) return kernel[this.grammar.name];
+  }
+
+  @computed
+  get filePath(): ?string {
+    return this.editor ? this.editor.getPath() : null;
   }
 
   @action
@@ -54,11 +57,17 @@ class Store {
   @action
   deleteKernel(kernel: Kernel) {
     _.forEach(this.kernelMapping, (value, key) => {
-      if (value === kernel) delete this.kernelMapping[key];
+      if (value === kernel) {
+        this.kernelMapping[key] = null;
+        delete this.kernelMapping[key];
+      }
 
       if (!(value instanceof Kernel)) {
         _.forEach(value, (k, key) => {
-          if (k === kernel) delete value[key];
+          if (k === kernel) {
+            value[key] = null;
+            delete value[key];
+          }
         });
       }
     });

--- a/lib/store/index.js
+++ b/lib/store/index.js
@@ -47,7 +47,10 @@ class Store {
     grammar: atom$Grammar
   ) {
     if (isMultilanguageGrammar(editor.getGrammar())) {
-      this.kernelMapping.merge({ [filePath]: { [grammar.name]: kernel } });
+      const old = this.kernelMapping.get(filePath);
+      const newMap = old && old instanceof Kernel === false ? old : {};
+      newMap[grammar.name] = kernel;
+      this.kernelMapping.set(filePath, newMap);
     } else {
       this.kernelMapping.set(filePath, kernel);
     }

--- a/lib/store/index.js
+++ b/lib/store/index.js
@@ -14,7 +14,7 @@ class Store {
   subscriptions = new CompositeDisposable();
   markers = new MarkerStore();
   runningKernels: Set<Kernel> = new Set();
-  @observable kernelMapping: KernelMapping = {};
+  @observable kernelMapping: KernelMapping = new Map();
   @observable startingKernels: Map<string, boolean> = new Map();
   @observable editor = atom.workspace.getActiveTextEditor();
   @observable grammar: ?atom$Grammar;
@@ -22,7 +22,7 @@ class Store {
   @computed
   get kernel(): ?Kernel {
     if (!this.filePath) return null;
-    const kernel = this.kernelMapping[this.filePath];
+    const kernel = this.kernelMapping.get(this.filePath);
     if (!kernel || kernel instanceof Kernel) return kernel;
     if (this.grammar) return kernel[this.grammar.name];
   }
@@ -45,9 +45,12 @@ class Store {
     grammar: atom$Grammar
   ) {
     if (isMultilanguageGrammar(editor.getGrammar())) {
-      _.merge(this.kernelMapping, { [filePath]: { [grammar.name]: kernel } });
+      const old = this.kernelMapping.get(filePath);
+      const newMap = old && old instanceof Kernel === false ? old : {};
+      newMap[grammar.name] = kernel;
+      this.kernelMapping.set(filePath, newMap);
     } else {
-      this.kernelMapping[filePath] = kernel;
+      this.kernelMapping.set(filePath, kernel);
     }
     this.runningKernels.add(kernel);
     // delete startingKernel since store.kernel now in place to prevent duplicate kernel
@@ -56,10 +59,9 @@ class Store {
 
   @action
   deleteKernel(kernel: Kernel) {
-    _.forEach(this.kernelMapping, (value, key) => {
+    this.kernelMapping.forEach((value, key) => {
       if (value === kernel) {
-        this.kernelMapping[key] = null;
-        delete this.kernelMapping[key];
+        this.kernelMapping.delete(key);
       }
 
       if (!(value instanceof Kernel)) {
@@ -80,7 +82,7 @@ class Store {
     this.markers.clear();
     this.runningKernels.forEach(kernel => kernel.destroy());
     this.runningKernels.clear();
-    this.kernelMapping = {};
+    this.kernelMapping.clear();
   }
 
   @action

--- a/lib/store/index.js
+++ b/lib/store/index.js
@@ -59,21 +59,44 @@ class Store {
 
   @action
   deleteKernel(kernel: Kernel) {
-    this.kernelMapping.forEach((value, key) => {
-      if (value === kernel) {
-        this.kernelMapping.delete(key);
+    this._iterateOverKernels(
+      kernel,
+      (_, file) => {
+        this.kernelMapping.delete(file);
+      },
+      (map, _, grammar) => {
+        map[grammar] = null;
+        delete map[grammar];
+      }
+    );
+
+    this.runningKernels.delete(kernel);
+  }
+
+  _iterateOverKernels(
+    kernel: Kernel,
+    func: (kernel: Kernel | KernelObj, file: string) => mixed,
+    func2: (obj: KernelObj, file: string, grammar: string) => mixed = func
+  ) {
+    this.kernelMapping.forEach((kernelOrObj, file) => {
+      if (kernelOrObj === kernel) {
+        func(kernel, file);
       }
 
-      if (!(value instanceof Kernel)) {
-        _.forEach(value, (k, key) => {
+      if (kernelOrObj instanceof Kernel === false) {
+        _.forEach(kernelOrObj, (k, grammar) => {
           if (k === kernel) {
-            value[key] = null;
-            delete value[key];
+            func2(kernelOrObj, file, grammar);
           }
         });
       }
     });
-    this.runningKernels.delete(kernel);
+  }
+
+  getFilesForKernel(kernel: Kernel) {
+    const files = [];
+    this._iterateOverKernels(kernel, (_, file) => files.push(file));
+    return files;
   }
 
   @action

--- a/lib/store/index.js
+++ b/lib/store/index.js
@@ -3,29 +3,30 @@
 import { CompositeDisposable } from "atom";
 import { observable, computed, action } from "mobx";
 import { isMultilanguageGrammar, getEmbeddedScope } from "./../utils";
+import _ from "lodash";
 
 import Config from "./../config";
 import MarkerStore from "./markers";
 import kernelManager from "./../kernel-manager";
-import type Kernel from "./../kernel";
+import Kernel from "./../kernel";
 
 class Store {
   subscriptions = new CompositeDisposable();
   markers = new MarkerStore();
+  runningKernels: Set<Kernel> = new Set();
+  @observable kernelMapping: KernelMapping = {};
   @observable startingKernels: Map<string, boolean> = new Map();
-  @observable runningKernels: Map<string, Kernel> = new Map();
   @observable editor = atom.workspace.getActiveTextEditor();
   @observable grammar: ?atom$Grammar;
 
   @computed
   get kernel(): ?Kernel {
-    for (let kernel of this.runningKernels.values()) {
-      const kernelSpec = kernel.kernelSpec;
-      if (kernelManager.kernelSpecProvidesGrammar(kernelSpec, this.grammar)) {
-        return kernel;
-      }
-    }
-    return null;
+    if (!this.editor) return null;
+    const filePath = this.editor.getPath();
+    if (!filePath) return null;
+    const kernel = this.kernelMapping[filePath];
+    if (!kernel || kernel instanceof Kernel) return kernel;
+    if (this.grammar) return kernel[this.grammar.name];
   }
 
   @action
@@ -34,21 +35,34 @@ class Store {
   }
 
   @action
-  newKernel(kernel: Kernel) {
-    const mappedLanguage =
-      Config.getJson("languageMappings")[kernel.language] || kernel.language;
-    this.runningKernels.set(mappedLanguage, kernel);
+  newKernel(
+    kernel: Kernel,
+    filePath: string,
+    editor: atom$TextEditor,
+    grammar: atom$Grammar
+  ) {
+    if (isMultilanguageGrammar(editor.getGrammar())) {
+      _.merge(this.kernelMapping, { [filePath]: { [grammar.name]: kernel } });
+    } else {
+      this.kernelMapping[filePath] = kernel;
+    }
+    this.runningKernels.add(kernel);
     // delete startingKernel since store.kernel now in place to prevent duplicate kernel
     this.startingKernels.delete(kernel.kernelSpec.display_name);
   }
 
   @action
   deleteKernel(kernel: Kernel) {
-    for (let [language, runningKernel] of this.runningKernels.entries()) {
-      if (kernel === runningKernel) {
-        this.runningKernels.delete(language);
+    _.forEach(this.kernelMapping, (value, key) => {
+      if (value === kernel) delete this.kernelMapping[key];
+
+      if (!(value instanceof Kernel)) {
+        _.forEach(value, (k, key) => {
+          if (k === kernel) delete value[key];
+        });
       }
-    }
+    });
+    this.runningKernels.delete(kernel);
   }
 
   @action
@@ -56,7 +70,8 @@ class Store {
     this.subscriptions.dispose();
     this.markers.clear();
     this.runningKernels.forEach(kernel => kernel.destroy());
-    this.runningKernels = new Map();
+    this.runningKernels.clear();
+    this.kernelMapping = {};
   }
 
   @action

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -117,6 +117,27 @@ export function isMultilanguageGrammar(grammar: atom$Grammar) {
   return markupGrammars.has(grammar.scopeName);
 }
 
+export function kernelSpecProvidesGrammar(
+  kernelSpec: Kernelspec,
+  grammar: ?atom$Grammar
+) {
+  if (!grammar || !grammar.name || !kernelSpec || !kernelSpec.language) {
+    return false;
+  }
+  const grammarLanguage = grammar.name.toLowerCase();
+  const kernelLanguage = kernelSpec.language.toLowerCase();
+  if (kernelLanguage === grammarLanguage) {
+    return true;
+  }
+
+  const mappedLanguage = Config.getJson("languageMappings")[kernelLanguage];
+  if (!mappedLanguage) {
+    return false;
+  }
+
+  return mappedLanguage.toLowerCase() === grammarLanguage;
+}
+
 export function getEmbeddedScope(
   editor: atom$TextEditor,
   position: atom$Point

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -13,6 +13,7 @@ import store from "./store";
 export const INSPECTOR_URI = "atom://hydrogen/inspector";
 export const WATCHES_URI = "atom://hydrogen/watch-sidebar";
 export const OUTPUT_AREA_URI = "atom://hydrogen/output-area";
+export const KERNEL_MONITOR_URI = "atom://hydrogen/kernel-monitor";
 
 export function reactFactory(
   reactElement: React$Element<any>,

--- a/lib/ws-kernel-picker.js
+++ b/lib/ws-kernel-picker.js
@@ -81,9 +81,8 @@ export default class WSKernelPicker {
       });
       return;
     }
-    const path = store.editor ? store.editor.getPath() : null;
 
-    this._path = `${path || "unsaved"}-${v4()}`;
+    this._path = `${store.filePath || "unsaved"}-${v4()}`;
 
     this.listView.onConfirmed = this.onGateway.bind(this);
 

--- a/lib/ws-kernel-picker.js
+++ b/lib/ws-kernel-picker.js
@@ -97,7 +97,7 @@ export default class WSKernelPicker {
   }
 
   async onGateway(gatewayInfo: any) {
-    this.listView.onConfirmed = this.onSession.bind(this);
+    this.listView.onConfirmed = this.onSession.bind(this, gatewayInfo.name);
     await this.listView.selectListView.update({
       items: [],
       infoMessage: null,
@@ -142,7 +142,7 @@ export default class WSKernelPicker {
         // Gateways offer the option of never listing sessions, for security
         // reasons.
         // Assume this is the case and proceed to creating a new session.
-        this.onSession({
+        this.onSession(gatewayInfo.name, {
           name: "[new session]",
           model: null,
           options: gatewayInfo.options,
@@ -155,7 +155,7 @@ export default class WSKernelPicker {
     }
   }
 
-  async onSession(sessionInfo: any) {
+  async onSession(gatewayName: string, sessionInfo: any) {
     if (!sessionInfo.model) {
       if (!sessionInfo.name) {
         await this.listView.selectListView.update({
@@ -175,7 +175,7 @@ export default class WSKernelPicker {
         };
       });
 
-      this.listView.onConfirmed = this.startSession.bind(this);
+      this.listView.onConfirmed = this.startSession.bind(this, gatewayName);
       await this.listView.selectListView.update({
         items: items,
         emptyMessage: "No kernel specs available",
@@ -184,21 +184,29 @@ export default class WSKernelPicker {
       });
     } else {
       this.onSessionChosen(
+        gatewayName,
         await Session.connectTo(sessionInfo.model.id, sessionInfo.options)
       );
     }
   }
 
-  startSession(sessionInfo: any) {
-    Session.startNew(sessionInfo.options).then(this.onSessionChosen.bind(this));
+  startSession(gatewayName: string, sessionInfo: any) {
+    Session.startNew(sessionInfo.options).then(
+      this.onSessionChosen.bind(this, gatewayName)
+    );
   }
 
-  async onSessionChosen(session: any) {
+  async onSessionChosen(gatewayName: string, session: any) {
     this.listView.cancel();
     const kernelSpec = await session.kernel.getSpec();
     if (!store.grammar) return;
 
-    const kernel = new WSKernel(kernelSpec, store.grammar, session);
+    const kernel = new WSKernel(
+      gatewayName,
+      kernelSpec,
+      store.grammar,
+      session
+    );
     this._onChosen(kernel);
   }
 }

--- a/lib/ws-kernel.js
+++ b/lib/ws-kernel.js
@@ -8,10 +8,17 @@ import type { Session } from "./jupyter-js-services-shim";
 
 export default class WSKernel extends Kernel {
   session: Session;
+  gatewayName: string;
 
-  constructor(kernelSpec: Kernelspec, grammar: atom$Grammar, session: Session) {
+  constructor(
+    gatewayName: string,
+    kernelSpec: Kernelspec,
+    grammar: atom$Grammar,
+    session: Session
+  ) {
     super(kernelSpec, grammar);
     this.session = session;
+    this.gatewayName = gatewayName;
 
     this.session.statusChanged.connect(() =>
       this.setExecutionState(this.session.status)

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "activationCommands": {
     "atom-text-editor": [
-      "hydrogen:select-kernel",
+      "hydrogen:start-local-kernel",
       "hydrogen:connect-to-remote-kernel",
       "hydrogen:run",
       "hydrogen:run-and-move-down",

--- a/spec/components/status-bar-spec.js
+++ b/spec/components/status-bar-spec.js
@@ -52,11 +52,11 @@ describe("Status Bar", () => {
     });
     kernel2.executionState = "idle";
 
-    store.kernelMapping = {
-      "foo.py": kernel,
-      "bar.py": kernel,
-      "foo.js": kernel2
-    };
+    store.kernelMapping = new Map([
+      ["foo.py", kernel],
+      ["bar.py", kernel],
+      ["foo.js", kernel2]
+    ]);
 
     store.editor = { getPath: () => "foo.py" };
 
@@ -82,6 +82,6 @@ describe("Status Bar", () => {
     expect(component.text()).toBe("Javascript | idle");
 
     // reset store
-    store.kernelMapping = {};
+    store.kernelMapping = new Map();
   });
 });

--- a/spec/store/index-spec.js
+++ b/spec/store/index-spec.js
@@ -200,6 +200,17 @@ describe("Store", () => {
     });
   });
 
+  describe("get filePath", () => {
+    it("should return null if no editor", () => {
+      expect(store.filePath).toBeNull();
+    });
+
+    it("should return file path", () => {
+      store.editor = { getPath: () => "foo.py" };
+      expect(store.filePath).toBe("foo.py");
+    });
+  });
+
   describe("get kernel", () => {
     it("should return null if no editor", () => {
       expect(store.kernel).toBeNull();

--- a/spec/store/index-spec.js
+++ b/spec/store/index-spec.js
@@ -22,9 +22,9 @@ describe("Store initialize", () => {
 describe("Store", () => {
   beforeEach(() => {
     store.subscriptions = new CompositeDisposable();
-    store.startingKernels = new Map();
+    store.startingKernels.clear();
     store.runningKernels.clear();
-    store.kernelMapping = new Map();
+    store.kernelMapping.clear();
     store.editor = null;
     store.grammar = null;
   });
@@ -128,6 +128,7 @@ describe("Store", () => {
     it("should store kernel for multilanguage file", () => {
       const editor = { getGrammar: () => ({ scopeName: "source.gfm" }) };
       const kernel = { kernelSpec: { display_name: "Python 3" } };
+      const kernel2 = { kernelSpec: { display_name: "Javascript" } };
       spyOn(store.startingKernels, "delete");
 
       store.newKernel(kernel, "foo.md", editor, { name: "python" });
@@ -135,6 +136,15 @@ describe("Store", () => {
       expect(store.kernelMapping.get("foo.md")).toEqual({ python: kernel });
       expect(store.runningKernels.slice()).toEqual([kernel]);
       expect(store.startingKernels.delete).toHaveBeenCalledWith("Python 3");
+
+      store.newKernel(kernel2, "foo.md", editor, { name: "javascript" });
+      expect(store.kernelMapping.size).toBe(1);
+      expect(store.kernelMapping.get("foo.md")).toEqual({
+        python: kernel,
+        javascript: kernel2
+      });
+      expect(store.runningKernels.slice()).toEqual([kernel, kernel2]);
+      expect(store.startingKernels.delete).toHaveBeenCalledWith("Javascript");
     });
   });
 

--- a/spec/store/index-spec.js
+++ b/spec/store/index-spec.js
@@ -10,7 +10,7 @@ describe("Store initialize", () => {
   it("should correctly initialize store", () => {
     expect(store.subscriptions instanceof CompositeDisposable).toBeTruthy();
     expect(store.markers instanceof MarkerStore).toBeTruthy();
-    expect(store.runningKernels).toEqual(new Set());
+    expect(store.runningKernels.slice()).toEqual([]);
     expect(isObservableMap(store.startingKernels)).toBeTruthy();
     expect(isObservableMap(store.kernelMapping)).toBeTruthy();
     expect(isObservable(store, "editor")).toBeTruthy();
@@ -23,7 +23,7 @@ describe("Store", () => {
   beforeEach(() => {
     store.subscriptions = new CompositeDisposable();
     store.startingKernels = new Map();
-    store.runningKernels = new Set();
+    store.runningKernels.clear();
     store.kernelMapping = new Map();
     store.editor = null;
     store.grammar = null;
@@ -121,7 +121,7 @@ describe("Store", () => {
       store.newKernel(kernel, "foo.py", editor);
       expect(store.kernelMapping.size).toBe(1);
       expect(store.kernelMapping.get("foo.py")).toEqual(kernel);
-      expect(store.runningKernels).toEqual(new Set([kernel]));
+      expect(store.runningKernels.slice()).toEqual([kernel]);
       expect(store.startingKernels.delete).toHaveBeenCalledWith("Python 3");
     });
 
@@ -133,7 +133,7 @@ describe("Store", () => {
       store.newKernel(kernel, "foo.md", editor, { name: "python" });
       expect(store.kernelMapping.size).toBe(1);
       expect(store.kernelMapping.get("foo.md")).toEqual({ python: kernel });
-      expect(store.runningKernels).toEqual(new Set([kernel]));
+      expect(store.runningKernels.slice()).toEqual([kernel]);
       expect(store.startingKernels.delete).toHaveBeenCalledWith("Python 3");
     });
   });
@@ -153,7 +153,7 @@ describe("Store", () => {
         language: "Javascript"
       });
 
-      store.runningKernels = new Set([kernel1, kernel2, kernel3]);
+      store.runningKernels.replace([kernel1, kernel2, kernel3]);
       store.kernelMapping = new Map([
         ["foo.py", kernel1],
         ["bar.py", kernel1],
@@ -168,7 +168,7 @@ describe("Store", () => {
       expect(store.kernelMapping.get("foo.md")).toEqual({
         javascript: kernel3
       });
-      expect(store.runningKernels).toEqual(new Set([kernel2, kernel3]));
+      expect(store.runningKernels.slice()).toEqual([kernel2, kernel3]);
     });
   });
 
@@ -217,10 +217,9 @@ describe("Store", () => {
       spyOn(store.markers, "clear");
       const kernel1 = jasmine.createSpyObj("kernel1", ["destroy"]);
       const kernel2 = jasmine.createSpyObj("kernel2", ["destroy"]);
-      store.runningKernels.add(kernel1);
-      store.runningKernels.add(kernel2);
+      store.runningKernels.replace([kernel1, kernel2]);
       store.dispose();
-      expect(store.runningKernels).toEqual(new Set());
+      expect(store.runningKernels.length).toEqual(0);
       expect(store.kernelMapping.size).toBe(0);
       expect(kernel1.destroy).toHaveBeenCalled();
       expect(kernel2.destroy).toHaveBeenCalled();

--- a/spec/store/index-spec.js
+++ b/spec/store/index-spec.js
@@ -3,12 +3,16 @@
 import { CompositeDisposable } from "atom";
 import { isObservableMap, isObservable, isComputed } from "mobx";
 import store from "./../../lib/store";
+import Kernel from "./../../lib/kernel";
+import MarkerStore from "./../../lib/store/markers";
 
 describe("Store initialize", () => {
   it("should correctly initialize store", () => {
     expect(store.subscriptions instanceof CompositeDisposable).toBeTruthy();
+    expect(store.markers instanceof MarkerStore).toBeTruthy();
+    expect(store.runningKernels).toEqual(new Set());
     expect(isObservableMap(store.startingKernels)).toBeTruthy();
-    expect(isObservableMap(store.runningKernels)).toBeTruthy();
+    expect(isObservable(store.kernelMapping)).toBeTruthy();
     expect(isObservable(store, "editor")).toBeTruthy();
     expect(isObservable(store, "grammar")).toBeTruthy();
     expect(isComputed(store, "kernel")).toBeTruthy();
@@ -19,37 +23,20 @@ describe("Store", () => {
   beforeEach(() => {
     store.subscriptions = new CompositeDisposable();
     store.startingKernels = new Map();
-    store.runningKernels = new Map();
+    store.runningKernels = new Set();
+    store.kernelMapping = {};
     store.editor = null;
     store.grammar = null;
   });
 
   describe("setGrammar", () => {
-    it("should set grammar and determine language and current kernel", () => {
+    it("should set grammar", () => {
       const editor = atom.workspace.buildTextEditor();
       const grammar = editor.getGrammar();
       expect(grammar.name).toBe("Null Grammar");
       expect(store.editor).toBeNull();
       store.setGrammar(editor);
       expect(store.grammar).toBe(grammar);
-
-      const currentKernel = { kernelSpec: { language: "null grammar" } };
-      const notCurrentKernel = { kernelSpec: { language: "mock grammar" } };
-
-      const runningKernels = {
-        "current kernel": currentKernel,
-        "not current kernel": notCurrentKernel
-      };
-      for (let kernelLanguage of Object.keys(runningKernels)) {
-        const kernel = runningKernels[kernelLanguage];
-        store.runningKernels.set(kernelLanguage, kernel);
-      }
-      expect(Object.keys(store.runningKernels.toJS()).sort()).toEqual(
-        Object.keys(runningKernels).sort()
-      );
-      expect(store.kernel.kernelSpec.language).toBe(
-        currentKernel.kernelSpec.language
-      );
     });
 
     it("should set grammar to null if editor is null", () => {
@@ -116,61 +103,142 @@ describe("Store", () => {
     });
   });
 
-  it("should add new kernel and reset starting kernel indicator", () => {
-    const kernelSpec = {
-      language: "null grammar",
-      display_name: "null grammar"
-    };
-    const kernel = {
-      language: "null grammar",
-      foo: "bar",
-      kernelSpec: kernelSpec
-    };
-    const { display_name } = kernelSpec;
-
-    store.startKernel(display_name);
-    expect(store.startingKernels.get(display_name)).toBeTruthy();
-
-    store.newKernel(kernel);
-    expect(store.startingKernels.get(display_name)).toBeUndefined();
-
-    expect(store.runningKernels.size).toBe(1);
-    expect(store.runningKernels.get("null grammar").language).toBe(
-      "null grammar"
-    );
-    expect(store.runningKernels.get("null grammar").foo).toBe("bar");
+  describe("startKernel", () => {
+    it("should add display name to startingKernels", () => {
+      const display_name = "null grammar";
+      expect(store.startingKernels.get(display_name)).toBeFalsy();
+      store.startKernel(display_name);
+      expect(store.startingKernels.get(display_name)).toBeTruthy();
+    });
   });
 
-  it("should delete kernel", () => {
-    store.runningKernels.set("lang1", "foo");
-    store.runningKernels.set("lang2", "bar");
-    expect(store.runningKernels.size).toBe(2);
-    store.deleteKernel("foo");
-    expect(store.runningKernels.size).toBe(1);
-    expect(store.runningKernels.get("lang2")).toBe("bar");
+  describe("newKernel", () => {
+    it("should store kernel", () => {
+      const editor = { getGrammar: () => ({ scopeName: "source.python" }) };
+      const kernel = { kernelSpec: { display_name: "Python 3" } };
+      spyOn(store.startingKernels, "delete");
+
+      store.newKernel(kernel, "foo.py", editor);
+      expect(store.kernelMapping).toEqual({ "foo.py": kernel });
+      expect(store.runningKernels).toEqual(new Set([kernel]));
+      expect(store.startingKernels.delete).toHaveBeenCalledWith("Python 3");
+    });
+
+    it("should store kernel for multilanguage file", () => {
+      const editor = { getGrammar: () => ({ scopeName: "source.gfm" }) };
+      const kernel = { kernelSpec: { display_name: "Python 3" } };
+      spyOn(store.startingKernels, "delete");
+
+      store.newKernel(kernel, "foo.md", editor, { name: "python" });
+      expect(store.kernelMapping).toEqual({ "foo.md": { python: kernel } });
+      expect(store.runningKernels).toEqual(new Set([kernel]));
+      expect(store.startingKernels.delete).toHaveBeenCalledWith("Python 3");
+    });
   });
 
-  it("should update editor", () => {
-    spyOn(store, "setGrammar").and.callThrough();
-    expect(store.editor).toBeNull();
-    const editor = atom.workspace.buildTextEditor();
-    store.updateEditor(editor);
-    expect(store.editor).toBe(editor);
-    expect(store.setGrammar).toHaveBeenCalledWith(editor);
-    expect(store.grammar).toBe(editor.getGrammar());
-    expect(store.grammar.name.toLowerCase()).toBe("null grammar");
+  describe("deleteKernel", () => {
+    it("should delete kernel", () => {
+      const kernel1 = new Kernel({
+        display_name: "Python 3",
+        language: "python"
+      });
+      const kernel2 = new Kernel({
+        display_name: "Python 3",
+        language: "python"
+      });
+      const kernel3 = new Kernel({
+        display_name: "JS",
+        language: "Javascript"
+      });
+
+      store.runningKernels = new Set([kernel1, kernel2, kernel3]);
+      store.kernelMapping = {
+        "foo.py": kernel1,
+        "bar.py": kernel1,
+        "baz.py": kernel2,
+        "foo.md": { python: kernel1, javascript: kernel3 }
+      };
+
+      store.deleteKernel(kernel1);
+
+      expect(store.kernelMapping).toEqual({
+        "baz.py": kernel2,
+        "foo.md": { javascript: kernel3 }
+      });
+      expect(store.runningKernels).toEqual(new Set([kernel2, kernel3]));
+    });
   });
 
-  it("should dispose kernels and subscriptions", () => {
-    spyOn(store.subscriptions, "dispose");
-    const kernel1 = jasmine.createSpyObj("kernel1", ["destroy"]);
-    const kernel2 = jasmine.createSpyObj("kernel2", ["destroy"]);
-    store.runningKernels.set("lang1", kernel1);
-    store.runningKernels.set("lang2", kernel2);
-    store.dispose();
-    expect(store.runningKernels.size).toBe(0);
-    expect(kernel1.destroy).toHaveBeenCalled();
-    expect(kernel2.destroy).toHaveBeenCalled();
-    expect(store.subscriptions.dispose).toHaveBeenCalled();
+  describe("updateEditor", () => {
+    it("should update editor", () => {
+      spyOn(store, "setGrammar").and.callThrough();
+      expect(store.editor).toBeNull();
+      const editor = atom.workspace.buildTextEditor();
+      store.updateEditor(editor);
+      expect(store.editor).toBe(editor);
+      expect(store.setGrammar).toHaveBeenCalledWith(editor);
+      expect(store.grammar).toBe(editor.getGrammar());
+      expect(store.grammar.name.toLowerCase()).toBe("null grammar");
+    });
+  });
+
+  describe("dispose", () => {
+    it("should dispose kernels and subscriptions", () => {
+      spyOn(store.subscriptions, "dispose");
+      spyOn(store.markers, "clear");
+      const kernel1 = jasmine.createSpyObj("kernel1", ["destroy"]);
+      const kernel2 = jasmine.createSpyObj("kernel2", ["destroy"]);
+      store.runningKernels.add(kernel1);
+      store.runningKernels.add(kernel2);
+      store.dispose();
+      expect(store.runningKernels).toEqual(new Set());
+      expect(store.kernelMapping).toEqual({});
+      expect(kernel1.destroy).toHaveBeenCalled();
+      expect(kernel2.destroy).toHaveBeenCalled();
+      expect(store.subscriptions.dispose).toHaveBeenCalled();
+      expect(store.markers.clear).toHaveBeenCalled();
+    });
+  });
+
+  describe("get kernel", () => {
+    it("should return null if no editor", () => {
+      expect(store.kernel).toBeNull();
+    });
+
+    it("should return null if editor isn't saved", () => {
+      store.editor = { getPath: () => {} };
+      expect(store.kernel).toBeNull();
+    });
+
+    it("should return kernel", () => {
+      store.editor = { getPath: () => "foo.py" };
+      const kernel = new Kernel({
+        display_name: "Python 3",
+        language: "python"
+      });
+      store.kernelMapping = { "foo.py": kernel };
+      expect(store.kernel).toEqual(kernel);
+    });
+
+    it("should return null if no kernel for file", () => {
+      store.editor = { getPath: () => "foo.py" };
+      const kernel = new Kernel({
+        display_name: "Python 3",
+        language: "python"
+      });
+      store.kernelMapping = { "bar.py": kernel };
+      expect(store.kernel).toBeUndefined();
+    });
+
+    it("should return null if no kernel for file", () => {
+      store.editor = { getPath: () => "foo.md" };
+      const kernel = new Kernel({
+        display_name: "Python 3",
+        language: "python"
+      });
+      store.kernelMapping = { "foo.md": { python: kernel } };
+      store.grammar = { name: "python" };
+      expect(store.kernel).toEqual(kernel);
+    });
   });
 });

--- a/spec/store/index-spec.js
+++ b/spec/store/index-spec.js
@@ -172,6 +172,32 @@ describe("Store", () => {
     });
   });
 
+  describe("getFilesForKernel", () => {
+    it("should return files related to kernel", () => {
+      const kernel1 = new Kernel({
+        display_name: "Python 3",
+        language: "python"
+      });
+      const kernel2 = new Kernel({
+        display_name: "Python 3",
+        language: "python"
+      });
+
+      store.kernelMapping = new Map([
+        ["foo.py", kernel1],
+        ["bar.py", kernel1],
+        ["baz.py", kernel2],
+        ["foo.md", { python: kernel1, javascript: kernel2 }]
+      ]);
+
+      expect(store.getFilesForKernel(kernel1)).toEqual([
+        "foo.py",
+        "bar.py",
+        "foo.md"
+      ]);
+    });
+  });
+
   describe("updateEditor", () => {
     it("should update editor", () => {
       spyOn(store, "setGrammar").and.callThrough();

--- a/styles/hydrogen.less
+++ b/styles/hydrogen.less
@@ -12,7 +12,6 @@
 @hydrogen-inline-background: contrast(@syntax-text-color, @hydrogen-dark-background, @hydrogen-light-background, 20%);
 @hydrogen-inline-color: lighten(@syntax-text-color, 10%);
 @hydrogen-error-color: average(@syntax-text-color, red);
-@hydrogen-separator-border-color: contrast(@pane-item-background-color, fade(@pane-item-border-color, 20%), @pane-item-border-color);
 
 
 .hydrogen.marker {
@@ -266,7 +265,7 @@ svg:first-child {
   }
 
   .icon:hover {
-    color: @text-color-subtle;
+    color: @text-color-error;
   }
 }
 

--- a/styles/hydrogen.less
+++ b/styles/hydrogen.less
@@ -12,6 +12,8 @@
 @hydrogen-inline-background: contrast(@syntax-text-color, @hydrogen-dark-background, @hydrogen-light-background, 20%);
 @hydrogen-inline-color: lighten(@syntax-text-color, 10%);
 @hydrogen-error-color: average(@syntax-text-color, red);
+@hydrogen-separator-border-color: contrast(@pane-item-background-color, fade(@pane-item-border-color, 20%), @pane-item-border-color);
+
 
 .hydrogen.marker {
   display: flex;
@@ -244,6 +246,28 @@ svg:first-child {
     }
   }
 
+}
+
+// ----------- Kernel Monitor -------------
+.kernel-monitor {
+  header {
+    line-height: 2.5em;
+    font-weight: 600;
+    border-bottom: 1px solid @base-border-color;
+    padding: 0 10px;
+  }
+
+  div:not(:first-child) header {
+    border-top: 1px solid @base-border-color;
+  }
+
+  .icon::before {
+    width: 100%;
+  }
+
+  .icon:hover {
+    color: @text-color-subtle;
+  }
 }
 
 // -------------- Watches -----------------

--- a/types/hydrogen.js.flow
+++ b/types/hydrogen.js.flow
@@ -12,4 +12,5 @@ export type Message = {
 };
 
 // We can't put it in store/index.js because Atom's babel version doesn't support this syntax
-export type KernelMapping = Map<string, Kernel | { [string]: Kernel }>;
+export type KernelObj = { [string]: Kernel };
+export type KernelMapping = Map<string, Kernel | KernelObj>;

--- a/types/hydrogen.js.flow
+++ b/types/hydrogen.js.flow
@@ -2,11 +2,14 @@ export type Kernelspec = {
   env: Object,
   argv: Array<string>,
   display_name: string,
-  language: string,
-}
+  language: string
+};
 
 // Be more specific
 export type Message = {
   header: Object,
-  content: Object,
-}
+  content: Object
+};
+
+// We can't put it in store/index.js because Atom's babel version doesn't support this syntax
+export type KernelMapping = { [string]: Kernel | { [string]: Kernel } };

--- a/types/hydrogen.js.flow
+++ b/types/hydrogen.js.flow
@@ -12,4 +12,4 @@ export type Message = {
 };
 
 // We can't put it in store/index.js because Atom's babel version doesn't support this syntax
-export type KernelMapping = { [string]: Kernel | { [string]: Kernel } };
+export type KernelMapping = Map<string, Kernel | { [string]: Kernel }>;


### PR DESCRIPTION
This is a initial attempt at supporting multiple independent kernels.

**There are now three commands to start a new kernel:**
- "Start Local Kernel" (default when executing code in a new file)
- "Connect to Existing Kernel" (replaces "Switch Kernel")
- "Connect to Remote Kernel"

**Main Changes in this PR:**
- Kernels are indexed by file path
- By default a new ZMQ kernel is started when users runs code in a new file
- Users can connect multiple files to the same kernel via "Connect to Existing Kernel". This also supports remote kernels
- "Switch Kernel" command is removed since it's now obsolete
- "Select Kernel" command is renamed to "Start Local Kernel"
- New "Kernel Monitor" panel to manage all running kernels (open with "Toggle Kernel Monitor") :  
<img width="802" alt="monitor" src="https://user-images.githubusercontent.com/13285808/30815792-7b685b8a-a214-11e7-863e-f334f03eef0f.png">

This should be ready for testing and review.

Fixes #40