### PR TITLE
Don't rely on jupyter to discover kernel specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Greenkeeper badge](https://badges.greenkeeper.io/nteract/hydrogen.svg)](https://greenkeeper.io/)
 [![Build Status](https://travis-ci.org/nteract/hydrogen.svg?branch=master)](https://travis-ci.org/nteract/hydrogen)
 
-Hydrogen is a interactive coding environment that supports Python, R, JavaScript and [other Jupyter kernels](https://github.com/jupyter/jupyter/wiki/Jupyter-kernels).
+Hydrogen is an interactive coding environment that supports Python, R, JavaScript and [other Jupyter kernels](https://github.com/jupyter/jupyter/wiki/Jupyter-kernels).
 
 Checkout our [Documentation](https://nteract.gitbooks.io/hydrogen/) and [Medium blog post](https://medium.com/nteract/hydrogen-interactive-computing-in-atom-89d291bcc4dd) to see what you can do with Hydrogen.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Greenkeeper badge](https://badges.greenkeeper.io/nteract/hydrogen.svg)](https://greenkeeper.io/)
 [![Build Status](https://travis-ci.org/nteract/hydrogen.svg?branch=master)](https://travis-ci.org/nteract/hydrogen)
 
-This package lets you run your code directly in Atom using any [Jupyter](https://jupyter.org/) kernels you have installed.
+Hydrogen is a interactive coding environment that supports Python, R, JavaScript and [other Jupyter kernels](https://github.com/jupyter/jupyter/wiki/Jupyter-kernels).
 
 Checkout our [Documentation](https://nteract.gitbooks.io/hydrogen/) and [Medium blog post](https://medium.com/nteract/hydrogen-interactive-computing-in-atom-89d291bcc4dd) to see what you can do with Hydrogen.
 

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-Hydrogen requires **[Atom](https://atom.io/)** `1.20.0+` and a **[Kernel](##kernels)** for the language you intend to use Hydrogen with.
+Hydrogen requires **[Atom](https://atom.io/)** `1.20.0+` and a **[kernels](##kernels)** for the languages you intend to use Hydrogen with.
 
 To install Hydrogen run `apm install hydrogen` or search for *Hydrogen* in the Install pane of the Atom settings.
 
@@ -13,12 +13,11 @@ Checkout [nteract.io/kernels](https://nteract.io/kernels) for instructions on ho
 Tested and works with:
 
 - [IPython](http://ipython.org/)
-- [IRkernel](https://github.com/IRkernel/IRkernel) `0.4+` requires
+- [IRkernel](https://github.com/IRkernel/IRkernel) `0.4+` requires [`language-r`](https://atom.io/packages/language-r) or similar
 - [IJulia](https://github.com/JuliaLang/IJulia.jl)
 - [iTorch](https://github.com/facebook/iTorch)
 - [IJavascript](https://github.com/n-riesco/ijavascript)
 - [jupyter-nodejs](https://github.com/notablemind/jupyter-nodejs)
- [`language-r`](https://atom.io/packages/language-r) or similar
 - [IElixir](https://github.com/pprzetacznik/IElixir)
 - [jupyter-scala](https://github.com/alexarchambault/jupyter-scala)
 - [kotlin-jupyter](https://github.com/ligee/kotlin-jupyter)

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -1,24 +1,24 @@
 # Installation
 
-For all systems, you'll need
+Hydrogen requires **[Atom](https://atom.io/)** `1.20.0+` and a **[Kernel](##kernels)** for the language you intend to use Hydrogen with.
 
-- [Atom](https://atom.io/) `1.17.0+`
-- [Jupyter](http://jupyter.org): If you have Python and conda or pip setup, install the notebook directly with `conda install jupyter` or `pip install jupyter`.
-
-You can now run `apm install hydrogen` or search for *Hydrogen* in the Install pane of the Atom settings.
+To install Hydrogen run `apm install hydrogen` or search for *Hydrogen* in the Install pane of the Atom settings.
 
 If you are using Linux 32-bit follow the installation instructions [here](Troubleshooting.md).
 
 ## Kernels
 
+Checkout [nteract.io/kernels](https://nteract.io/kernels) for instructions on how to install the most popular kernels.
+
 Tested and works with:
 
 - [IPython](http://ipython.org/)
+- [IRkernel](https://github.com/IRkernel/IRkernel) `0.4+` requires
 - [IJulia](https://github.com/JuliaLang/IJulia.jl)
 - [iTorch](https://github.com/facebook/iTorch)
 - [IJavascript](https://github.com/n-riesco/ijavascript)
 - [jupyter-nodejs](https://github.com/notablemind/jupyter-nodejs)
-- [IRkernel](https://github.com/IRkernel/IRkernel) `0.4+` requires [`language-r`](https://atom.io/packages/language-r) or similar
+ [`language-r`](https://atom.io/packages/language-r) or similar
 - [IElixir](https://github.com/pprzetacznik/IElixir)
 - [jupyter-scala](https://github.com/alexarchambault/jupyter-scala)
 - [kotlin-jupyter](https://github.com/ligee/kotlin-jupyter)

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -18,40 +18,6 @@ Please, also include the output or a screenshot of the debug messages. To access
 
 ## Common Issues
 
-### Debian 8 and Ubuntu 16.04 LTS
-
-Unfortunately, the versions of IPython provided in Debian's and Ubuntu's
-repositories are rather old and Hydrogen is unable to detect the kernel specs
-installed in your machine. To workaround this issue, Hydrogen provides the
-setting `KernelSpec`, where the user can declare the kernel specs manually.
-Find the `KernelSpec` setting in the Atom GUI by going to the Settings pane,
-click Packages, search for Hydrogen, and click the Hydrogen Settings button.
-
-Below is an example `KernelSpec` for IPython 2 and 3:
-
-```json
-{
-  "kernelspecs": {
-    "python2": {
-      "spec": {
-        "display_name": "Python 2",
-        "language": "python",
-        "argv": ["python2.7", "-m", "ipykernel", "-f", "{connection_file}"],
-        "env": {}
-      }
-    },
-    "python3": {
-      "spec": {
-        "display_name": "Python 3",
-        "language": "python",
-        "argv": ["python3.4", "-m", "ipykernel", "-f", "{connection_file}"],
-        "env": {}
-      }
-    }
-  }
-}
-```
-
 ### Installation fails on Linux 32-bit
 
 At the moment we don't ship prebuilts for 32-bit Linux. Hence you'll need some additional toolling to build from source:
@@ -64,13 +30,9 @@ Use your distribution's package manager to install.
 
 If your default `python` is 3.x, you need to run instead `PYTHON=python2.7 apm install hydrogen` or change the default version for `apm` with `apm config set python $(which python2.7)` beforehand. You can still use 3.x versions of Python in Hydrogen, but it will only build with 2.x due to a [longstanding issue with `gyp`](https://bugs.chromium.org/p/gyp/issues/detail?id=36).
 
-### No kernel for language X found, but I have a kernel for that language.
+### No kernel for language X found
 
-Currently, a recent version of Jupyter is required for Hydrogen to detect the
-available kernels automatically. Users can set kernels manually using the
-Hydrogen settings. See
-[this section](https://github.com/nteract/hydrogen#debian-8-and-ubuntu-1604-lts)
-in the [README](README.md) for more details.
+Hydrogen requires a Kernel to run code. Checkout [nteract.io/kernels](https://nteract.io/kernels) for instructions on how to install the most popular kernels.
 
 Atom won't pick up kernels inside a virtualenv unless Atom is launched as `atom .` within the virtualenv. The alternative is to [create a kernel specifically for a virtualenv](http://www.alfredo.motta.name/create-isolated-jupyter-ipython-kernels-with-pyenv-and-virtualenv/).
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -82,14 +82,6 @@ const Config = {
       type: "string",
       default: "[]"
     },
-    kernelspec: {
-      title: "Kernel Specs",
-      includeTitle: false,
-      description:
-        'This field is populated on every launch or by invoking the command `hydrogen:update-kernels`. It contains the JSON string resulting from running `jupyter kernelspec list --json` or `ipython kernelspec list --json`. You can also edit this field and specify custom kernel specs , like this: ``` { "kernelspecs": { "ijavascript": { "spec": { "display_name": "IJavascript", "env": {}, "argv": [ "node", "/home/user/node_modules/ijavascript/lib/kernel.js", "--protocol=5.0", "{connection_file}" ], "language": "javascript" }, "resources_dir": "/home/user/node_modules/ijavascript/images" } } } ```',
-      type: "string",
-      default: "{}"
-    },
     languageMappings: {
       title: "Language Mappings",
       includeTitle: false,

--- a/lib/config.js
+++ b/lib/config.js
@@ -14,6 +14,7 @@ const Config = {
   },
 
   schema: {
+    kernelspec: {},
     autocomplete: {
       title: "Enable Autocomplete",
       includeTitle: false,

--- a/lib/kernel-manager.js
+++ b/lib/kernel-manager.js
@@ -1,12 +1,11 @@
 /* @flow */
 
 import _ from "lodash";
-import { exec } from "child_process";
+import * as kernelspecs from "kernelspecs";
 import { launchSpec } from "spawnteract";
-import fs from "fs";
-import path from "path";
+// $FlowFixMe
+import { shell } from "electron";
 
-import Config from "./config";
 import ZMQKernel from "./zmq-kernel";
 
 import KernelPicker from "./kernel-picker";
@@ -15,12 +14,11 @@ import { getEditorDirectory, kernelSpecProvidesGrammar, log } from "./utils";
 
 import type { Connection } from "./zmq-kernel";
 
-class KernelManager {
-  _kernelSpecs: ?Object;
+export const ks = kernelspecs;
+
+export class KernelManager {
+  kernelSpecs: ?Array<Kernelspec> = null;
   kernelPicker: ?KernelPicker;
-  constructor() {
-    this._kernelSpecs = this.getKernelSpecsFromSettings();
-  }
 
   startKernelFor(
     grammar: atom$Grammar,
@@ -28,7 +26,7 @@ class KernelManager {
     filePath: string,
     onStarted: (kernel: ZMQKernel) => void
   ) {
-    this.getKernelSpecForGrammar(grammar, kernelSpec => {
+    this.getKernelSpecForGrammar(grammar).then(kernelSpec => {
       if (!kernelSpec) {
         const message = `No kernel for grammar \`${grammar.name}\` found`;
         const description =
@@ -81,129 +79,75 @@ class KernelManager {
     });
   }
 
-  getAllKernelSpecs(callback: Function) {
-    if (_.isEmpty(this._kernelSpecs)) {
-      return this.updateKernelSpecs(() =>
-        callback(_.map(this._kernelSpecs, "spec"))
-      );
-    }
-    return callback(_.map(this._kernelSpecs, "spec"));
+  async update() {
+    const kernelSpecs = await ks.findAll();
+    this.kernelSpecs = _.map(kernelSpecs, "spec");
+    return this.kernelSpecs;
   }
 
-  getAllKernelSpecsForGrammar(grammar: ?atom$Grammar, callback: Function) {
-    if (grammar) {
-      return this.getAllKernelSpecs(kernelSpecs => {
-        const specs = kernelSpecs.filter(spec =>
-          kernelSpecProvidesGrammar(spec, grammar)
-        );
-
-        return callback(specs);
-      });
-    }
-    return callback([]);
+  async getAllKernelSpecs() {
+    if (this.kernelSpecs) return this.kernelSpecs;
+    return this.updateKernelSpecs();
   }
 
-  getKernelSpecForGrammar(grammar: atom$Grammar, callback: Function) {
-    this.getAllKernelSpecsForGrammar(grammar, kernelSpecs => {
-      if (kernelSpecs.length <= 1) {
-        callback(kernelSpecs[0]);
-        return;
-      }
+  async getAllKernelSpecsForGrammar(grammar: ?atom$Grammar) {
+    if (!grammar) return [];
 
-      if (this.kernelPicker) {
-        this.kernelPicker.kernelSpecs = kernelSpecs;
-      } else {
-        this.kernelPicker = new KernelPicker(kernelSpecs);
-      }
+    const kernelSpecs = await this.getAllKernelSpecs();
+    return kernelSpecs.filter(spec => kernelSpecProvidesGrammar(spec, grammar));
+  }
 
-      this.kernelPicker.onConfirmed = kernelSpec => callback(kernelSpec);
+  async getKernelSpecForGrammar(grammar: atom$Grammar) {
+    const kernelSpecs = await this.getAllKernelSpecsForGrammar(grammar);
+    if (kernelSpecs.length <= 1) {
+      return kernelSpecs[0];
+    }
+
+    if (this.kernelPicker) {
+      this.kernelPicker.kernelSpecs = kernelSpecs;
+    } else {
+      this.kernelPicker = new KernelPicker(kernelSpecs);
+    }
+
+    return new Promise(resolve => {
+      if (!this.kernelPicker) return resolve(null);
+      this.kernelPicker.onConfirmed = kernelSpec => resolve(kernelSpec);
       this.kernelPicker.toggle();
     });
   }
 
-  kernelSpecProvidesLanguage(kernelSpec: Kernelspec, grammarLanguage: string) {
-    return kernelSpec.language.toLowerCase() === grammarLanguage.toLowerCase();
-  }
+  async updateKernelSpecs() {
+    const kernelSpecs = await this.update();
 
-  getKernelSpecsFromSettings() {
-    const settings = Config.getJson("kernelspec");
-
-    if (!settings.kernelspecs) {
-      return {};
+    if (kernelSpecs.length === 0) {
+      const message = "No Kernels Installed";
+      const options = {
+        description:
+          "No kernels are installed on your system so you will not be able to execute code in any language.\n\nCheckout [all available kernels](https://github.com/jupyter/jupyter/wiki/Jupyter-kernels).",
+        dismissable: true,
+        buttons: [
+          {
+            text: "Install Instructions",
+            onDidClick: () =>
+              shell.openExternal(
+                "https://nteract.gitbooks.io/hydrogen/docs/Installation.html"
+              )
+          },
+          {
+            text: "Popular Kernels",
+            onDidClick: () => shell.openExternal("https://nteract.io/kernels")
+          }
+        ]
+      };
+      atom.notifications.addError(message, options);
+    } else {
+      const message = "Hydrogen Kernels updated:";
+      const options = {
+        detail: _.map(kernelSpecs, "display_name").join("\n")
+      };
+      atom.notifications.addInfo(message, options);
     }
-
-    // remove invalid entries
-    return _.pickBy(
-      settings.kernelspecs,
-      ({ spec }) => spec && spec.language && spec.display_name && spec.argv
-    );
-  }
-
-  mergeKernelSpecs(kernelSpecs: Kernelspec) {
-    _.assign(this._kernelSpecs, kernelSpecs);
-  }
-
-  updateKernelSpecs(callback: ?Function) {
-    this._kernelSpecs = this.getKernelSpecsFromSettings();
-    this.getKernelSpecsFromJupyter((err, kernelSpecsFromJupyter) => {
-      if (!err) {
-        this.mergeKernelSpecs(kernelSpecsFromJupyter);
-      }
-
-      if (_.isEmpty(this._kernelSpecs)) {
-        const message = "No kernel specs found";
-        const options = {
-          description:
-            "Use kernelSpec option in Hydrogen or update IPython/Jupyter to a version that supports: `jupyter kernelspec list --json` or `ipython kernelspec list --json`",
-          dismissable: true
-        };
-        atom.notifications.addError(message, options);
-      } else {
-        err = null;
-        const message = "Hydrogen Kernels updated:";
-        const options = {
-          detail: _.map(this._kernelSpecs, "spec.display_name").join("\n")
-        };
-        atom.notifications.addInfo(message, options);
-      }
-
-      if (callback) callback(err, this._kernelSpecs);
-    });
-  }
-
-  getKernelSpecsFromJupyter(callback: Function) {
-    const jupyter = "jupyter kernelspec list --json --log-level=CRITICAL";
-    const ipython = "ipython kernelspec list --json --log-level=CRITICAL";
-
-    return this.getKernelSpecsFrom(jupyter, (jupyterError, kernelSpecs) => {
-      if (!jupyterError) {
-        return callback(jupyterError, kernelSpecs);
-      }
-
-      return this.getKernelSpecsFrom(ipython, (ipythonError, specs) => {
-        if (!ipythonError) {
-          return callback(ipythonError, specs);
-        }
-        return callback(jupyterError, specs);
-      });
-    });
-  }
-
-  getKernelSpecsFrom(command: string, callback: Function) {
-    const options = { killSignal: "SIGINT" };
-    let kernelSpecs;
-    return exec(command, options, (err, stdout) => {
-      if (!err) {
-        try {
-          kernelSpecs = JSON.parse(stdout.toString()).kernelspecs;
-        } catch (error) {
-          err = error;
-          log("Could not parse kernelspecs:", err);
-        }
-      }
-
-      return callback(err, kernelSpecs);
-    });
+    return kernelSpecs;
   }
 }
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -513,23 +513,25 @@ const Hydrogen = {
   },
 
   startZMQKernel() {
-    kernelManager.getAllKernelSpecsForGrammar(store.grammar, kernelSpecs => {
-      if (this.kernelPicker) {
-        this.kernelPicker.kernelSpecs = kernelSpecs;
-      } else {
-        this.kernelPicker = new KernelPicker(kernelSpecs);
+    kernelManager
+      .getAllKernelSpecsForGrammar(store.grammar)
+      .then(kernelSpecs => {
+        if (this.kernelPicker) {
+          this.kernelPicker.kernelSpecs = kernelSpecs;
+        } else {
+          this.kernelPicker = new KernelPicker(kernelSpecs);
 
-        this.kernelPicker.onConfirmed = (kernelSpec: Kernelspec) => {
-          const { editor, grammar, filePath } = store;
-          if (!editor || !grammar || !filePath) return;
-          store.markers.clear();
+          this.kernelPicker.onConfirmed = (kernelSpec: Kernelspec) => {
+            const { editor, grammar, filePath } = store;
+            if (!editor || !grammar || !filePath) return;
+            store.markers.clear();
 
-          kernelManager.startKernel(kernelSpec, grammar, editor, filePath);
-        };
-      }
+            kernelManager.startKernel(kernelSpec, grammar, editor, filePath);
+          };
+        }
 
-      this.kernelPicker.toggle();
-    });
+        this.kernelPicker.toggle();
+      });
   },
 
   connectToWSKernel() {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "escape-carriage": "^1.2.0",
     "escape-string-regexp": "^1.0.5",
     "jmp": "^0.7.5",
+    "kernelspecs": "^2.0.0",
     "lodash": "^4.14.0",
     "mobx": "^3.3.0",
     "mobx-react": "^4.3.3",

--- a/spec/kernel-manager-spec.js
+++ b/spec/kernel-manager-spec.js
@@ -1,142 +1,137 @@
 "use babel";
 
-import kernelManager from "../lib/kernel-manager";
+import { KernelManager, ks } from "../lib/kernel-manager";
+
+const JAVASCRIPT_SPEC = {
+  display_name: "IJavascript",
+  env: {},
+  argv: [
+    "node",
+    "/home/user/node_modules/ijavascript/lib/kernel.js",
+    "--protocol=5.0",
+    "{connection_file}"
+  ],
+  language: "javascript"
+};
+const PYTHON_SPEC = {
+  language: "python",
+  display_name: "Python 2",
+  env: {},
+  argv: [
+    "/usr/local/opt/python/bin/python2.7",
+    "-m",
+    "ipykernel",
+    "-f",
+    "{connection_file}"
+  ]
+};
+
+const PYTHON3_SPEC = Object.assign({}, PYTHON_SPEC, {
+  display_name: "Python 3"
+});
+
+const KERNEL_SPECS = {
+  ijavascript: { spec: JAVASCRIPT_SPEC },
+  python2: { spec: PYTHON_SPEC },
+  python3: { spec: PYTHON3_SPEC }
+};
+const SPECS = [JAVASCRIPT_SPEC, PYTHON_SPEC, PYTHON3_SPEC];
 
 describe("Kernel manager", () => {
+  let manager;
+  beforeEach(() => {
+    spyOn(ks, "findAll").and.returnValue(Promise.resolve(KERNEL_SPECS));
+    manager = new KernelManager();
+  });
   describe("constructor", () => {
-    it("should call initialize _kernelSpecs", () => {
-      expect(kernelManager._kernelSpecs).toEqual({});
+    it("should call initialize kernelSpecs", () => {
+      expect(manager.kernelSpecs).toEqual(null);
+    });
+  });
+  describe("update", () => {
+    it("should update kernelspecs", async () => {
+      const specs = await manager.update();
+      expect(specs).toEqual(SPECS);
+      expect(manager.kernelSpecs).toEqual(SPECS);
+      expect(ks.findAll).toHaveBeenCalled();
     });
   });
 
-  describe("handle kernelspecs", () => {
-    const firstKernelSpecString = `{
-        "kernelspecs": {
-          "ijavascript": {
-            "spec": {
-              "display_name": "IJavascript",
-              "env": {},
-              "argv": [
-                "node",
-                "/home/user/node_modules/ijavascript/lib/kernel.js",
-                "--protocol=5.0",
-                "{connection_file}"
-              ],
-              "language": "javascript"
-            },
-            "resource_dir": "/home/user/node_modules/ijavascript/images"
-          }
-        }
-      }`;
-    const secondKernelSpecString = `{
-        "kernelspecs": {
-          "python2": {
-            "spec": {
-              "language": "python",
-              "display_name": "Python 2",
-              "env": {},
-              "argv": [
-                "/usr/local/opt/python/bin/python2.7",
-                "-m",
-                "ipykernel",
-                "-f",
-                "{connection_file}"
-              ]
-            }
-          }
-        }
-      }`;
-
-    const firstKernelSpec = JSON.parse(firstKernelSpecString);
-    const secondKernelSpec = JSON.parse(secondKernelSpecString);
-
-    const kernelSpecs = JSON.parse(firstKernelSpecString);
-    kernelSpecs.kernelspecs.python2 = secondKernelSpec.kernelspecs.python2;
-    describe("getKernelSpecsFromSettings", () => {
-      it("should parse kernelspecs from settings", () => {
-        atom.config.set("Hydrogen.kernelspec", firstKernelSpecString);
-
-        const parsed = kernelManager.getKernelSpecsFromSettings();
-
-        expect(parsed).toEqual(firstKernelSpec.kernelspecs);
-      });
-
-      it("should return {} if no kernelspec is set", () => {
-        atom.config.set("Hydrogen.kernelspec", "");
-        expect(kernelManager.getKernelSpecsFromSettings()).toEqual({});
-      });
-
-      it("should return {} if invalid kernelspec is set", () => {
-        atom.config.set("Hydrogen.kernelspec", "invalid");
-        expect(kernelManager.getKernelSpecsFromSettings()).toEqual({});
-      });
+  describe("getAllKernelSpecs", () => {
+    it("should update kernelspecs if no kernelspecs are stored", async () => {
+      spyOn(manager, "update").and.returnValue("specs");
+      expect(await manager.getAllKernelSpecs()).toBe("specs");
+      expect(manager.update).toHaveBeenCalled();
     });
 
-    describe("mergeKernelSpecs", () =>
-      it("should merge kernelspecs", () => {
-        kernelManager._kernelSpecs = firstKernelSpec.kernelspecs;
-        kernelManager.mergeKernelSpecs(secondKernelSpec.kernelspecs);
+    it("should return stored kernelspecs", async () => {
+      spyOn(manager, "update").and.returnValue("specs");
+      manager.kernelSpecs = SPECS;
+      expect(await manager.getAllKernelSpecs()).toEqual(SPECS);
+      expect(manager.update).not.toHaveBeenCalled();
+    });
+  });
 
-        const specs = kernelManager._kernelSpecs;
-        expect(specs).toEqual(kernelSpecs.kernelspecs);
-      }));
-
-    describe("getAllKernelSpecs", () => {
-      it("should return an array with specs", done => {
-        kernelManager._kernelSpecs = kernelSpecs.kernelspecs;
-        kernelManager.getAllKernelSpecs(specs => {
-          expect(specs.length).toEqual(2);
-          expect(specs[0]).toEqual(kernelSpecs.kernelspecs.ijavascript.spec);
-          expect(specs[1]).toEqual(kernelSpecs.kernelspecs.python2.spec);
-          done();
-        });
-      });
+  describe("getAllKernelSpecsForGrammar", () => {
+    it("should return empty array if no grammar", async () => {
+      expect(await manager.getAllKernelSpecsForGrammar()).toEqual([]);
+      expect(await manager.getAllKernelSpecsForGrammar(null)).toEqual([]);
     });
 
-    describe("getAllKernelSpecsForGrammar", () => {
-      it("should return an array with specs for given language", done => {
-        kernelManager._kernelSpecs = kernelSpecs.kernelspecs;
-        kernelManager.getAllKernelSpecsForGrammar({ name: "python" }, specs => {
-          expect(specs.length).toEqual(1);
-          expect(specs[0]).toEqual(kernelSpecs.kernelspecs.python2.spec);
-          done();
-        });
-      });
+    it("should return matching specs for grammar", async () => {
+      spyOn(manager, "getAllKernelSpecs").and.returnValue(SPECS);
+      expect(
+        await manager.getAllKernelSpecsForGrammar({ name: "python" })
+      ).toEqual([PYTHON_SPEC, PYTHON3_SPEC]);
+    });
+  });
 
-      it("should return an empty array", done => {
-        kernelManager._kernelSpecs = kernelSpecs.kernelspecs;
-        kernelManager.getAllKernelSpecsForGrammar({ name: "julia" }, specs => {
-          expect(specs).toEqual([]);
-          done();
-        });
-      });
+  describe("getKernelSpecForGrammar", () => {
+    it("should return undefined if not kernelspecs found", async () => {
+      spyOn(manager, "getAllKernelSpecsForGrammar").and.returnValue([]);
+      expect(await manager.getKernelSpecForGrammar()).toBeUndefined();
     });
 
-    describe("getKernelSpecForGrammar", () => {
-      it("should return spec for given language", done => {
-        kernelManager._kernelSpecs = kernelSpecs.kernelspecs;
-        kernelManager.getKernelSpecForGrammar({ name: "python" }, spec => {
-          expect(spec).toEqual(kernelSpecs.kernelspecs.python2.spec);
-          done();
-        });
-      });
-
-      it("should return undefined", done => {
-        kernelManager._kernelSpecs = kernelSpecs.kernelspecs;
-        kernelManager.getKernelSpecForGrammar({ name: "julia" }, spec => {
-          expect(spec).toBeUndefined();
-          done();
-        });
-      });
+    it("should return single kernelspec", async () => {
+      spyOn(manager, "getAllKernelSpecsForGrammar").and.returnValue([
+        JAVASCRIPT_SPEC
+      ]);
+      expect(await manager.getKernelSpecForGrammar()).toEqual(JAVASCRIPT_SPEC);
     });
 
-    it("should update kernelspecs", done => {
-      kernelManager.getKernelSpecsFromJupyter((err, specs) => {
-        if (!err) {
-          expect(specs instanceof Object).toEqual(true);
-        }
-        done();
-      });
+    it("should toggle kernel picker", async () => {
+      const specs = [PYTHON_SPEC, PYTHON3_SPEC];
+      spyOn(manager, "getAllKernelSpecsForGrammar").and.returnValue(specs);
+      manager.kernelPicker = {
+        toggle: () => {}
+      };
+      spyOn(manager.kernelPicker, "toggle");
+      const spec = manager.getKernelSpecForGrammar();
+      setTimeout(() => {
+        manager.kernelPicker.onConfirmed(PYTHON3_SPEC);
+      }, 0);
+
+      expect(await spec).toEqual(PYTHON3_SPEC);
+      expect(manager.kernelPicker.kernelSpecs).toEqual(specs);
+      expect(manager.kernelPicker.toggle).toHaveBeenCalled();
+    });
+  });
+
+  describe("updateKernelSpecs", () => {
+    it("should show error if no kernelspecs are found", async () => {
+      spyOn(manager, "update").and.returnValue(Promise.resolve([]));
+      spyOn(atom.notifications, "addError");
+      expect(await manager.updateKernelSpecs()).toEqual([]);
+      expect(manager.update).toHaveBeenCalled();
+      expect(atom.notifications.addError).toHaveBeenCalled();
+    });
+
+    it("should show info if kernelspecs are found", async () => {
+      spyOn(manager, "update").and.returnValue(Promise.resolve(SPECS));
+      spyOn(atom.notifications, "addInfo");
+      expect(await manager.updateKernelSpecs()).toEqual(SPECS);
+      expect(manager.update).toHaveBeenCalled();
+      expect(atom.notifications.addInfo).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION

This PR brings Hydrogen inline with nteract regarding kernel discovery. It now uses [`kernelspecs`](https://github.com/nteract/kernelspecs) to get the available kernels from the system.

The main advantage of using [`kernelspecs`](https://github.com/nteract/kernelspecs) over `jupyter kernelspec list --json` is the speed. Our current solution takes approximately 800ms to get all available kernels. This time can easily be over 2s during initial startup (note my shell is minimal and quite fast, on other system this can take a lot longer). I think this long startup time is unacceptable. The new solution will take only 10ms for updating the kernels (during initial startup it will take around 30-50ms) which makes startup noticable faster :rocket:.
I haven't looked at `kernelspecs` and `jupyter-paths` in detail, but I think we can even optimize the speed further.

Appart from that this removes `jupyter` as a dependency. This means people using other kernels than IPython no longer need a Python installation just to find the kernels. This brings us inline with nteract and allows us to ensure a seamless back and forth between nteract and Hydrogen.

### Main changes
- Use `kernelspecs` over `jupyter kernelspec list --json`
- Use async/await and promises for managing kernel specs

### BREAKING CHANGES
- Remove Kernelspec setting. This setting was introduced because we ran into some issues where `jupyter` was not available from Atom. Editing this setting is a horrible user experience and everything can be achived by properly installing the kernels too.
- Remove support for old python installations, relying on deprecated `ipython` kernel directories. Come on it's 2017 :wink:
- The default Python installation won't be discovered anymore. The IPython kernel needs to be installed with:
```bash
python -m pip install ipykernel
python -m ipykernel install --user
```

I think the advantages are well worth the breaking change. They also fit quite nicely in our release cycle since #123 can be also considered as a breaking change. I guess we're on the road to 2.0.0 now :innocent:
