### PR TITLE
Fix: Backspace key not working in Watches editor

### DIFF
--- a/lib/components/inspector.js
+++ b/lib/components/inspector.js
@@ -28,6 +28,8 @@ const Inspector = observer(({ store: { kernel } }: Props) => {
   const Transform = transforms[mimetype];
   return (
     <div
+      className="native-key-bindings"
+      tabIndex="-1"
       style={{
         fontSize: atom.config.get(`Hydrogen.outputAreaFontSize`) || "inherit"
       }}

--- a/lib/components/result-view/history.js
+++ b/lib/components/result-view/history.js
@@ -46,7 +46,8 @@ const History = observer(({ store }: { store: OutputStore }) => {
         />
       </div>
       <div
-        className="multiline-container"
+        className="multiline-container native-key-bindings"
+        tabIndex="-1"
         style={{
           fontSize: atom.config.get(`Hydrogen.outputAreaFontSize`) || "inherit"
         }}

--- a/lib/components/result-view/list.js
+++ b/lib/components/result-view/list.js
@@ -34,7 +34,8 @@ class ScrollList extends React.Component<Props> {
     if (this.props.outputs.length === 0) return null;
     return (
       <div
-        className="scroll-list multiline-container"
+        className="scroll-list multiline-container native-key-bindings"
+        tabIndex="-1"
         style={{
           fontSize: atom.config.get(`Hydrogen.outputAreaFontSize`) || "inherit"
         }}

--- a/lib/panes/inspector.js
+++ b/lib/panes/inspector.js
@@ -13,8 +13,7 @@ export default class InspectorPane {
   disposer = new CompositeDisposable();
 
   constructor(store: store) {
-    this.element.classList.add("hydrogen", "inspector", "native-key-bindings");
-    this.element.setAttribute("tabindex", "-1");
+    this.element.classList.add("hydrogen", "inspector");
 
     reactFactory(
       <Inspector store={store} />,

--- a/lib/panes/output-area.js
+++ b/lib/panes/output-area.js
@@ -13,8 +13,7 @@ export default class OutputPane {
   disposer = new CompositeDisposable();
 
   constructor(store: store) {
-    this.element.classList.add("hydrogen", "native-key-bindings");
-    this.element.setAttribute("tabindex", "-1");
+    this.element.classList.add("hydrogen");
 
     this.disposer.add(
       new Disposable(() => {

--- a/lib/panes/watches.js
+++ b/lib/panes/watches.js
@@ -13,8 +13,7 @@ export default class WatchesPane {
   disposer = new CompositeDisposable();
 
   constructor(store: store) {
-    this.element.classList.add("hydrogen", "native-key-bindings");
-    this.element.setAttribute("tabindex", "-1");
+    this.element.classList.add("hydrogen");
 
     reactFactory(<Watches store={store} />, this.element, null, this.disposer);
   }


### PR DESCRIPTION
#1017 Cause the backspace key to stop working in the watch editor.

This fixes it by only applying the `native-key-bindings` class to the elements where people should be able to copy from.

/cc @ttor 