### PR TITLE
WIP on simplifying remote kernel docs

### DIFF
--- a/docs/Usage/RemoteKernelConnection.md
+++ b/docs/Usage/RemoteKernelConnection.md
@@ -6,7 +6,7 @@ To connect to a server, you must first add the connection information to the Hyd
 
 ```json
 [{
-  "name": "Remote notebook",
+  "name": "Remote kernel",
   "options": {
     "baseUrl": "http://example.com:8888",
     "token": "my_secret_token"
@@ -48,20 +48,12 @@ jupyter notebook --port=8888
 
 TODO: what is the difference between running the kernel gateway and the notebook?
 
-# Running a Kernel gateway on Docker
+# Running a Kernel gateway using Docker
 
 You can use the same technique to create a kernel gateway in a Docker container. That would allow you to develop from Atom but with all the dependencies, autocompletion, environment, etc. of a Docker container.
 
 **Note**: due to the way that the kernel gateway creates sub-processes for each kernel, you have to use it in a special way, you can't run the `jupyter kernelgateway` directly in your `Dockerfile` `CMD` section. You need to call it with an init manager such as [**tini**](https://github.com/krallin/tini) or run it from an interactive console.
 
-If all you need is a Docker Python environment to execute your code, you can read the section [**Example Jupyter Docker Stack kernel gateway**](#example-jupyter-docker-stack-kernel-gateway) (this method uses **tini** under the hood).
-
-
-## Jupyter Docker Stack kernel gateway
-
-Follow this if you only need to have a simple environment to run commands inside a Docker container and nothing more.
-
-If you need to customize a Docker image (e.g. for web development) follow the section below: [**Example Docker kernel gateway**](#example-docker-kernel-gateway).
 
 ### Dockerfile
 
@@ -144,7 +136,7 @@ docker run -it --rm --name hydro -p 8888:8888 hydro
 - If running locally, you can use `localhost` as the host of your `baseUrl`
 - In Atom, open a Python file, e.g. `main.py`
 - Connect to the kernel you just configured: `ctrl-shift-p` and type: `Hydrogen: Connect To Remote Kernel`
-- Select the kernel gateway you configured, e.g. `docker-kernel`
+- Select the kernel gateway you configured, e.g. `Remote kernel`
 - Select the "type of kernel" to run, there will just be the option `Python 2` or `Python 3`
 - Then select the line or block of code that you want to execute inside of your container
 - Run the code with: `ctrl-shift-p` and type: `Hydrogen: Run`
@@ -186,4 +178,4 @@ markdown.version ['2.6.6']
 ## Terminate the connection and container
 
 - To terminate a running kernel gateway you can "kill" it as any Linux process with `ctrl-c`
-- If you're running the kernel gateway as a Docker container, you can stop the Docker container (this assumes you're using an init manager, such as tini. If you're not, this may not close the process)
+- If you're running the kernel gateway as a Docker container, you can stop the Docker container (this assumes you're using an init manager, such as tini. If you're not, this may not close the process.)

--- a/docs/Usage/RemoteKernelConnection.md
+++ b/docs/Usage/RemoteKernelConnection.md
@@ -77,7 +77,7 @@ ENTRYPOINT [/tini, --]
 # --no-browser & --port aren't strictly necessary. presented here for clarity
 CMD [jupyter-notebook, --no-browser, --port=8888]
 # if running as root, you need to explicitly allow this:
-# CMD [jupyter-notebook, --alow-root, --no-browser, --port=8888]
+# CMD [jupyter-notebook, --allow-root, --no-browser, --port=8888]
 
 ```
 
@@ -91,7 +91,7 @@ services:
   hydro:
     build: .
     entrypoint: [/tini, --]
-    command: [jupyter-notebook, --alow-root, --no-browser, --port=8888]
+    command: [jupyter-notebook, --allow-root, --no-browser, --port=8888]
     ports:
       - 8888:8888
     environment:

