### PR TITLE
Set up specs with a mock global store

### DIFF
--- a/lib/store/index.js
+++ b/lib/store/index.js
@@ -12,7 +12,7 @@ import Kernel from "./../kernel";
 
 import type { IObservableArray } from "mobx";
 
-class Store {
+export class Store {
   subscriptions = new CompositeDisposable();
   markers = new MarkerStore();
   runningKernels: IObservableArray<Kernel> = observable([]);

--- a/spec/commands-spec.js
+++ b/spec/commands-spec.js
@@ -1,0 +1,45 @@
+"use babel";
+
+import { Store } from "../lib/store";
+import { toggleInspector } from "../lib/commands";
+import Kernel from "../lib/kernel";
+
+describe("commands", () => {
+  let storeMock, mockKernel, filePath, grammar, editor;
+
+  beforeAll(() => {
+    storeMock = new Store();
+    filePath = "fake.py";
+    grammar = atom.grammars.grammarForScopeName("source.python");
+    editor = atom.workspace.buildTextEditor();
+    mockKernel = new Kernel({
+      display_name: "Python 3",
+      language: "python"
+    });
+
+    spyOn(editor, "getPath").and.returnValue(filePath);
+    spyOn(storeMock.subscriptions, "dispose");
+    storeMock.newKernel(mockKernel, filePath, editor, grammar);
+  });
+
+  describe("toggleInspector", () => {
+    let codeText, cursorPos, bundle;
+    beforeEach(() => {
+      codeText = `print('hello world')`;
+      bundle = { "text/plain": "Mockstring: so helpful" };
+
+      editor.setText(codeText);
+      storeMock.updateEditor(editor);
+      spyOn(storeMock.kernel, "inspect");
+    });
+
+    it("calls kernel.inspect with code and cursor position", () => {
+      toggleInspector(storeMock);
+      expect(storeMock.kernel.inspect).toHaveBeenCalledWith(
+        codeText,
+        codeText.length,
+        jasmine.any(Function)
+      );
+    });
+  });
+});


### PR DESCRIPTION
- The global store export causes issues between specs
- This could be fixed by exporting the Store class, for spec purposes only,
- the spec here is just an example of how we could test modules independently outside of main.