### PR TITLE
Improve error message if no Python kernels are found

### DIFF
--- a/lib/kernel-manager.js
+++ b/lib/kernel-manager.js
@@ -85,15 +85,15 @@ export class KernelManager {
     return this.kernelSpecs;
   }
 
-  async getAllKernelSpecs() {
+  async getAllKernelSpecs(grammar: ?atom$Grammar) {
     if (this.kernelSpecs) return this.kernelSpecs;
-    return this.updateKernelSpecs();
+    return this.updateKernelSpecs(grammar);
   }
 
   async getAllKernelSpecsForGrammar(grammar: ?atom$Grammar) {
     if (!grammar) return [];
 
-    const kernelSpecs = await this.getAllKernelSpecs();
+    const kernelSpecs = await this.getAllKernelSpecs(grammar);
     return kernelSpecs.filter(spec => kernelSpecProvidesGrammar(spec, grammar));
   }
 
@@ -116,14 +116,17 @@ export class KernelManager {
     });
   }
 
-  async updateKernelSpecs() {
+  async updateKernelSpecs(grammar: ?atom$Grammar) {
     const kernelSpecs = await this.update();
 
     if (kernelSpecs.length === 0) {
       const message = "No Kernels Installed";
+      const pythonDescription =
+        grammar && /python/g.test(grammar.scopeName)
+          ? "\n\nTo detect your current Python install you will need to run:\n\n`python -m pip install ipykernel`\n\n`python -m ipykernel install --user`"
+          : "";
       const options = {
-        description:
-          "No kernels are installed on your system so you will not be able to execute code in any language.\n\nCheckout [all available kernels](https://github.com/jupyter/jupyter/wiki/Jupyter-kernels).",
+        description: `No kernels are installed on your system so you will not be able to execute code in any language.${pythonDescription}\n\nCheckout [all available kernels](https://github.com/jupyter/jupyter/wiki/Jupyter-kernels).`,
         dismissable: true,
         buttons: [
           {


### PR DESCRIPTION
Make it easier for people to upgrade from the old kernel spec setup:
<img width="481" alt="bildschirmfoto 2017-10-11 um 18 38 03" src="https://user-images.githubusercontent.com/13285808/31472375-ff538a86-aeb3-11e7-9153-e617f4f3f093.png">
