### PR TITLE
Make text in panes (inspector, output, watch) copyable

### DIFF
--- a/lib/panes/inspector.js
+++ b/lib/panes/inspector.js
@@ -13,7 +13,8 @@ export default class InspectorPane {
   disposer = new CompositeDisposable();
 
   constructor(store: store) {
-    this.element.classList.add("hydrogen", "inspector");
+    this.element.classList.add("hydrogen", "inspector", "native-key-bindings");
+    this.element.setAttribute("tabindex", "-1");
 
     reactFactory(
       <Inspector store={store} />,

--- a/lib/panes/output-area.js
+++ b/lib/panes/output-area.js
@@ -13,7 +13,8 @@ export default class OutputPane {
   disposer = new CompositeDisposable();
 
   constructor(store: store) {
-    this.element.classList.add("hydrogen");
+    this.element.classList.add("hydrogen", "native-key-bindings");
+    this.element.setAttribute("tabindex", "-1");
 
     this.disposer.add(
       new Disposable(() => {

--- a/lib/panes/watches.js
+++ b/lib/panes/watches.js
@@ -13,7 +13,8 @@ export default class WatchesPane {
   disposer = new CompositeDisposable();
 
   constructor(store: store) {
-    this.element.classList.add("hydrogen");
+    this.element.classList.add("hydrogen", "native-key-bindings");
+    this.element.setAttribute("tabindex", "-1");
 
     reactFactory(<Watches store={store} />, this.element, null, this.disposer);
   }


### PR DESCRIPTION
added `native-key-binding` class and `tabindex:-1` to panes to allow copying via ctrl-c from them
addresses #989 and #845 (related: #954)
inspired by rgbkrk/atom-script/pull/79