### PR TITLE
Improve "no kernels" error message

### DIFF
--- a/lib/kernel-manager.js
+++ b/lib/kernel-manager.js
@@ -123,10 +123,10 @@ export class KernelManager {
       const message = "No Kernels Installed";
       const pythonDescription =
         grammar && /python/g.test(grammar.scopeName)
-          ? "\n\nTo detect your current Python install you will need to run:\n\n`python -m pip install ipykernel`\n\n`python -m ipykernel install --user`"
+          ? "\n\nTo detect your current Python install you will need to run:<pre>python -m pip install ipykernel\npython -m ipykernel install --user</pre>"
           : "";
       const options = {
-        description: `No kernels are installed on your system so you will not be able to execute code in any language.${pythonDescription}\n\nCheckout [all available kernels](https://github.com/jupyter/jupyter/wiki/Jupyter-kernels).`,
+        description: `No kernels are installed on your system so you will not be able to execute code in any language.${pythonDescription}`,
         dismissable: true,
         buttons: [
           {
@@ -139,6 +139,13 @@ export class KernelManager {
           {
             text: "Popular Kernels",
             onDidClick: () => shell.openExternal("https://nteract.io/kernels")
+          },
+          {
+            text: "All Kernels",
+            onDidClick: () =>
+              shell.openExternal(
+                "https://github.com/jupyter/jupyter/wiki/Jupyter-kernels"
+              )
           }
         ]
       };


### PR DESCRIPTION
I just received a error message from the github extension that taught me how to properly style the code section:
## PR
Python:
<img width="473" alt="bildschirmfoto 2017-10-14 um 18 00 45" src="https://user-images.githubusercontent.com/13285808/31577200-ab674472-b10a-11e7-93bb-8c033100bd93.png">
Other Languages:
<img width="466" alt="bildschirmfoto 2017-10-14 um 18 04 01" src="https://user-images.githubusercontent.com/13285808/31577201-ad942238-b10a-11e7-9044-5f50d1d6e737.png">

## master
<img width="481" alt="bildschirmfoto 2017-10-11 um 18 38 03" src="https://user-images.githubusercontent.com/13285808/31472375-ff538a86-aeb3-11e7-9153-e617f4f3f093.png">
