### PR TITLE
display-area: Add padding for big outputs

### DIFF
--- a/lib/components/result-view/result-view.js
+++ b/lib/components/result-view/result-view.js
@@ -130,7 +130,10 @@ class ResultViewComponent extends React.Component<Props> {
         style={
           isPlain
             ? inlineStyle
-            : { maxWidth: `${position.editorWidth}px`, margin: "0px" }
+            : {
+                maxWidth: `${position.editorWidth - 2 * position.charWidth}px`,
+                margin: "0px"
+              }
         }
       >
         <Display


### PR DESCRIPTION
### Before
<img width="221" alt="bildschirmfoto 2017-12-14 um 20 12 57" src="https://user-images.githubusercontent.com/13285808/34026738-e91fc7d0-e10c-11e7-86e6-be3489be2703.png">

### After
<img width="254" alt="bildschirmfoto 2017-12-14 um 20 12 17" src="https://user-images.githubusercontent.com/13285808/34026742-ed073928-e10c-11e7-9e4f-2d1092e5ddb7.png">


Note: The flow failure is unrelated but unfortunately I don't know how to fix it.
