### PR TITLE
Fix compatibility with Atom 1.22

### DIFF
--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -6,7 +6,12 @@ import escapeStringRegexp from "escape-string-regexp";
 import _ from "lodash";
 
 import store from "./store";
-import { log, isMultilanguageGrammar, getEmbeddedScope } from "./utils";
+import {
+  log,
+  isMultilanguageGrammar,
+  getEmbeddedScope,
+  rowRangeForCodeFoldAtBufferRow
+} from "./utils";
 
 export function normalizeString(code: ?string) {
   if (code) {
@@ -73,7 +78,7 @@ export function escapeBlankRows(
 }
 
 export function getFoldRange(editor: atom$TextEditor, row: number) {
-  const range = editor.languageMode.rowRangeForCodeFoldAtBufferRow(row);
+  const range = rowRangeForCodeFoldAtBufferRow(editor, row);
   if (!range) return;
   if (
     range[1] < editor.getLastBufferRow() &&
@@ -311,7 +316,7 @@ export function findCodeBlock(editor: atom$TextEditor) {
 
   const indentLevel = cursor.getIndentLevel();
   let foldable = editor.isFoldableAtBufferRow(row);
-  const foldRange = editor.languageMode.rowRangeForCodeFoldAtBufferRow(row);
+  const foldRange = rowRangeForCodeFoldAtBufferRow(editor, row);
   if (!foldRange || foldRange[0] == null || foldRange[1] == null) {
     foldable = false;
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { Disposable } from "atom";
+import { Disposable, Point } from "atom";
 import React from "react";
 import ReactDOM from "react-dom";
 import _ from "lodash";
@@ -199,4 +199,20 @@ export function hotReloadPackage() {
   atom.packages.loadPackage(packName);
   atom.packages.activatePackage(packName);
   console.info(`activated ${packName}`);
+}
+
+export function rowRangeForCodeFoldAtBufferRow(
+  editor: atom$TextEditor,
+  row: number
+) {
+  if (parseFloat(atom.getVersion()) < 1.22) {
+    return editor.languageMode.rowRangeForCodeFoldAtBufferRow(row);
+  } else {
+    // $FlowFixMe
+    const range = editor.tokenizedBuffer.getFoldableRangeContainingPoint(
+      new Point(row, Infinity)
+    );
+
+    return range ? [range.start.row, range.end.row] : null;
+  }
 }


### PR DESCRIPTION
Atom 1.22 removed the unofficial `languageMode` API: https://github.com/atom/atom/pull/15713

Fixes #1034 

It would be great if someone could give this a quick spin in Atom 1.21, I only tested it on 1.22