--- a/docs/Usage/RemoteKernelConnection.md
+++ b/docs/Usage/RemoteKernelConnection.md
@@ -58,6 +58,7 @@ You can use the same technique to create a kernel gateway in a Docker container.
 - Create a `Dockerfile` based on either one of the [Jupyter Docker Stacks](https://github.com/jupyter/docker-stacks) (recommended), or your own
 - Ensure `jupyter_kernel_gateway` and `tini` are installed, either in the image or as an additional command in the `Dockerfile`
 - Expose the gateway port, in this example it will be `8888`
+- Add an environment variable allowing the Kernel Gateway to get a list of the kernels running
 - Set the `CMD` instruction to starting a Kernel Gateway (though run through an init manager such as `tini`):
 
 ```Dockerfile
@@ -68,6 +69,8 @@ ADD https://github.com/krallin/tini/releases/download/v0.14.0/tini /tini
 RUN chmod +x /tini
 
 RUN pip install jupyter_kernel_gateway
+
+ENV KG_LIST_KERNELS=True
 
 EXPOSE 8888
 ENTRYPOINT [/tini, --]
@@ -87,6 +90,8 @@ services:
     command: [jupyter, kernelgateway, --ip=0.0.0.0, --port=8888]
     ports:
       - 8888:8888
+    environment:
+      - KG_LIST_KERNELS=True
 ```
 
 - This duplicates the entrypoint & command between this and the Dockerfile - strictly speaking, you only need one of these 

--- a/docs/Usage/RemoteKernelConnection.md
+++ b/docs/Usage/RemoteKernelConnection.md
@@ -93,7 +93,7 @@ services:
     ports:
       - 8888:8888
     environment:
-      # if you can also have this var in your environment it will override this
+      # the value of `JUPYTER_TOKEN` in your environment will override `my_secret_token`
       - JUPYTER_TOKEN=my_secret_token
 ```
 

--- a/docs/Usage/RemoteKernelConnection.md
+++ b/docs/Usage/RemoteKernelConnection.md
@@ -74,9 +74,11 @@ ENV JUPYTER_TOKEN=my_secret_token  # you can also pass this at runtime
 
 EXPOSE 8888
 ENTRYPOINT [/tini, --]
-CMD [jupyter-notebook]
+# --no-browser & --port aren't strictly necessary. presented here for clarity
+CMD [jupyter-notebook, --no-browser, --port=8888]
 # if running as root, you need to explicitly allow this:
-# CMD [jupyter-notebook, --alow-root]
+# CMD [jupyter-notebook, --alow-root, --no-browser, --port=8888]
+
 ```
 
 ### Run with Docker Compose
@@ -89,7 +91,7 @@ services:
   hydro:
     build: .
     entrypoint: [/tini, --]
-    command: [jupyter-notebook, --alow-root]
+    command: [jupyter-notebook, --alow-root, --no-browser, --port=8888]
     ports:
       - 8888:8888
     environment:
@@ -150,7 +152,7 @@ ENV JUPYTER_TOKEN=my_secret_token # you can also pass this at runtime
 
 EXPOSE 8888
 ENTRYPOINT [/tini, --]
-CMD [jupyter-notebook]
+CMD [jupyter-notebook, --no-browser, --port=8888]
 
 RUN pip install markdown # <- installing new package
 ```

--- a/docs/Usage/RemoteKernelConnection.md
+++ b/docs/Usage/RemoteKernelConnection.md
@@ -2,11 +2,11 @@
 
 In addition to managing local kernels and connecting to them over ZeroMQ, Hydrogen is also able to connect to Jupyter Notebook (or Jupyter Kernel Gateway) servers. This is most useful for running code remotely (e.g. in the cloud), or in a Docker container running locally.
 
-To connect to a server, you must first add the connection information to the Hydrogen `gateways` setting. An example settings entry might be:
+To connect to a server, add the connection information to the Hydrogen `gateways` setting. For example:
 
 ```json
 [{
-  "name": "Remote kernel",
+  "name": "Remote server",
   "options": {
     "baseUrl": "http://example.com:8888",
     "token": "my_secret_token"
@@ -46,8 +46,6 @@ jupyter notebook --port=8888
 
 - To run a public server, consult the [official instructions](http://jupyter-notebook.readthedocs.io/en/latest/public_server.html) for setting up certificates. Skip the steps for setting up a password: hydrogen only supports token-based authentication. Also note that hydrogen does not support self-signed certificates -- we recommend that you use Let's Encrypt or consider alternatives such as listening on localhost followed by SSH port forwarding.
 
-TODO: what is the difference between running the kernel gateway and the notebook?
-
 # Running a Kernel gateway using Docker
 
 You can use the same technique to create a kernel gateway in a Docker container. That would allow you to develop from Atom but with all the dependencies, autocompletion, environment, etc. of a Docker container.
@@ -57,15 +55,14 @@ You can use the same technique to create a kernel gateway in a Docker container.
 
 ### Dockerfile
 
-- Create a `Dockerfile` based on either one of the [Jupyter Docker Stacks](https://github.com/jupyter/docker-stacks), or one you supply
+- Create a `Dockerfile` based on either one of the [Jupyter Docker Stacks](https://github.com/jupyter/docker-stacks) (recommended), or your own
 - Ensure `jupyter_kernel_gateway` and `tini` are installed, either in the image or as an additional command in the `Dockerfile`
 - Expose the gateway port, in this example it will be `8888`
-- Make the command to run be the Kernel Gateway (though run through an init manager such as `tini`):
+- Set the `CMD` instruction to starting a Kernel Gateway (though run through an init manager such as `tini`):
 
 ```Dockerfile
+# If using your own Docker image, use the following `FROM` command syntax substituting your image name
 FROM jupyter/minimal-notebook
-# this can also be an image of your own, e.g.:
-# FROM acmecorp/our-libaries:4.2.0
 
 ADD https://github.com/krallin/tini/releases/download/v0.14.0/tini /tini
 RUN chmod +x /tini
@@ -130,7 +127,7 @@ docker run -it --rm --name hydro -p 8888:8888 hydro
 - Add the connection information to the Hydrogen `gateways` setting, as above. If running locally, you can use `localhost` as the host of your `baseUrl`
 - In Atom, open a Python file
 - Connect to the kernel you just configured: `ctrl-shift-p` and type: `Hydrogen: Connect To Remote Kernel`
-- Select the kernel gateway you configured, e.g. `Remote kernel`
+- Select the kernel gateway you configured, e.g. `Remote server`
 - Select the "type of kernel" to run, there will just be the option `Python 2` or `Python 3`
 - Then select the line or block of code that you want to execute inside of your container
 - Run the code with: `ctrl-shift-p` and type: `Hydrogen: Run`

--- a/docs/Usage/RemoteKernelConnection.md
+++ b/docs/Usage/RemoteKernelConnection.md
@@ -127,14 +127,8 @@ docker run -it --rm --name hydro -p 8888:8888 hydro
 
 ## Connect Atom
 
-- Go to the settings in Atom with: `ctrl-shift-p` and type `Settings View: Open`
-- Go to the "Packages" section
-- Type `Hydrogen` and go to package settings
-- In the section "List of kernel gateways to use" add settings for the container your created
-- Use a `name` that you can remind when running Hydrogen
-- In the `baseUrl` section use the host or IP that you use to access your Docker containers:
-- If running locally, you can use `localhost` as the host of your `baseUrl`
-- In Atom, open a Python file, e.g. `main.py`
+- Add the connection information to the Hydrogen `gateways` setting, as above. If running locally, you can use `localhost` as the host of your `baseUrl`
+- In Atom, open a Python file
 - Connect to the kernel you just configured: `ctrl-shift-p` and type: `Hydrogen: Connect To Remote Kernel`
 - Select the kernel gateway you configured, e.g. `Remote kernel`
 - Select the "type of kernel" to run, there will just be the option `Python 2` or `Python 3`


### PR DESCRIPTION
- Some updates (no need for Docker Toolbox, Dec 2016 bug fixed)
- Some of the way to combining the two docker sections, that are mostly repetitive
- Starting jupyter kernel should be part of the docker process, not something people are `exec`ing in to start
- Everyone should run tini rather than go through the long-winded steps of manually shutting processes

One question: what's the difference between running a notebook and connection to a kernel there, and running `kernelgateway`