### PR TITLE
Prompt to authenticate with token or cookie

### DIFF
--- a/lib/ws-kernel-picker.js
+++ b/lib/ws-kernel-picker.js
@@ -15,7 +15,8 @@ import InputView from "./input-view";
 import store from "./store";
 
 class CustomListView {
-  onConfirmed: Function = () => {};
+  onConfirmed: ?Function = null;
+  onCancelled: ?Function = null;
   previouslyFocusedElement: ?HTMLElement;
   selectListView: SelectListView;
   panel: ?atom$Panel;
@@ -34,7 +35,10 @@ class CustomListView {
       didConfirmSelection: item => {
         if (this.onConfirmed) this.onConfirmed(item);
       },
-      didCancelSelection: () => this.cancel()
+      didCancelSelection: () => {
+        this.cancel();
+        if (this.onCancelled) this.onCancelled();
+      }
     });
   }
 
@@ -174,7 +178,52 @@ export default class WSKernelPicker {
     return true;
   }
 
+  async promptForCredentials(options: any) {
+    await this.listView.selectListView.update({
+      items: [
+        {
+          name: "Authenticate with a token",
+          action: "token"
+        },
+        {
+          name: "Authenticate with a cookie",
+          action: "cookie"
+        },
+        {
+          name: "Cancel",
+          action: "cancel"
+        }
+      ],
+      infoMessage:
+        "Connection to gateway failed. Your settings may be incorrect, the server may be unavailable, or you may lack sufficient privileges to complete the connection.",
+      loadingMessage: null,
+      emptyMessage: null
+    });
+
+    const action = await new Promise((resolve, reject) => {
+      this.listView.onConfirmed = item => resolve(item.action);
+      this.listView.onCancelled = () => resolve("cancel");
+    });
+    if (action === "token") {
+      return await this.promptForToken(options);
+    } else if (action === "cookie") {
+      return await this.promptForCookie(options);
+    } else {
+      // action === "cancel"
+      this.listView.cancel();
+      return false;
+    }
+  }
+
   async onGateway(gatewayInfo: any) {
+    this.listView.onConfirmed = null;
+    await this.listView.selectListView.update({
+      items: [],
+      infoMessage: null,
+      loadingMessage: "Loading sessions...",
+      emptyMessage: "No sessions available"
+    });
+
     const gatewayOptions = Object.assign(
       {
         xhrFactory: () => new xhr.XMLHttpRequest(),
@@ -183,27 +232,42 @@ export default class WSKernelPicker {
       gatewayInfo.options
     );
 
-    let promptSucceeded = true;
-    if (gatewayInfo.prompt == "cookie") {
-      promptSucceeded = await this.promptForCookie(gatewayOptions);
-    } else if (gatewayInfo.prompt == "token") {
-      promptSucceeded = await this.promptForToken(gatewayOptions);
-    }
+    let serverSettings = ServerConnection.makeSettings(gatewayOptions);
+    let specModels;
 
-    if (!promptSucceeded) {
-      return;
-    }
-
-    const serverSettings = ServerConnection.makeSettings(gatewayOptions);
-    this.listView.onConfirmed = this.onSession.bind(this, gatewayInfo.name);
-    await this.listView.selectListView.update({
-      items: [],
-      infoMessage: null,
-      loadingMessage: "Loading sessions...",
-      emptyMessage: "No sessions available"
-    });
     try {
-      const specModels = await Kernel.getSpecs(serverSettings);
+      specModels = await Kernel.getSpecs(serverSettings);
+    } catch (error) {
+      // The error types you get back at this stage are fairly opaque. In
+      // particular, having invalid credentials typically triggers ECONNREFUSED
+      // rather than 403 Forbidden. This does some basic checks and then assumes
+      // that all remaining error types could be caused by invalid credentials.
+      if (!error.xhr || !error.xhr.responseText) {
+        throw error;
+      } else if (error.xhr.responseText.includes("ETIMEDOUT")) {
+        atom.notifications.addError("Connection to gateway failed");
+        this.listView.cancel();
+        return;
+      } else {
+        const promptSucceeded = await this.promptForCredentials(gatewayOptions);
+        if (!promptSucceeded) {
+          return;
+        }
+        serverSettings = ServerConnection.makeSettings(gatewayOptions);
+        await this.listView.selectListView.update({
+          items: [],
+          infoMessage: null,
+          loadingMessage: "Loading sessions...",
+          emptyMessage: "No sessions available"
+        });
+      }
+    }
+
+    try {
+      if (!specModels) {
+        specModels = await Kernel.getSpecs(serverSettings);
+      }
+
       const kernelSpecs = _.filter(specModels.kernelspecs, spec =>
         this._kernelSpecFilter(spec)
       );
@@ -231,6 +295,7 @@ export default class WSKernelPicker {
           options: serverSettings,
           kernelSpecs
         });
+        this.listView.onConfirmed = this.onSession.bind(this, gatewayInfo.name);
         await this.listView.selectListView.update({
           items: items,
           loadingMessage: null

--- a/lib/ws-kernel-picker.js
+++ b/lib/ws-kernel-picker.js
@@ -6,10 +6,12 @@ import tildify from "tildify";
 import v4 from "uuid/v4";
 import ws from "ws";
 import xhr from "xmlhttprequest";
+import { URL } from "url";
 import { Kernel, Session, ServerConnection } from "@jupyterlab/services";
 
 import Config from "./config";
 import WSKernel from "./ws-kernel";
+import InputView from "./input-view";
 import store from "./store";
 
 class CustomListView {
@@ -98,16 +100,101 @@ export default class WSKernelPicker {
     this.listView.show();
   }
 
+  async promptForText(prompt: string) {
+    const previouslyFocusedElement = this.listView.previouslyFocusedElement;
+    this.listView.cancel();
+
+    const inputPromise = new Promise((resolve, reject) => {
+      const inputView = new InputView({ prompt }, resolve);
+      atom.commands.add(inputView.element, {
+        "core:cancel": () => {
+          inputView.close();
+          reject();
+        }
+      });
+      inputView.attach();
+    });
+
+    let response;
+    try {
+      response = await inputPromise;
+      if (response === "") {
+        return null;
+      }
+    } catch (e) {
+      return null;
+    }
+
+    // Assume that no response to the prompt will cancel the entire flow, so
+    // only restore listView if a response was received
+    this.listView.show();
+    this.listView.previouslyFocusedElement = previouslyFocusedElement;
+    return response;
+  }
+
+  async promptForCookie(options: any) {
+    const cookie = await this.promptForText("Cookie:");
+    if (cookie === null) {
+      return false;
+    }
+
+    if (options.requestHeaders === undefined) {
+      options.requestHeaders = {};
+    }
+    options.requestHeaders.Cookie = cookie;
+    options.xhrFactory = () => {
+      let request = new xhr.XMLHttpRequest();
+      // Disable protections against setting the Cookie header
+      request.setDisableHeaderCheck(true);
+      return request;
+    };
+    options.wsFactory = (url, protocol) => {
+      // Authentication requires requests to appear to be same-origin
+      let parsedUrl = new URL(url);
+      if (parsedUrl.protocol == "wss:") {
+        parsedUrl.protocol = "https:";
+      } else {
+        parsedUrl.protocol = "http:";
+      }
+      const headers = { Cookie: cookie };
+      const origin = parsedUrl.origin;
+      const host = parsedUrl.host;
+      return new ws(url, protocol, { headers, origin, host });
+    };
+    return true;
+  }
+
+  async promptForToken(options: any) {
+    const token = await this.promptForText("Token:");
+    if (token === null) {
+      return false;
+    }
+
+    options.token = token;
+    return true;
+  }
+
   async onGateway(gatewayInfo: any) {
-    const serverSettings = ServerConnection.makeSettings(
-      Object.assign(
-        {
-          xhrFactory: () => new xhr.XMLHttpRequest(),
-          wsFactory: (url, protocol) => new ws(url, protocol)
-        },
-        gatewayInfo.options
-      )
+    const gatewayOptions = Object.assign(
+      {
+        xhrFactory: () => new xhr.XMLHttpRequest(),
+        wsFactory: (url, protocol) => new ws(url, protocol)
+      },
+      gatewayInfo.options
     );
+
+    let promptSucceeded = true;
+    if (gatewayInfo.prompt == "cookie") {
+      promptSucceeded = await this.promptForCookie(gatewayOptions);
+    } else if (gatewayInfo.prompt == "token") {
+      promptSucceeded = await this.promptForToken(gatewayOptions);
+    }
+
+    if (!promptSucceeded) {
+      return;
+    }
+
+    const serverSettings = ServerConnection.makeSettings(gatewayOptions);
     this.listView.onConfirmed = this.onSession.bind(this, gatewayInfo.name);
     await this.listView.selectListView.update({
       items: [],


### PR DESCRIPTION
(This is a proof of concept, don't merge)

The cluster I've been using for work has recently gotten a JupyterHub installation, and I've been trying to connect Hydrogen to it instead of having to run my own notebook servers all the time. However, there are two problems that prevent me from using hydrogen as-is:
* The security policy doesn't allow just setting a token once and forgetting about it. Instead there is a custom authentication procedure that creates a new session every time you log in.
* There's no way to request a token for accessing the notebooks/kernels. The only way to get a session handle is to copy the cookie out of the browser. (I think JupyterHub is working on a better token-auth story than that, but the nature of having someone else run a server for you is that you don't get to control what version of software it's running.)

The code changes here are something I've put together to address these issues. The first change is that instead of specifying `options.token` in a gateway config, you can instead specify `prompt: "token"` to have hydrogen ask you to input a token while connecting to a kernel. The second change also implements an analogous `prompt: "cookie"` option, which lets you copy-paste your session cookie into Hydrogen and have it use that to authenticate.

I'm not really sure where to go next with this code, other than using it for my personal use-case.

Another thing to note is that there is code here to generate same-origin headers for the websocket connection. This used to be a lot harder before the introduction of the `wsFactory` API to `@jupyterlab/services`. I wonder if it would make sense to enable this for all remote connections, not just the cookie-based ones as I have here.


Disclaimer: the code has not been cleaned up, and I haven't run any of the dev tooling (e.g. flow types or style check)