### PR TITLE
Refactor ws kernel picker

### DIFF
--- a/lib/ws-kernel-picker.js
+++ b/lib/ws-kernel-picker.js
@@ -11,15 +11,12 @@ import WSKernel from "./ws-kernel";
 import store from "./store";
 
 class CustomListView {
-  emptyMessage: string;
-  onConfirmed: (kernelSpecs: Kernelspec) => mixed;
+  onConfirmed: Function = () => {};
   previouslyFocusedElement: ?HTMLElement;
   selectListView: SelectListView;
   panel: ?atom$Panel;
 
-  constructor(emptyMessage, onConfirmed) {
-    this.emptyMessage = emptyMessage;
-    this.onConfirmed = onConfirmed;
+  constructor() {
     this.previouslyFocusedElement = document.activeElement;
     this.selectListView = new SelectListView({
       itemsClassList: ["mark-active"],
@@ -32,12 +29,12 @@ class CustomListView {
       },
       didConfirmSelection: item => {
         if (this.onConfirmed) this.onConfirmed(item);
-        this.cancel();
       },
-      didCancelSelection: () => this.cancel(),
-      emptyMessage: this.emptyMessage
+      didCancelSelection: () => this.cancel()
     });
+  }
 
+  show() {
     if (!this.panel) {
       this.panel = atom.workspace.addModalPanel({ item: this.selectListView });
     }
@@ -66,13 +63,15 @@ export default class WSKernelPicker {
   _onChosen: (kernel: Kernel) => void;
   _kernelSpecFilter: (kernelSpec: Kernelspec) => boolean;
   _path: string;
-  previouslyFocusedElement: ?HTMLElement;
+  listView: CustomListView;
 
   constructor(onChosen: (kernel: Kernel) => void) {
     this._onChosen = onChosen;
+    this.listView = new CustomListView();
   }
 
   async toggle(_kernelSpecFilter: (kernelSpec: Kernelspec) => boolean) {
+    this.listView.previouslyFocusedElement = document.activeElement;
     this._kernelSpecFilter = _kernelSpecFilter;
     const gateways = Config.getJson("gateways") || [];
     if (_.isEmpty(gateways)) {
@@ -85,22 +84,27 @@ export default class WSKernelPicker {
     const path = store.editor ? store.editor.getPath() : null;
 
     this._path = `${path || "unsaved"}-${v4()}`;
-    const gatewayListing = new CustomListView(
-      "No gateways available",
-      this.onGateway.bind(this)
-    );
-    this.previouslyFocusedElement = gatewayListing.previouslyFocusedElement;
-    await gatewayListing.selectListView.update({
+
+    this.listView.onConfirmed = this.onGateway.bind(this);
+
+    await this.listView.selectListView.update({
       items: gateways,
-      infoMessage: "Select a gateway"
+      infoMessage: "Select a gateway",
+      emptyMessage: "No gateways available",
+      loadingMessage: null
     });
+
+    this.listView.show();
   }
 
   async onGateway(gatewayInfo: any) {
-    const sessionListing = new CustomListView(
-      "No sessions available",
-      this.onSession.bind(this)
-    );
+    this.listView.onConfirmed = this.onSession.bind(this);
+    await this.listView.selectListView.update({
+      items: [],
+      infoMessage: null,
+      loadingMessage: "Loading sessions...",
+      emptyMessage: "No sessions available"
+    });
     try {
       const specModels = await Kernel.getSpecs(gatewayInfo.options);
       const kernelSpecs = _.filter(specModels.kernelspecs, spec =>
@@ -108,11 +112,6 @@ export default class WSKernelPicker {
       );
 
       const kernelNames = _.map(kernelSpecs, specModel => specModel.name);
-
-      sessionListing.previouslyFocusedElement = this.previouslyFocusedElement;
-      await sessionListing.selectListView.update({
-        loadingMessage: "Loading sessions..."
-      });
 
       try {
         let sessionModels = await Session.listRunning(gatewayInfo.options);
@@ -135,7 +134,7 @@ export default class WSKernelPicker {
           options: gatewayInfo.options,
           kernelSpecs
         });
-        await sessionListing.selectListView.update({
+        await this.listView.selectListView.update({
           items: items,
           loadingMessage: null
         });
@@ -153,20 +152,20 @@ export default class WSKernelPicker {
       }
     } catch (e) {
       atom.notifications.addError("Connection to gateway failed");
+      this.listView.cancel();
     }
-
-    sessionListing.selectListView.focus();
-    sessionListing.selectListView.reset();
   }
 
   async onSession(sessionInfo: any) {
     if (!sessionInfo.model) {
-      const kernelListing = new CustomListView(
-        "No kernel specs available",
-        this.startSession.bind(this)
-      );
-      kernelListing.previouslyFocusedElement = this.previouslyFocusedElement;
-
+      if (!sessionInfo.name) {
+        await this.listView.selectListView.update({
+          items: [],
+          errorMessage: "This gateway does not support listing sessions",
+          loadingMessage: null,
+          infoMessage: null
+        });
+      }
       const items = _.map(sessionInfo.kernelSpecs, spec => {
         const options = Object.assign({}, sessionInfo.options);
         options.kernelName = spec.name;
@@ -176,14 +175,14 @@ export default class WSKernelPicker {
           options
         };
       });
-      await kernelListing.selectListView.update({ items: items });
-      kernelListing.selectListView.focus();
-      kernelListing.selectListView.reset();
-      if (!sessionInfo.name) {
-        await kernelListing.selectListView.update({
-          errorMessage: "This gateway does not support listing sessions"
-        });
-      }
+
+      this.listView.onConfirmed = this.startSession.bind(this);
+      await this.listView.selectListView.update({
+        items: items,
+        emptyMessage: "No kernel specs available",
+        infoMessage: "Select a session",
+        loadingMessage: null
+      });
     } else {
       this.onSessionChosen(
         await Session.connectTo(sessionInfo.model.id, sessionInfo.options)
@@ -196,6 +195,7 @@ export default class WSKernelPicker {
   }
 
   async onSessionChosen(session: any) {
+    this.listView.cancel();
     const kernelSpec = await session.kernel.getSpec();
     if (!store.grammar) return;
 

--- a/lib/ws-kernel-picker.js
+++ b/lib/ws-kernel-picker.js
@@ -12,7 +12,7 @@ import store from "./store";
 
 class CustomListView {
   emptyMessage: string;
-  onConfirmed: (kernelSpecs: Kernelspec) => void;
+  onConfirmed: (kernelSpecs: Kernelspec) => mixed;
   previouslyFocusedElement: ?HTMLElement;
   selectListView: SelectListView;
   panel: ?atom$Panel;
@@ -72,7 +72,7 @@ export default class WSKernelPicker {
     this._onChosen = onChosen;
   }
 
-  toggle(_kernelSpecFilter: (kernelSpec: Kernelspec) => boolean) {
+  async toggle(_kernelSpecFilter: (kernelSpec: Kernelspec) => boolean) {
     this._kernelSpecFilter = _kernelSpecFilter;
     const gateways = Config.getJson("gateways") || [];
     if (_.isEmpty(gateways)) {
@@ -90,82 +90,76 @@ export default class WSKernelPicker {
       this.onGateway.bind(this)
     );
     this.previouslyFocusedElement = gatewayListing.previouslyFocusedElement;
-    gatewayListing.selectListView.update({
+    await gatewayListing.selectListView.update({
       items: gateways,
       infoMessage: "Select a gateway"
     });
   }
 
-  onGateway(gatewayInfo: any) {
+  async onGateway(gatewayInfo: any) {
     const sessionListing = new CustomListView(
       "No sessions available",
       this.onSession.bind(this)
     );
-    Kernel.getSpecs(gatewayInfo.options)
-      .then(
-        specModels => {
-          const kernelSpecs = _.filter(specModels.kernelspecs, spec =>
-            this._kernelSpecFilter(spec)
-          );
+    try {
+      const specModels = await Kernel.getSpecs(gatewayInfo.options);
+      const kernelSpecs = _.filter(specModels.kernelspecs, spec =>
+        this._kernelSpecFilter(spec)
+      );
 
-          const kernelNames = _.map(kernelSpecs, specModel => specModel.name);
+      const kernelNames = _.map(kernelSpecs, specModel => specModel.name);
 
-          sessionListing.previouslyFocusedElement = this.previouslyFocusedElement;
-          sessionListing.selectListView.update({
-            loadingMessage: "Loading sessions..."
-          });
-
-          Session.listRunning(gatewayInfo.options).then(
-            sessionModels => {
-              sessionModels = sessionModels.filter(model => {
-                const name = model.kernel ? model.kernel.name : null;
-                return name ? kernelNames.includes(name) : true;
-              });
-              const items = sessionModels.map(model => {
-                let name;
-                if (model.notebook && model.notebook.path) {
-                  name = tildify(model.notebook.path);
-                } else {
-                  name = `Session ${model.id}`;
-                }
-                return {
-                  name,
-                  model,
-                  options: gatewayInfo.options
-                };
-              });
-              items.unshift({
-                name: "[new session]",
-                model: null,
-                options: gatewayInfo.options,
-                kernelSpecs
-              });
-              return sessionListing.selectListView.update({
-                items: items,
-                loadingMessage: null
-              });
-            },
-            () =>
-              // Gateways offer the option of never listing sessions, for security
-              // reasons.
-              // Assume this is the case and proceed to creating a new session.
-              this.onSession({
-                name: "[new session]",
-                model: null,
-                options: gatewayInfo.options,
-                kernelSpecs
-              })
-          );
-        },
-        () => atom.notifications.addError("Connection to gateway failed")
-      )
-      .then(() => {
-        sessionListing.selectListView.focus();
-        sessionListing.selectListView.reset();
+      sessionListing.previouslyFocusedElement = this.previouslyFocusedElement;
+      await sessionListing.selectListView.update({
+        loadingMessage: "Loading sessions..."
       });
+
+      try {
+        let sessionModels = await Session.listRunning(gatewayInfo.options);
+        sessionModels = sessionModels.filter(model => {
+          const name = model.kernel ? model.kernel.name : null;
+          return name ? kernelNames.includes(name) : true;
+        });
+        const items = sessionModels.map(model => {
+          let name;
+          if (model.notebook && model.notebook.path) {
+            name = tildify(model.notebook.path);
+          } else {
+            name = `Session ${model.id}`;
+          }
+          return { name, model, options: gatewayInfo.options };
+        });
+        items.unshift({
+          name: "[new session]",
+          model: null,
+          options: gatewayInfo.options,
+          kernelSpecs
+        });
+        await sessionListing.selectListView.update({
+          items: items,
+          loadingMessage: null
+        });
+      } catch (error) {
+        if (!error.xhr || error.xhr.status !== 403) throw error;
+        // Gateways offer the option of never listing sessions, for security
+        // reasons.
+        // Assume this is the case and proceed to creating a new session.
+        this.onSession({
+          name: "[new session]",
+          model: null,
+          options: gatewayInfo.options,
+          kernelSpecs
+        });
+      }
+    } catch (e) {
+      atom.notifications.addError("Connection to gateway failed");
+    }
+
+    sessionListing.selectListView.focus();
+    sessionListing.selectListView.reset();
   }
 
-  onSession(sessionInfo: any) {
+  async onSession(sessionInfo: any) {
     if (!sessionInfo.model) {
       const kernelListing = new CustomListView(
         "No kernel specs available",
@@ -182,17 +176,17 @@ export default class WSKernelPicker {
           options
         };
       });
-      kernelListing.selectListView.update({ items: items });
+      await kernelListing.selectListView.update({ items: items });
       kernelListing.selectListView.focus();
       kernelListing.selectListView.reset();
       if (!sessionInfo.name) {
-        kernelListing.selectListView.update({
+        await kernelListing.selectListView.update({
           errorMessage: "This gateway does not support listing sessions"
         });
       }
     } else {
-      Session.connectTo(sessionInfo.model.id, sessionInfo.options).then(
-        this.onSessionChosen.bind(this)
+      this.onSessionChosen(
+        await Session.connectTo(sessionInfo.model.id, sessionInfo.options)
       );
     }
   }
@@ -201,12 +195,11 @@ export default class WSKernelPicker {
     Session.startNew(sessionInfo.options).then(this.onSessionChosen.bind(this));
   }
 
-  onSessionChosen(session: any) {
-    session.kernel.getSpec().then(kernelSpec => {
-      if (!store.grammar) return;
+  async onSessionChosen(session: any) {
+    const kernelSpec = await session.kernel.getSpec();
+    if (!store.grammar) return;
 
-      const kernel = new WSKernel(kernelSpec, store.grammar, session);
-      this._onChosen(kernel);
-    });
+    const kernel = new WSKernel(kernelSpec, store.grammar, session);
+    this._onChosen(kernel);
   }
 }


### PR DESCRIPTION
While checking out #908 I did a small refactor of the WS-Kernel-Picker.

Main changes:
- Replace promises with async/await
- Only use one `select-list-view` instance. This removes some annoying UI flickering when using the picker and makes the navigation smoother. 
