### PR TITLE
Pr/autocomplete

### DIFF
--- a/lib/autocomplete-provider.js
+++ b/lib/autocomplete-provider.js
@@ -107,10 +107,10 @@ export default function() {
         return null;
       }
 
-      var minimumWordLength = atom.config.get(
+      let minimumWordLength = atom.config.get(
         "autocomplete-plus.minimumWordLength"
       );
-      if (typeof minimumWordLength != "number") {
+      if (typeof minimumWordLength !== "number") {
         minimumWordLength = 3;
       }
 

--- a/lib/autocomplete-provider.js
+++ b/lib/autocomplete-provider.js
@@ -107,10 +107,14 @@ export default function() {
         return null;
       }
 
-      if (
-        prefix.trim().length <
-        atom.config.get("autocomplete-plus.minimumWordLength")
-      ) {
+      var minimumWordLength = atom.config.get(
+        "autocomplete-plus.minimumWordLength"
+      );
+      if (typeof minimumWordLength != "number") {
+        minimumWordLength = 3;
+      }
+
+      if (prefix.trim().length < minimumWordLength) {
         return null;
       }
 

--- a/lib/autocomplete-provider.js
+++ b/lib/autocomplete-provider.js
@@ -107,7 +107,10 @@ export default function() {
         return null;
       }
 
-      if (prefix.trim().length < 3) {
+      if (
+        prefix.trim().length <
+        atom.config.get("autocomplete-plus.minimumWordLength")
+      ) {
         return null;
       }
 


### PR DESCRIPTION
Added the config value from autocomplete-plus instead of 3 as min length. Not sure if there should be some if statement that provide 3 as an alternative if it cannot find atom.config.get("autocomplete-plus.minimumWordLength").