### PR TITLE
Improve error message if kernelspec isn't correctly setup

### DIFF
--- a/lib/kernel-manager.js
+++ b/lib/kernel-manager.js
@@ -29,9 +29,17 @@ export class KernelManager {
     this.getKernelSpecForGrammar(grammar).then(kernelSpec => {
       if (!kernelSpec) {
         const message = `No kernel for grammar \`${grammar.name}\` found`;
-        const description =
-          "Check that the language for this file is set in Atom and that you have a Jupyter kernel installed for it.";
-        atom.notifications.addError(message, { description });
+        const pythonDescription =
+          grammar && /python/g.test(grammar.scopeName)
+            ? "\n\nTo detect your current Python install you will need to run:<pre>python -m pip install ipykernel\npython -m ipykernel install --user</pre>"
+            : "";
+        const description = `Check that the language for this file is set in Atom and that you have a Jupyter kernel installed for it.${
+          pythonDescription
+        }`;
+        atom.notifications.addError(message, {
+          description,
+          dismissable: pythonDescription !== ""
+        });
         return;
       }
 
@@ -121,14 +129,10 @@ export class KernelManager {
 
     if (kernelSpecs.length === 0) {
       const message = "No Kernels Installed";
-      const pythonDescription =
-        grammar && /python/g.test(grammar.scopeName)
-          ? "\n\nTo detect your current Python install you will need to run:<pre>python -m pip install ipykernel\npython -m ipykernel install --user</pre>"
-          : "";
+
       const options = {
-        description: `No kernels are installed on your system so you will not be able to execute code in any language.${
-          pythonDescription
-        }`,
+        description:
+          "No kernels are installed on your system so you will not be able to execute code in any language.",
         dismissable: true,
         buttons: [
           {


### PR DESCRIPTION
This will show a helpful error message in all cases where hydrogen can't detect a Python kernel.

Before it was only shown when there are no kernelspecs found.