### PR TITLE
Update Plugin API [v2]

### DIFF
--- a/docs/PluginAPI.md
+++ b/docs/PluginAPI.md
@@ -63,9 +63,8 @@ The display name of the kernel, as specified in its kernelspec
 Add a kernel middleware, which allows intercepting and issuing commands to
 the kernel.
 
-All of the middleware object's methods are called with `this` set to the
-middleware object. Also note that adding or removing methods from the
-middleware object after this method has been called is not supported.
+If the methods of a `middleware` object are added/modified/deleted after
+`addMiddleware` has been called, the changes will take effect immediately.
 
 ### Params:
 

--- a/docs/PluginAPI.md
+++ b/docs/PluginAPI.md
@@ -50,6 +50,27 @@ Get the `atom$Range` that will run if `hydrogen:run-cell` is called.
 The `HydrogenKernel` class wraps Hydrogen's internal representation of kernels
 and exposes a small set of methods that should be usable by plugins.
 
+## language
+
+The language of the kernel, as specified in its kernelspec
+
+## displayName
+
+The display name of the kernel, as specified in its kernelspec
+
+## addMiddleware(middleware)
+
+Add a kernel middleware, which allows intercepting and issuing commands to
+the kernel.
+
+All of the middleware object's methods are called with `this` set to the
+middleware object. Also note that adding or removing methods from the
+middleware object after this method has been called is not supported.
+
+### Params:
+
+* **HydrogenKernelMiddleware** *middleware* 
+
 ## onDidDestroy(Callback)
 
 Calls your callback when the kernel has been destroyed.

--- a/lib/autocomplete-provider.js
+++ b/lib/autocomplete-provider.js
@@ -24,9 +24,7 @@ type CompleteReply = {
   }
 };
 
-const iconHTML = `<img src='${
-  __dirname
-}/../static/logo.svg' style='width: 100%;'>`;
+const iconHTML = `<img src='${__dirname}/../static/logo.svg' style='width: 100%;'>`;
 
 const regexes = {
   // pretty dodgy, adapted from http://stackoverflow.com/a/8396658

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -135,9 +135,7 @@ export function getRegexString(editor: atom$TextEditor) {
     commentStartString.trimRight()
   );
 
-  const regexString = `${
-    escapedCommentStartString
-  }(%%| %%| <codecell>| In\[[0-9 ]*\]:?)`;
+  const regexString = `${escapedCommentStartString}(%%| %%| <codecell>| In\[[0-9 ]*\]:?)`;
 
   return regexString;
 }

--- a/lib/existing-kernel-picker.js
+++ b/lib/existing-kernel-picker.js
@@ -11,7 +11,10 @@ import { kernelSpecProvidesGrammar } from "./utils";
 import type Kernel from "./kernel";
 
 function getName(kernel: Kernel) {
-  const prefix = kernel instanceof WSKernel ? `${kernel.gatewayName}: ` : "";
+  const prefix =
+    kernel.transport instanceof WSKernel
+      ? `${kernel.transport.gatewayName}: `
+      : "";
   return (
     prefix +
     kernel.displayName +

--- a/lib/kernel-manager.js
+++ b/lib/kernel-manager.js
@@ -6,6 +6,7 @@ import { launchSpec } from "spawnteract";
 import { shell } from "electron";
 
 import ZMQKernel from "./zmq-kernel";
+import Kernel from "./kernel";
 
 import KernelPicker from "./kernel-picker";
 import store from "./store";
@@ -32,9 +33,7 @@ export class KernelManager {
           grammar && /python/g.test(grammar.scopeName)
             ? "\n\nTo detect your current Python install you will need to run:<pre>python -m pip install ipykernel\npython -m ipykernel install --user</pre>"
             : "";
-        const description = `Check that the language for this file is set in Atom and that you have a Jupyter kernel installed for it.${
-          pythonDescription
-        }`;
+        const description = `Check that the language for this file is set in Atom and that you have a Jupyter kernel installed for it.${pythonDescription}`;
         atom.notifications.addError(message, {
           description,
           dismissable: pythonDescription !== ""
@@ -81,8 +80,9 @@ export class KernelManager {
     };
 
     const kernel = new ZMQKernel(kernelSpec, grammar, options, () => {
-      store.newKernel(kernel, filePath, editor, grammar);
-      if (onStarted) onStarted(kernel);
+      const kernel_ = new Kernel(kernel);
+      store.newKernel(kernel_, filePath, editor, grammar);
+      if (onStarted) onStarted(kernel_);
     });
   }
 

--- a/lib/kernel-manager.js
+++ b/lib/kernel-manager.js
@@ -79,10 +79,10 @@ export class KernelManager {
       stdio: ["ignore", "pipe", "pipe"]
     };
 
-    const kernel = new ZMQKernel(kernelSpec, grammar, options, () => {
-      const kernel_ = new Kernel(kernel);
-      store.newKernel(kernel_, filePath, editor, grammar);
-      if (onStarted) onStarted(kernel_);
+    const transport = new ZMQKernel(kernelSpec, grammar, options, () => {
+      const kernel = new Kernel(transport);
+      store.newKernel(kernel, filePath, editor, grammar);
+      if (onStarted) onStarted(kernel);
     });
   }
 

--- a/lib/kernel-transport.js
+++ b/lib/kernel-transport.js
@@ -1,0 +1,124 @@
+/* @flow */
+
+import { observable, action } from "mobx";
+
+import { log } from "./utils";
+
+export type ResultsCallback = (
+  message: any,
+  channel: "shell" | "iopub" | "stdin"
+) => void;
+
+export default class KernelTransport {
+  @observable executionState = "loading";
+  @observable inspector = { bundle: {} };
+
+  kernelSpec: Kernelspec;
+  grammar: atom$Grammar;
+  language: string;
+  displayName: string;
+  watchCallbacks: Array<Function> = [];
+
+  constructor(kernelSpec: Kernelspec, grammar: atom$Grammar) {
+    this.kernelSpec = kernelSpec;
+    this.grammar = grammar;
+
+    this.language = kernelSpec.language.toLowerCase();
+    this.displayName = kernelSpec.display_name;
+  }
+
+  @action
+  setExecutionState(state: string) {
+    this.executionState = state;
+  }
+
+  addWatchCallback(watchCallback: Function) {
+    this.watchCallbacks.push(watchCallback);
+  }
+
+  _callWatchCallbacks() {
+    this.watchCallbacks.forEach(watchCallback => watchCallback());
+  }
+
+  interrupt() {
+    throw new Error("KernelTransport: interrupt method not implemented");
+  }
+
+  shutdown() {
+    throw new Error("KernelTransport: shutdown method not implemented");
+  }
+
+  restart(onRestarted: ?Function) {
+    throw new Error("KernelTransport: restart method not implemented");
+  }
+
+  execute(code: string, callWatches: boolean, onResults: ResultsCallback) {
+    throw new Error("KernelTransport: execute method not implemented");
+  }
+
+  complete(code: string, onResults: ResultsCallback) {
+    throw new Error("KernelTransport: complete method not implemented");
+  }
+
+  inspect(code: string, cursorPos: number, onResults: ResultsCallback) {
+    throw new Error("KernelTransport: inspect method not implemented");
+  }
+
+  inputReply(input: string) {
+    throw new Error("KernelTransport: inputReply method not implemented");
+  }
+
+  _isValidMessage(message: Message) {
+    if (!message) {
+      log("Invalid message: null");
+      return false;
+    }
+
+    if (!message.content) {
+      log("Invalid message: Missing content");
+      return false;
+    }
+
+    if (message.content.execution_state === "starting") {
+      // Kernels send a starting status message with an empty parent_header
+      log("Dropped starting status IO message");
+      return false;
+    }
+
+    if (!message.parent_header) {
+      log("Invalid message: Missing parent_header");
+      return false;
+    }
+
+    if (!message.parent_header.msg_id) {
+      log("Invalid message: Missing parent_header.msg_id");
+      return false;
+    }
+
+    if (!message.parent_header.msg_type) {
+      log("Invalid message: Missing parent_header.msg_type");
+      return false;
+    }
+
+    if (!message.header) {
+      log("Invalid message: Missing header");
+      return false;
+    }
+
+    if (!message.header.msg_id) {
+      log("Invalid message: Missing header.msg_id");
+      return false;
+    }
+
+    if (!message.header.msg_type) {
+      log("Invalid message: Missing header.msg_type");
+      return false;
+    }
+
+    return true;
+  }
+
+  destroy() {
+    log("KernelTransport: Destroying base kernel");
+  }
+}

--- a/lib/kernel-transport.js
+++ b/lib/kernel-transport.js
@@ -68,7 +68,7 @@ export default class KernelTransport {
     throw new Error("KernelTransport: inputReply method not implemented");
   }
 
-  _isValidMessage(message: Message) {
+  isValidMessage(message: Message) {
     if (!message) {
       log("Invalid message: null");
       return false;

--- a/lib/kernel-transport.js
+++ b/lib/kernel-transport.js
@@ -17,7 +17,6 @@ export default class KernelTransport {
   grammar: atom$Grammar;
   language: string;
   displayName: string;
-  watchCallbacks: Array<Function> = [];
 
   constructor(kernelSpec: Kernelspec, grammar: atom$Grammar) {
     this.kernelSpec = kernelSpec;
@@ -32,14 +31,6 @@ export default class KernelTransport {
     this.executionState = state;
   }
 
-  addWatchCallback(watchCallback: Function) {
-    this.watchCallbacks.push(watchCallback);
-  }
-
-  _callWatchCallbacks() {
-    this.watchCallbacks.forEach(watchCallback => watchCallback());
-  }
-
   interrupt() {
     throw new Error("KernelTransport: interrupt method not implemented");
   }
@@ -52,7 +43,7 @@ export default class KernelTransport {
     throw new Error("KernelTransport: restart method not implemented");
   }
 
-  execute(code: string, callWatches: boolean, onResults: ResultsCallback) {
+  execute(code: string, onResults: ResultsCallback) {
     throw new Error("KernelTransport: execute method not implemented");
   }
 

--- a/lib/kernel-transport.js
+++ b/lib/kernel-transport.js
@@ -68,56 +68,6 @@ export default class KernelTransport {
     throw new Error("KernelTransport: inputReply method not implemented");
   }
 
-  isValidMessage(message: Message) {
-    if (!message) {
-      log("Invalid message: null");
-      return false;
-    }
-
-    if (!message.content) {
-      log("Invalid message: Missing content");
-      return false;
-    }
-
-    if (message.content.execution_state === "starting") {
-      // Kernels send a starting status message with an empty parent_header
-      log("Dropped starting status IO message");
-      return false;
-    }
-
-    if (!message.parent_header) {
-      log("Invalid message: Missing parent_header");
-      return false;
-    }
-
-    if (!message.parent_header.msg_id) {
-      log("Invalid message: Missing parent_header.msg_id");
-      return false;
-    }
-
-    if (!message.parent_header.msg_type) {
-      log("Invalid message: Missing parent_header.msg_type");
-      return false;
-    }
-
-    if (!message.header) {
-      log("Invalid message: Missing header");
-      return false;
-    }
-
-    if (!message.header.msg_id) {
-      log("Invalid message: Missing header.msg_id");
-      return false;
-    }
-
-    if (!message.header.msg_type) {
-      log("Invalid message: Missing header.msg_type");
-      return false;
-    }
-
-    return true;
-  }
-
   destroy() {
     log("KernelTransport: Destroying base kernel");
   }

--- a/lib/kernel.js
+++ b/lib/kernel.js
@@ -16,25 +16,107 @@ import store from "./store";
 import WatchesStore from "./store/watches";
 import OutputStore from "./store/output";
 import HydrogenKernel from "./plugin-api/hydrogen-kernel";
+import type {
+  HydrogenKernelMiddlewareStack,
+  HydrogenKernelMiddleware
+} from "./plugin-api/hydrogen-types";
 import InputView from "./input-view";
 import KernelTransport from "./kernel-transport";
 import type { ResultsCallback } from "./kernel-transport";
 
-interface KernelMiddlewareStack {
-  interrupt: () => void;
-  shutdown: () => void;
-  restart: (onRestarted: ?Function) => void;
-  execute: (
+// Adapts middleware objects provided by plugins to an internal interface. In
+// particular, this implements fallthrough logic for when a plugin defines some
+// methods (e.g. execute) but doesn't implement others (e.g. interrupt). Note
+// that HydrogenKernelMiddleware objects are mutable: they may lose/gain methods
+// at any time, including in the middle of processing a request.
+// TODO(nikita): insert checks between plugins that ensure that messages being
+// passed around via results callbacks comply with the Jupyter messaging spec.
+class MiddlewareAdapter implements HydrogenKernelMiddlewareStack {
+  _middleware: HydrogenKernelMiddleware;
+  _next: MiddlewareAdapter | KernelTransport;
+  constructor(
+    middleware: HydrogenKernelMiddleware,
+    next: MiddlewareAdapter | KernelTransport
+  ) {
+    this._middleware = middleware;
+    this._next = next;
+  }
+
+  // The return value of this method gets passed to plugins! For now we just
+  // return the MiddlewareAdapter object itself, which is why all private
+  // functionality is prefixed with _, and why MiddlewareAdapter is marked as
+  // implementing HydrogenKernelMiddlewareStack. Something more complicated may
+  // to handle plugin API compatibility, once multiple API versions exist.
+  get _nextAsPluginType(): HydrogenKernelMiddlewareStack {
+    if (this._next instanceof KernelTransport) {
+      throw new Error(
+        "MiddlewareAdapter: _nextAsPluginType must never be called when _next is KernelTransport"
+      );
+    }
+    return this._next;
+  }
+
+  interrupt(): void {
+    if (this._middleware.interrupt) {
+      this._middleware.interrupt(this._nextAsPluginType);
+    } else {
+      this._next.interrupt();
+    }
+  }
+
+  shutdown(): void {
+    if (this._middleware.shutdown) {
+      this._middleware.shutdown(this._nextAsPluginType);
+    } else {
+      this._next.shutdown();
+    }
+  }
+
+  restart(onRestarted: ?Function): void {
+    if (this._middleware.restart) {
+      this._middleware.restart(this._nextAsPluginType, onRestarted);
+    } else {
+      this._next.restart(onRestarted);
+    }
+  }
+
+  execute(
     code: string,
     callWatches: boolean,
     onResults: ResultsCallback
-  ) => void;
-  complete: (code: string, onResults: ResultsCallback) => void;
-  inspect: (
-    code: string,
-    cursorPos: number,
-    onResults: ResultsCallback
-  ) => void;
+  ): void {
+    if (this._middleware.execute) {
+      this._middleware.execute(
+        this._nextAsPluginType,
+        code,
+        callWatches,
+        onResults
+      );
+    } else {
+      this._next.execute(code, callWatches, onResults);
+    }
+  }
+
+  complete(code: string, onResults: ResultsCallback): void {
+    if (this._middleware.complete) {
+      this._middleware.complete(this._nextAsPluginType, code, onResults);
+    } else {
+      this._next.complete(code, onResults);
+    }
+  }
+
+  inspect(code: string, cursorPos: number, onResults: ResultsCallback): void {
+    if (this._middleware.inspect) {
+      this._middleware.inspect(
+        this._nextAsPluginType,
+        code,
+        cursorPos,
+        onResults
+      );
+    } else {
+      this._next.inspect(code, cursorPos, onResults);
+    }
+  }
 }
 
 export default class Kernel {
@@ -45,27 +127,23 @@ export default class Kernel {
   emitter = new Emitter();
   pluginWrapper: HydrogenKernel | null = null;
   transport: KernelTransport;
-  middlewareStack: KernelMiddlewareStack;
+
+  // Invariant: the `._next` of each entry in this array must point to the next
+  // element of the array. The `._next` of the last element must point to
+  // `this.transport`.
+  middleware: Array<MiddlewareAdapter>;
 
   constructor(kernel: KernelTransport) {
     this.transport = kernel;
 
     this.watchesStore = new WatchesStore(this);
 
-    this.middlewareStack = {
-      interrupt: () => this.transport.interrupt(),
-      shutdown: () => this.transport.shutdown(),
-      restart: (onRestarted: ?Function) => this.transport.restart(onRestarted),
-      execute: (
-        code: string,
-        callWatches: boolean,
-        onResults: ResultsCallback
-      ) => this.transport.execute(code, callWatches, onResults),
-      complete: (code: string, onResults: ResultsCallback) =>
-        this.transport.complete(code, onResults),
-      inspect: (code: string, cursorPos: number, onResults: ResultsCallback) =>
-        this.transport.inspect(code, cursorPos, onResults)
-    };
+    // A MiddlewareAdapter that forwards all requests to `this.transport`.
+    // Needed to terminate the middleware chain in a way such that the `next`
+    // object passed to the last middleware is not the KernelTransport instance
+    // itself (which would be violate isolation of internals from plugins).
+    const delegateToTransport = new MiddlewareAdapter({}, this.transport);
+    this.middleware = [delegateToTransport];
   }
 
   get kernelSpec(): Kernelspec {
@@ -84,8 +162,14 @@ export default class Kernel {
     return this.transport.displayName;
   }
 
-  setMiddlewareStack(middlewareStack: KernelMiddlewareStack) {
-    this.middlewareStack = middlewareStack;
+  get firstMiddlewareAdapter(): MiddlewareAdapter {
+    return this.middleware[0];
+  }
+
+  addMiddleware(middleware: HydrogenKernelMiddleware) {
+    this.middleware.unshift(
+      new MiddlewareAdapter(middleware, this.middleware[0])
+    );
   }
 
   @computed
@@ -121,19 +205,19 @@ export default class Kernel {
   }
 
   interrupt() {
-    this.middlewareStack.interrupt();
+    this.firstMiddlewareAdapter.interrupt();
   }
 
   shutdown() {
-    this.middlewareStack.shutdown();
+    this.firstMiddlewareAdapter.shutdown();
   }
 
   restart(onRestarted: ?Function) {
-    this.middlewareStack.restart(onRestarted);
+    this.firstMiddlewareAdapter.restart(onRestarted);
   }
 
   execute(code: string, onResults: Function) {
-    this.middlewareStack.execute(
+    this.firstMiddlewareAdapter.execute(
       code,
       true,
       this._wrapExecutionResultsCallback(onResults)
@@ -141,7 +225,7 @@ export default class Kernel {
   }
 
   executeWatch(code: string, onResults: Function) {
-    this.middlewareStack.execute(
+    this.firstMiddlewareAdapter.execute(
       code,
       false,
       this._wrapExecutionResultsCallback(onResults)
@@ -204,20 +288,23 @@ export default class Kernel {
   }
 
   complete(code: string, onResults: Function) {
-    this.middlewareStack.complete(code, (message: Message, channel: string) => {
-      if (channel !== "shell") {
-        log("Invalid reply: wrong channel");
-        return;
+    this.firstMiddlewareAdapter.complete(
+      code,
+      (message: Message, channel: string) => {
+        if (channel !== "shell") {
+          log("Invalid reply: wrong channel");
+          return;
+        }
+        if (!this.transport.isValidMessage(message)) {
+          return;
+        }
+        onResults(message.content);
       }
-      if (!this.transport.isValidMessage(message)) {
-        return;
-      }
-      onResults(message.content);
-    });
+    );
   }
 
   inspect(code: string, cursorPos: number, onResults: Function) {
-    this.middlewareStack.inspect(
+    this.firstMiddlewareAdapter.inspect(
       code,
       cursorPos,
       (message: Message, channel: string) => {

--- a/lib/kernel.js
+++ b/lib/kernel.js
@@ -16,14 +16,28 @@ import store from "./store";
 import WatchesStore from "./store/watches";
 import OutputStore from "./store/output";
 import HydrogenKernel from "./plugin-api/hydrogen-kernel";
+import InputView from "./input-view";
+
+export type ResultsCallback = (
+  message: any,
+  channel: "shell" | "iopub" | "stdin"
+) => void;
 
 interface KernelMiddlewareStack {
   interrupt: () => void;
   shutdown: () => void;
   restart: (onRestarted: ?Function) => void;
-  execute: (code: string, callWatches: boolean, onResults: Function) => void;
-  complete: (code: string, onResults: Function) => void;
-  inspect: (code: string, cursorPos: number, onResults: Function) => void;
+  execute: (
+    code: string,
+    callWatches: boolean,
+    onResults: ResultsCallback
+  ) => void;
+  complete: (code: string, onResults: ResultsCallback) => void;
+  inspect: (
+    code: string,
+    cursorPos: number,
+    onResults: ResultsCallback
+  ) => void;
 }
 
 export default class Kernel {
@@ -54,11 +68,14 @@ export default class Kernel {
       interrupt: () => this.rawInterrupt(),
       shutdown: () => this.rawShutdown(),
       restart: (onRestarted: ?Function) => this.rawRestart(onRestarted),
-      execute: (code: string, callWatches: boolean, onResults: Function) =>
-        this.rawExecute(code, callWatches, onResults),
-      complete: (code: string, onResults: Function) =>
+      execute: (
+        code: string,
+        callWatches: boolean,
+        onResults: ResultsCallback
+      ) => this.rawExecute(code, callWatches, onResults),
+      complete: (code: string, onResults: ResultsCallback) =>
         this.rawComplete(code, onResults),
-      inspect: (code: string, cursorPos: number, onResults: Function) =>
+      inspect: (code: string, cursorPos: number, onResults: ResultsCallback) =>
         this.rawInspect(code, cursorPos, onResults)
     };
   }
@@ -112,19 +129,100 @@ export default class Kernel {
   }
 
   execute(code: string, onResults: Function) {
-    this.middlewareStack.execute(code, true, onResults);
+    this.middlewareStack.execute(
+      code,
+      true,
+      this._translateExecuteResults(onResults)
+    );
   }
 
   executeWatch(code: string, onResults: Function) {
-    this.middlewareStack.execute(code, false, onResults);
+    this.middlewareStack.execute(
+      code,
+      false,
+      this._translateExecuteResults(onResults)
+    );
+  }
+
+  _translateExecuteResults(onResults: Function) {
+    return (message: Message, channel: string) => {
+      if (!this._isValidMessage(message)) {
+        return;
+      }
+
+      if (channel === "shell") {
+        const { status } = message.content;
+        if (status === "error" || status === "ok") {
+          onResults({
+            data: status,
+            stream: "status"
+          });
+        } else {
+          console.warn(
+            "Kernel: ignoring unexpected value for message.content.status"
+          );
+        }
+      } else if (channel === "iopub") {
+        if (message.header.msg_type === "execute_input") {
+          onResults({
+            data: message.content.execution_count,
+            stream: "execution_count"
+          });
+        }
+
+        // TODO(nikita): Consider converting to V5 elsewhere, so that plugins
+        // never have to deal with messages in the V4 format
+        const result = msgSpecToNotebookFormat(msgSpecV4toV5(message));
+        onResults(result);
+      } else if (channel === "stdin") {
+        if (message.header.msg_type !== "input_request") {
+          return;
+        }
+
+        const { prompt } = message.content;
+
+        // TODO(nikita): perhaps it would make sense to install middleware for
+        // sending input replies
+        const inputView = new InputView({ prompt }, (input: string) =>
+          this.rawInputReply(input)
+        );
+
+        inputView.attach();
+      }
+    };
   }
 
   complete(code: string, onResults: Function) {
-    this.middlewareStack.complete(code, onResults);
+    this.middlewareStack.complete(code, (message: Message, channel: string) => {
+      if (channel !== "shell") {
+        log("Invalid reply: wrong channel");
+        return;
+      }
+      if (!this._isValidMessage(message)) {
+        return;
+      }
+      onResults(message.content);
+    });
   }
 
   inspect(code: string, cursorPos: number, onResults: Function) {
-    this.middlewareStack.inspect(code, cursorPos, onResults);
+    this.middlewareStack.inspect(
+      code,
+      cursorPos,
+      (message: Message, channel: string) => {
+        if (channel !== "shell") {
+          log("Invalid reply: wrong channel");
+          return;
+        }
+        if (!this._isValidMessage(message)) {
+          return;
+        }
+        onResults({
+          data: message.content.data,
+          found: message.content.found
+        });
+      }
+    );
   }
 
   // The "raw" family of methods directly perform their functions without
@@ -142,37 +240,70 @@ export default class Kernel {
     throw new Error("Kernel: rawRestart method not implemented");
   }
 
-  rawExecute(code: string, callWatches: boolean, onResults: Function) {
+  rawExecute(code: string, callWatches: boolean, onResults: ResultsCallback) {
     throw new Error("Kernel: rawExecute method not implemented");
   }
 
-  rawComplete(code: string, onResults: Function) {
+  rawComplete(code: string, onResults: ResultsCallback) {
     throw new Error("Kernel: rawComplete method not implemented");
   }
 
-  rawInspect(code: string, cursorPos: number, onResults: Function) {
+  rawInspect(code: string, cursorPos: number, onResults: ResultsCallback) {
     throw new Error("Kernel: rawInspect method not implemented");
   }
 
-  _parseIOMessage(message: Message) {
-    let result = this._parseExecuteInputIOMessage(message);
-
-    if (!result) {
-      result = msgSpecToNotebookFormat(msgSpecV4toV5(message));
-    }
-
-    return result;
+  rawInputReply(input: string) {
+    throw new Error("Kernel: rawInputReply method not implemented");
   }
 
-  _parseExecuteInputIOMessage(message: Message) {
-    if (message.header.msg_type === "execute_input") {
-      return {
-        data: message.content.execution_count,
-        stream: "execution_count"
-      };
+  _isValidMessage(message: Message) {
+    if (!message) {
+      log("Invalid message: null");
+      return false;
     }
 
-    return null;
+    if (!message.content) {
+      log("Invalid message: Missing content");
+      return false;
+    }
+
+    if (message.content.execution_state === "starting") {
+      // Kernels send a starting status message with an empty parent_header
+      log("Dropped starting status IO message");
+      return false;
+    }
+
+    if (!message.parent_header) {
+      log("Invalid message: Missing parent_header");
+      return false;
+    }
+
+    if (!message.parent_header.msg_id) {
+      log("Invalid message: Missing parent_header.msg_id");
+      return false;
+    }
+
+    if (!message.parent_header.msg_type) {
+      log("Invalid message: Missing parent_header.msg_type");
+      return false;
+    }
+
+    if (!message.header) {
+      log("Invalid message: Missing header");
+      return false;
+    }
+
+    if (!message.header.msg_id) {
+      log("Invalid message: Missing header.msg_id");
+      return false;
+    }
+
+    if (!message.header.msg_type) {
+      log("Invalid message: Missing header.msg_type");
+      return false;
+    }
+
+    return true;
   }
 
   destroy() {

--- a/lib/kernel.js
+++ b/lib/kernel.js
@@ -18,7 +18,6 @@ import OutputStore from "./store/output";
 import HydrogenKernel from "./plugin-api/hydrogen-kernel";
 import InputView from "./input-view";
 import KernelTransport from "./kernel-transport";
-import ZMQKernel from "./zmq-kernel";
 import type { ResultsCallback } from "./kernel-transport";
 
 interface KernelMiddlewareStack {
@@ -137,7 +136,7 @@ export default class Kernel {
     this.middlewareStack.execute(
       code,
       true,
-      this._wrapExecuteResultsCallback(onResults)
+      this._wrapExecutionResultsCallback(onResults)
     );
   }
 
@@ -145,11 +144,18 @@ export default class Kernel {
     this.middlewareStack.execute(
       code,
       false,
-      this._wrapExecuteResultsCallback(onResults)
+      this._wrapExecutionResultsCallback(onResults)
     );
   }
 
-  _wrapExecuteResultsCallback(onResults: Function) {
+  /*
+   * Takes a callback that accepts execution results in a hydrogen-internal
+   * format and wraps it to accept Jupyter message/channel pairs instead.
+   * Kernels and plugins all operate on types specified by the Jupyter messaging
+   * protocol in order to maximize compatibility, but hydrogen internally uses
+   * its own types.
+   */
+  _wrapExecutionResultsCallback(onResults: Function) {
     return (message: Message, channel: string) => {
       if (!this.transport.isValidMessage(message)) {
         return;

--- a/lib/kernel.js
+++ b/lib/kernel.js
@@ -17,11 +17,9 @@ import WatchesStore from "./store/watches";
 import OutputStore from "./store/output";
 import HydrogenKernel from "./plugin-api/hydrogen-kernel";
 import InputView from "./input-view";
-
-export type ResultsCallback = (
-  message: any,
-  channel: "shell" | "iopub" | "stdin"
-) => void;
+import KernelTransport from "./kernel-transport";
+import ZMQKernel from "./zmq-kernel";
+import type { ResultsCallback } from "./kernel-transport";
 
 interface KernelMiddlewareStack {
   interrupt: () => void;
@@ -41,52 +39,66 @@ interface KernelMiddlewareStack {
 }
 
 export default class Kernel {
-  @observable executionState = "loading";
   @observable inspector = { bundle: {} };
   outputStore = new OutputStore();
 
-  kernelSpec: Kernelspec;
-  grammar: atom$Grammar;
-  language: string;
-  displayName: string;
   watchesStore: WatchesStore;
-  watchCallbacks: Array<Function> = [];
   emitter = new Emitter();
   pluginWrapper: HydrogenKernel | null = null;
+  transport: KernelTransport;
   middlewareStack: KernelMiddlewareStack;
 
-  constructor(kernelSpec: Kernelspec, grammar: atom$Grammar) {
-    this.kernelSpec = kernelSpec;
-    this.grammar = grammar;
-
-    this.language = kernelSpec.language.toLowerCase();
-    this.displayName = kernelSpec.display_name;
+  constructor(kernel: KernelTransport) {
+    this.transport = kernel;
 
     this.watchesStore = new WatchesStore(this);
 
     this.middlewareStack = {
-      interrupt: () => this.rawInterrupt(),
-      shutdown: () => this.rawShutdown(),
-      restart: (onRestarted: ?Function) => this.rawRestart(onRestarted),
+      interrupt: () => this.transport.interrupt(),
+      shutdown: () => this.transport.shutdown(),
+      restart: (onRestarted: ?Function) => this.transport.restart(onRestarted),
       execute: (
         code: string,
         callWatches: boolean,
         onResults: ResultsCallback
-      ) => this.rawExecute(code, callWatches, onResults),
+      ) => this.transport.execute(code, callWatches, onResults),
       complete: (code: string, onResults: ResultsCallback) =>
-        this.rawComplete(code, onResults),
+        this.transport.complete(code, onResults),
       inspect: (code: string, cursorPos: number, onResults: ResultsCallback) =>
-        this.rawInspect(code, cursorPos, onResults)
+        this.transport.inspect(code, cursorPos, onResults)
     };
+  }
+
+  get kernelSpec(): Kernelspec {
+    return this.transport.kernelSpec;
+  }
+
+  get grammar(): atom$Grammar {
+    return this.transport.grammar;
+  }
+
+  get language(): string {
+    return this.transport.language;
+  }
+
+  get displayName(): string {
+    return this.transport.displayName;
   }
 
   setMiddlewareStack(middlewareStack: KernelMiddlewareStack) {
     this.middlewareStack = middlewareStack;
   }
 
+  get executionState(): string {
+    // XXX(nikita): Does returning an observable do the right thing?
+    return this.transport.executionState;
+  }
+
   @action
   setExecutionState(state: string) {
-    this.executionState = state;
+    // XXX(nikita): call this.transport.executionState instead? But in that case
+    // what do we do about the @action decorator?
+    this.transport.executionState = state;
   }
 
   @action
@@ -109,11 +121,7 @@ export default class Kernel {
   }
 
   addWatchCallback(watchCallback: Function) {
-    this.watchCallbacks.push(watchCallback);
-  }
-
-  _callWatchCallbacks() {
-    this.watchCallbacks.forEach(watchCallback => watchCallback());
+    this.transport.addWatchCallback(watchCallback);
   }
 
   interrupt() {
@@ -146,7 +154,8 @@ export default class Kernel {
 
   _translateExecuteResults(onResults: Function) {
     return (message: Message, channel: string) => {
-      if (!this._isValidMessage(message)) {
+      if (!this.transport._isValidMessage(message)) {
+        //XXX(nikita): it's private!
         return;
       }
 
@@ -184,7 +193,7 @@ export default class Kernel {
         // TODO(nikita): perhaps it would make sense to install middleware for
         // sending input replies
         const inputView = new InputView({ prompt }, (input: string) =>
-          this.rawInputReply(input)
+          this.transport.inputReply(input)
         );
 
         inputView.attach();
@@ -198,7 +207,8 @@ export default class Kernel {
         log("Invalid reply: wrong channel");
         return;
       }
-      if (!this._isValidMessage(message)) {
+      if (!this.transport._isValidMessage(message)) {
+        //XXX(nikita): it's private!
         return;
       }
       onResults(message.content);
@@ -214,7 +224,8 @@ export default class Kernel {
           log("Invalid reply: wrong channel");
           return;
         }
-        if (!this._isValidMessage(message)) {
+        if (!this.transport._isValidMessage(message)) {
+          //XXX(nikita): it's private!
           return;
         }
         onResults({
@@ -225,90 +236,10 @@ export default class Kernel {
     );
   }
 
-  // The "raw" family of methods directly perform their functions without
-  // activating any plugins along the way. Subclasses override these.
-
-  rawInterrupt() {
-    throw new Error("Kernel: rawInterrupt method not implemented");
-  }
-
-  rawShutdown() {
-    throw new Error("Kernel: rawShutdown method not implemented");
-  }
-
-  rawRestart(onRestarted: ?Function) {
-    throw new Error("Kernel: rawRestart method not implemented");
-  }
-
-  rawExecute(code: string, callWatches: boolean, onResults: ResultsCallback) {
-    throw new Error("Kernel: rawExecute method not implemented");
-  }
-
-  rawComplete(code: string, onResults: ResultsCallback) {
-    throw new Error("Kernel: rawComplete method not implemented");
-  }
-
-  rawInspect(code: string, cursorPos: number, onResults: ResultsCallback) {
-    throw new Error("Kernel: rawInspect method not implemented");
-  }
-
-  rawInputReply(input: string) {
-    throw new Error("Kernel: rawInputReply method not implemented");
-  }
-
-  _isValidMessage(message: Message) {
-    if (!message) {
-      log("Invalid message: null");
-      return false;
-    }
-
-    if (!message.content) {
-      log("Invalid message: Missing content");
-      return false;
-    }
-
-    if (message.content.execution_state === "starting") {
-      // Kernels send a starting status message with an empty parent_header
-      log("Dropped starting status IO message");
-      return false;
-    }
-
-    if (!message.parent_header) {
-      log("Invalid message: Missing parent_header");
-      return false;
-    }
-
-    if (!message.parent_header.msg_id) {
-      log("Invalid message: Missing parent_header.msg_id");
-      return false;
-    }
-
-    if (!message.parent_header.msg_type) {
-      log("Invalid message: Missing parent_header.msg_type");
-      return false;
-    }
-
-    if (!message.header) {
-      log("Invalid message: Missing header");
-      return false;
-    }
-
-    if (!message.header.msg_id) {
-      log("Invalid message: Missing header.msg_id");
-      return false;
-    }
-
-    if (!message.header.msg_type) {
-      log("Invalid message: Missing header.msg_type");
-      return false;
-    }
-
-    return true;
-  }
-
   destroy() {
-    log("Kernel: Destroying base kernel");
+    log("Kernel: Destroying");
     store.deleteKernel(this);
+    this.transport.destroy();
     if (this.pluginWrapper) {
       this.pluginWrapper.destroyed = true;
     }

--- a/lib/kernel.js
+++ b/lib/kernel.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import { Emitter } from "atom";
-import { observable, action } from "mobx";
+import { observable, action, computed } from "mobx";
 import { isEqual } from "lodash";
 
 import {
@@ -89,16 +89,13 @@ export default class Kernel {
     this.middlewareStack = middlewareStack;
   }
 
+  @computed
   get executionState(): string {
-    // XXX(nikita): Does returning an observable do the right thing?
     return this.transport.executionState;
   }
 
-  @action
   setExecutionState(state: string) {
-    // XXX(nikita): call this.transport.executionState instead? But in that case
-    // what do we do about the @action decorator?
-    this.transport.executionState = state;
+    this.transport.setExecutionState(state);
   }
 
   @action

--- a/lib/kernel.js
+++ b/lib/kernel.js
@@ -17,7 +17,7 @@ import WatchesStore from "./store/watches";
 import OutputStore from "./store/output";
 import HydrogenKernel from "./plugin-api/hydrogen-kernel";
 import type {
-  HydrogenKernelMiddlewareStack,
+  HydrogenKernelMiddlewareThunk,
   HydrogenKernelMiddleware
 } from "./plugin-api/hydrogen-types";
 import InputView from "./input-view";
@@ -31,7 +31,7 @@ import type { ResultsCallback } from "./kernel-transport";
 // at any time, including in the middle of processing a request.
 // TODO(nikita): insert checks between plugins that ensure that messages being
 // passed around via results callbacks comply with the Jupyter messaging spec.
-class MiddlewareAdapter implements HydrogenKernelMiddlewareStack {
+class MiddlewareAdapter implements HydrogenKernelMiddlewareThunk {
   _middleware: HydrogenKernelMiddleware;
   _next: MiddlewareAdapter | KernelTransport;
   constructor(
@@ -45,9 +45,10 @@ class MiddlewareAdapter implements HydrogenKernelMiddlewareStack {
   // The return value of this method gets passed to plugins! For now we just
   // return the MiddlewareAdapter object itself, which is why all private
   // functionality is prefixed with _, and why MiddlewareAdapter is marked as
-  // implementing HydrogenKernelMiddlewareStack. Something more complicated may
-  // to handle plugin API compatibility, once multiple API versions exist.
-  get _nextAsPluginType(): HydrogenKernelMiddlewareStack {
+  // implementing HydrogenKernelMiddlewareThunk. Once multiple plugin API
+  // versions exist, we may want to generate a HydrogenKernelMiddlewareThunk
+  // specialized for a particular plugin API version.
+  get _nextAsPluginType(): HydrogenKernelMiddlewareThunk {
     if (this._next instanceof KernelTransport) {
       throw new Error(
         "MiddlewareAdapter: _nextAsPluginType must never be called when _next is KernelTransport"

--- a/lib/kernel.js
+++ b/lib/kernel.js
@@ -140,7 +140,7 @@ export default class Kernel {
     this.middlewareStack.execute(
       code,
       true,
-      this._translateExecuteResults(onResults)
+      this._wrapExecuteResultsCallback(onResults)
     );
   }
 
@@ -148,14 +148,13 @@ export default class Kernel {
     this.middlewareStack.execute(
       code,
       false,
-      this._translateExecuteResults(onResults)
+      this._wrapExecuteResultsCallback(onResults)
     );
   }
 
-  _translateExecuteResults(onResults: Function) {
+  _wrapExecuteResultsCallback(onResults: Function) {
     return (message: Message, channel: string) => {
-      if (!this.transport._isValidMessage(message)) {
-        //XXX(nikita): it's private!
+      if (!this.transport.isValidMessage(message)) {
         return;
       }
 
@@ -207,8 +206,7 @@ export default class Kernel {
         log("Invalid reply: wrong channel");
         return;
       }
-      if (!this.transport._isValidMessage(message)) {
-        //XXX(nikita): it's private!
+      if (!this.transport.isValidMessage(message)) {
         return;
       }
       onResults(message.content);
@@ -224,8 +222,7 @@ export default class Kernel {
           log("Invalid reply: wrong channel");
           return;
         }
-        if (!this.transport._isValidMessage(message)) {
-          //XXX(nikita): it's private!
+        if (!this.transport.isValidMessage(message)) {
           return;
         }
         onResults({

--- a/lib/kernel.js
+++ b/lib/kernel.js
@@ -24,13 +24,68 @@ import InputView from "./input-view";
 import KernelTransport from "./kernel-transport";
 import type { ResultsCallback } from "./kernel-transport";
 
+function protectFromInvalidMessages(
+  onResults: ResultsCallback
+): ResultsCallback {
+  const wrappedOnResults: ResultsCallback = (message, channel) => {
+    if (!message) {
+      log("Invalid message: null");
+      return;
+    }
+
+    if (!message.content) {
+      log("Invalid message: Missing content");
+      return;
+    }
+
+    if (message.content.execution_state === "starting") {
+      // Kernels send a starting status message with an empty parent_header
+      log("Dropped starting status IO message");
+      return;
+    }
+
+    if (!message.parent_header) {
+      log("Invalid message: Missing parent_header");
+      return;
+    }
+
+    if (!message.parent_header.msg_id) {
+      log("Invalid message: Missing parent_header.msg_id");
+      return;
+    }
+
+    if (!message.parent_header.msg_type) {
+      log("Invalid message: Missing parent_header.msg_type");
+      return;
+    }
+
+    if (!message.header) {
+      log("Invalid message: Missing header");
+      return;
+    }
+
+    if (!message.header.msg_id) {
+      log("Invalid message: Missing header.msg_id");
+      return;
+    }
+
+    if (!message.header.msg_type) {
+      log("Invalid message: Missing header.msg_type");
+      return;
+    }
+
+    onResults(message, channel);
+  };
+  return wrappedOnResults;
+}
+
 // Adapts middleware objects provided by plugins to an internal interface. In
 // particular, this implements fallthrough logic for when a plugin defines some
 // methods (e.g. execute) but doesn't implement others (e.g. interrupt). Note
 // that HydrogenKernelMiddleware objects are mutable: they may lose/gain methods
-// at any time, including in the middle of processing a request.
-// TODO(nikita): insert checks between plugins that ensure that messages being
-// passed around via results callbacks comply with the Jupyter messaging spec.
+// at any time, including in the middle of processing a request. This class also
+// adds basic checks that messages passed via the `onResults` callbacks are not
+// missing key mandatory fields specified in the Jupyter messaging spec.
 class MiddlewareAdapter implements HydrogenKernelMiddlewareThunk {
   _middleware: HydrogenKernelMiddleware;
   _next: MiddlewareAdapter | KernelTransport;
@@ -86,36 +141,53 @@ class MiddlewareAdapter implements HydrogenKernelMiddlewareThunk {
     callWatches: boolean,
     onResults: ResultsCallback
   ): void {
+    // We don't want to repeatedly wrap the onResults callback every time we
+    // fall through, but we need to do it at least once before delegating to
+    // the KernelTransport.
+    let safeOnResults =
+      this._middleware.execute || this._next instanceof KernelTransport
+        ? protectFromInvalidMessages(onResults)
+        : onResults;
+
     if (this._middleware.execute) {
       this._middleware.execute(
         this._nextAsPluginType,
         code,
         callWatches,
-        onResults
+        safeOnResults
       );
     } else {
-      this._next.execute(code, callWatches, onResults);
+      this._next.execute(code, callWatches, safeOnResults);
     }
   }
 
   complete(code: string, onResults: ResultsCallback): void {
+    let safeOnResults =
+      this._middleware.complete || this._next instanceof KernelTransport
+        ? protectFromInvalidMessages(onResults)
+        : onResults;
+
     if (this._middleware.complete) {
-      this._middleware.complete(this._nextAsPluginType, code, onResults);
+      this._middleware.complete(this._nextAsPluginType, code, safeOnResults);
     } else {
-      this._next.complete(code, onResults);
+      this._next.complete(code, safeOnResults);
     }
   }
 
   inspect(code: string, cursorPos: number, onResults: ResultsCallback): void {
+    let safeOnResults =
+      this._middleware.inspect || this._next instanceof KernelTransport
+        ? protectFromInvalidMessages(onResults)
+        : onResults;
     if (this._middleware.inspect) {
       this._middleware.inspect(
         this._nextAsPluginType,
         code,
         cursorPos,
-        onResults
+        safeOnResults
       );
     } else {
-      this._next.inspect(code, cursorPos, onResults);
+      this._next.inspect(code, cursorPos, safeOnResults);
     }
   }
 }
@@ -242,10 +314,6 @@ export default class Kernel {
    */
   _wrapExecutionResultsCallback(onResults: Function) {
     return (message: Message, channel: string) => {
-      if (!this.transport.isValidMessage(message)) {
-        return;
-      }
-
       if (channel === "shell") {
         const { status } = message.content;
         if (status === "error" || status === "ok") {
@@ -296,9 +364,6 @@ export default class Kernel {
           log("Invalid reply: wrong channel");
           return;
         }
-        if (!this.transport.isValidMessage(message)) {
-          return;
-        }
         onResults(message.content);
       }
     );
@@ -311,9 +376,6 @@ export default class Kernel {
       (message: Message, channel: string) => {
         if (channel !== "shell") {
           log("Invalid reply: wrong channel");
-          return;
-        }
-        if (!this.transport.isValidMessage(message)) {
           return;
         }
         onResults({

--- a/lib/kernel.js
+++ b/lib/kernel.js
@@ -136,11 +136,7 @@ class MiddlewareAdapter implements HydrogenKernelMiddlewareThunk {
     }
   }
 
-  execute(
-    code: string,
-    callWatches: boolean,
-    onResults: ResultsCallback
-  ): void {
+  execute(code: string, onResults: ResultsCallback): void {
     // We don't want to repeatedly wrap the onResults callback every time we
     // fall through, but we need to do it at least once before delegating to
     // the KernelTransport.
@@ -150,14 +146,9 @@ class MiddlewareAdapter implements HydrogenKernelMiddlewareThunk {
         : onResults;
 
     if (this._middleware.execute) {
-      this._middleware.execute(
-        this._nextAsPluginType,
-        code,
-        callWatches,
-        safeOnResults
-      );
+      this._middleware.execute(this._nextAsPluginType, code, safeOnResults);
     } else {
-      this._next.execute(code, callWatches, safeOnResults);
+      this._next.execute(code, safeOnResults);
     }
   }
 
@@ -197,6 +188,8 @@ export default class Kernel {
   outputStore = new OutputStore();
 
   watchesStore: WatchesStore;
+  watchCallbacks: Array<Function> = [];
+
   emitter = new Emitter();
   pluginWrapper: HydrogenKernel | null = null;
   transport: KernelTransport;
@@ -274,7 +267,7 @@ export default class Kernel {
   }
 
   addWatchCallback(watchCallback: Function) {
-    this.transport.addWatchCallback(watchCallback);
+    this.watchCallbacks.push(watchCallback);
   }
 
   interrupt() {
@@ -290,19 +283,32 @@ export default class Kernel {
   }
 
   execute(code: string, onResults: Function) {
+    const wrappedOnResults = this._wrapExecutionResultsCallback(onResults);
     this.firstMiddlewareAdapter.execute(
       code,
-      true,
-      this._wrapExecutionResultsCallback(onResults)
+      (message: Message, channel: string) => {
+        wrappedOnResults(message, channel);
+
+        if (
+          channel == "iopub" &&
+          message.header.msg_type === "status" &&
+          message.content.execution_state === "idle"
+        ) {
+          this._callWatchCallbacks();
+        }
+      }
     );
   }
 
   executeWatch(code: string, onResults: Function) {
     this.firstMiddlewareAdapter.execute(
       code,
-      false,
       this._wrapExecutionResultsCallback(onResults)
     );
+  }
+
+  _callWatchCallbacks() {
+    this.watchCallbacks.forEach(watchCallback => watchCallback());
   }
 
   /*

--- a/lib/kernel.js
+++ b/lib/kernel.js
@@ -17,6 +17,15 @@ import WatchesStore from "./store/watches";
 import OutputStore from "./store/output";
 import HydrogenKernel from "./plugin-api/hydrogen-kernel";
 
+interface KernelMiddlewareStack {
+  interrupt: () => void;
+  shutdown: () => void;
+  restart: (onRestarted: ?Function) => void;
+  execute: (code: string, callWatches: boolean, onResults: Function) => void;
+  complete: (code: string, onResults: Function) => void;
+  inspect: (code: string, cursorPos: number, onResults: Function) => void;
+}
+
 export default class Kernel {
   @observable executionState = "loading";
   @observable inspector = { bundle: {} };
@@ -30,6 +39,7 @@ export default class Kernel {
   watchCallbacks: Array<Function> = [];
   emitter = new Emitter();
   pluginWrapper: HydrogenKernel | null = null;
+  middlewareStack: KernelMiddlewareStack;
 
   constructor(kernelSpec: Kernelspec, grammar: atom$Grammar) {
     this.kernelSpec = kernelSpec;
@@ -39,6 +49,22 @@ export default class Kernel {
     this.displayName = kernelSpec.display_name;
 
     this.watchesStore = new WatchesStore(this);
+
+    this.middlewareStack = {
+      interrupt: () => this.rawInterrupt(),
+      shutdown: () => this.rawShutdown(),
+      restart: (onRestarted: ?Function) => this.rawRestart(onRestarted),
+      execute: (code: string, callWatches: boolean, onResults: Function) =>
+        this.rawExecute(code, callWatches, onResults),
+      complete: (code: string, onResults: Function) =>
+        this.rawComplete(code, onResults),
+      inspect: (code: string, cursorPos: number, onResults: Function) =>
+        this.rawInspect(code, cursorPos, onResults)
+    };
+  }
+
+  setMiddlewareStack(middlewareStack: KernelMiddlewareStack) {
+    this.middlewareStack = middlewareStack;
   }
 
   @action
@@ -74,31 +100,58 @@ export default class Kernel {
   }
 
   interrupt() {
-    throw new Error("Kernel: interrupt method not implemented");
+    this.middlewareStack.interrupt();
   }
 
   shutdown() {
-    throw new Error("Kernel: shutdown method not implemented");
+    this.middlewareStack.shutdown();
   }
 
   restart(onRestarted: ?Function) {
-    throw new Error("Kernel: restart method not implemented");
+    this.middlewareStack.restart(onRestarted);
   }
 
   execute(code: string, onResults: Function) {
-    throw new Error("Kernel: execute method not implemented");
+    this.middlewareStack.execute(code, true, onResults);
   }
 
   executeWatch(code: string, onResults: Function) {
-    throw new Error("Kernel: executeWatch method not implemented");
+    this.middlewareStack.execute(code, false, onResults);
   }
 
   complete(code: string, onResults: Function) {
-    throw new Error("Kernel: complete method not implemented");
+    this.middlewareStack.complete(code, onResults);
   }
 
-  inspect(code: string, curorPos: number, onResults: Function) {
-    throw new Error("Kernel: inspect method not implemented");
+  inspect(code: string, cursorPos: number, onResults: Function) {
+    this.middlewareStack.inspect(code, cursorPos, onResults);
+  }
+
+  // The "raw" family of methods directly perform their functions without
+  // activating any plugins along the way. Subclasses override these.
+
+  rawInterrupt() {
+    throw new Error("Kernel: rawInterrupt method not implemented");
+  }
+
+  rawShutdown() {
+    throw new Error("Kernel: rawShutdown method not implemented");
+  }
+
+  rawRestart(onRestarted: ?Function) {
+    throw new Error("Kernel: rawRestart method not implemented");
+  }
+
+  rawExecute(code: string, callWatches: boolean, onResults: Function) {
+    throw new Error("Kernel: rawExecute method not implemented");
+  }
+
+  rawComplete(code: string, onResults: Function) {
+    throw new Error("Kernel: rawComplete method not implemented");
+  }
+
+  rawInspect(code: string, cursorPos: number, onResults: Function) {
+    throw new Error("Kernel: rawInspect method not implemented");
   }
 
   _parseIOMessage(message: Message) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -36,6 +36,7 @@ import Config from "./config";
 import kernelManager from "./kernel-manager";
 import ZMQKernel from "./zmq-kernel";
 import WSKernel from "./ws-kernel";
+import Kernel from "./kernel";
 import AutocompleteProvider from "./autocomplete-provider";
 import HydrogenProvider from "./plugin-api/hydrogen-provider";
 
@@ -52,8 +53,6 @@ import {
   openOrShowDock,
   kernelSpecProvidesGrammar
 } from "./utils";
-
-import type Kernel from "./kernel";
 
 import exportNotebook from "./export-notebook";
 
@@ -324,9 +323,11 @@ const Hydrogen = {
       // Note that destroy alone does not shut down a WSKernel
       kernel.shutdown();
       kernel.destroy();
-    } else if (command === "rename-kernel" && kernel.promptRename) {
-      // $FlowFixMe Will only be called if remote kernel
-      if (kernel instanceof WSKernel) kernel.promptRename();
+    } else if (
+      command === "rename-kernel" &&
+      kernel.transport instanceof WSKernel
+    ) {
+      kernel.transport.promptRename();
     } else if (command === "disconnect-kernel") {
       store.markers.clear();
       kernel.destroy();
@@ -542,12 +543,13 @@ const Hydrogen = {
 
   connectToWSKernel() {
     if (!this.wsKernelPicker) {
-      this.wsKernelPicker = new WSKernelPicker((kernel: Kernel) => {
+      this.wsKernelPicker = new WSKernelPicker((transport: WSKernel) => {
+        const kernel = new Kernel(transport);
         store.markers.clear();
         const { editor, grammar, filePath } = store;
         if (!editor || !grammar || !filePath) return;
 
-        if (kernel instanceof ZMQKernel) kernel.destroy();
+        if (kernel.transport instanceof ZMQKernel) kernel.destroy();
 
         store.newKernel(kernel, filePath, editor, grammar);
       });

--- a/lib/plugin-api/hydrogen-kernel.js
+++ b/lib/plugin-api/hydrogen-kernel.js
@@ -1,56 +1,11 @@
 /* @flow */
 
 import type Kernel from "./../kernel";
-
-// We define all our own types here to isolate the plugin API from internal
-// implementation details of hydrogen.
-type HydrogenResultsCallback = (
-  message: any,
-  channel: "shell" | "iopub" | "stdin"
-) => void;
-
-interface HydrogenKernelMiddlewareStack {
-  interrupt: () => void;
-  shutdown: () => void;
-  restart: (onRestarted: ?Function) => void;
-  execute: (
-    code: string,
-    callWatches: boolean,
-    onResults: HydrogenResultsCallback
-  ) => void;
-  complete: (code: string, onResults: HydrogenResultsCallback) => void;
-  inspect: (
-    code: string,
-    cursorPos: number,
-    onResults: HydrogenResultsCallback
-  ) => void;
-}
-
-interface HydrogenKernelMiddleware {
-  interrupt?: (next: HydrogenKernelMiddlewareStack) => void;
-  shutdown?: (next: HydrogenKernelMiddlewareStack) => void;
-  restart?: (
-    next: HydrogenKernelMiddlewareStack,
-    onRestarted: ?Function
-  ) => void;
-  execute?: (
-    next: HydrogenKernelMiddlewareStack,
-    code: string,
-    callWatches: boolean,
-    onResults: HydrogenResultsCallback
-  ) => void;
-  complete?: (
-    next: HydrogenKernelMiddlewareStack,
-    code: string,
-    onResults: HydrogenResultsCallback
-  ) => void;
-  inspect?: (
-    next: HydrogenKernelMiddlewareStack,
-    code: string,
-    cursorPos: number,
-    onResults: HydrogenResultsCallback
-  ) => void;
-}
+import type {
+  HydrogenResultsCallback,
+  HydrogenKernelMiddlewareStack,
+  HydrogenKernelMiddleware
+} from "./hydrogen-types";
 
 /*
  * The `HydrogenKernel` class wraps Hydrogen's internal representation of kernels
@@ -105,46 +60,7 @@ export default class HydrogenKernel {
    */
   addMiddleware(middleware: HydrogenKernelMiddleware) {
     this._assertNotDestroyed();
-
-    const prevMiddlewareStack = this._kernel.middlewareStack;
-    const middlewareStack = Object.assign({}, prevMiddlewareStack);
-
-    // The middleware object we get as an argument may later be mutated to
-    // remove/replace some of its methods. The current plugin API is designed to
-    // ignore any such changes, which requires making a copy here. We use local
-    // variables instead of copying the entire object to make flow happy.
-    if (middleware.interrupt) {
-      const interrupt = middleware.interrupt.bind(middleware);
-      middlewareStack.interrupt = (...args) =>
-        interrupt(prevMiddlewareStack, ...args);
-    }
-    if (middleware.shutdown) {
-      const shutdown = middleware.shutdown.bind(middleware);
-      middlewareStack.shutdown = (...args) =>
-        shutdown(prevMiddlewareStack, ...args);
-    }
-    if (middleware.restart) {
-      const restart = middleware.restart.bind(middleware);
-      middlewareStack.restart = (...args) =>
-        restart(prevMiddlewareStack, ...args);
-    }
-    if (middleware.execute) {
-      const execute = middleware.execute.bind(middleware);
-      middlewareStack.execute = (...args) =>
-        execute(prevMiddlewareStack, ...args);
-    }
-    if (middleware.complete) {
-      const complete = middleware.complete.bind(middleware);
-      middlewareStack.complete = (...args) =>
-        complete(prevMiddlewareStack, ...args);
-    }
-    if (middleware.inspect) {
-      const inspect = middleware.inspect.bind(middleware);
-      middlewareStack.inspect = (...args) =>
-        inspect(prevMiddlewareStack, ...args);
-    }
-
-    this._kernel.setMiddlewareStack(middlewareStack);
+    this._kernel.addMiddleware(middleware);
   }
 
   /*

--- a/lib/plugin-api/hydrogen-kernel.js
+++ b/lib/plugin-api/hydrogen-kernel.js
@@ -1,7 +1,6 @@
 /* @flow */
 
 import type Kernel from "./../kernel";
-import type ZMQKernel from "./../zmq-kernel";
 
 // We define all our own types here to isolate the plugin API from internal
 // implementation details of hydrogen.
@@ -60,7 +59,7 @@ interface HydrogenKernelMiddleware {
  */
 
 export default class HydrogenKernel {
-  _kernel: Kernel | ZMQKernel;
+  _kernel: Kernel;
   destroyed: boolean;
 
   constructor(_kernel: Kernel) {
@@ -158,8 +157,8 @@ export default class HydrogenKernel {
   getConnectionFile() {
     this._assertNotDestroyed();
 
-    const connectionFile = this._kernel.connectionFile
-      ? this._kernel.connectionFile
+    const connectionFile = this._kernel.transport.connectionFile
+      ? this._kernel.transport.connectionFile
       : null;
     if (!connectionFile) {
       throw new Error(

--- a/lib/plugin-api/hydrogen-kernel.js
+++ b/lib/plugin-api/hydrogen-kernel.js
@@ -96,6 +96,12 @@ export default class HydrogenKernel {
   /*
    * Add a kernel middleware, which allows intercepting and issuing commands to
    * the kernel.
+   *
+   * All of the middleware object's methods are called with `this` set to the
+   * middleware object. Also note that adding or removing methods from the
+   * middleware object after this method has been called is not supported.
+   *
+   * @param {HydrogenKernelMiddleware} middleware
    */
   addMiddleware(middleware: HydrogenKernelMiddleware) {
     this._assertNotDestroyed();
@@ -108,32 +114,32 @@ export default class HydrogenKernel {
     // ignore any such changes, which requires making a copy here. We use local
     // variables instead of copying the entire object to make flow happy.
     if (middleware.interrupt) {
-      const interrupt = middleware.interrupt;
+      const interrupt = middleware.interrupt.bind(middleware);
       middlewareStack.interrupt = (...args) =>
         interrupt(prevMiddlewareStack, ...args);
     }
     if (middleware.shutdown) {
-      const shutdown = middleware.shutdown;
+      const shutdown = middleware.shutdown.bind(middleware);
       middlewareStack.shutdown = (...args) =>
         shutdown(prevMiddlewareStack, ...args);
     }
     if (middleware.restart) {
-      const restart = middleware.restart;
+      const restart = middleware.restart.bind(middleware);
       middlewareStack.restart = (...args) =>
         restart(prevMiddlewareStack, ...args);
     }
     if (middleware.execute) {
-      const execute = middleware.execute;
+      const execute = middleware.execute.bind(middleware);
       middlewareStack.execute = (...args) =>
         execute(prevMiddlewareStack, ...args);
     }
     if (middleware.complete) {
-      const complete = middleware.complete;
+      const complete = middleware.complete.bind(middleware);
       middlewareStack.complete = (...args) =>
         complete(prevMiddlewareStack, ...args);
     }
     if (middleware.inspect) {
-      const inspect = middleware.inspect;
+      const inspect = middleware.inspect.bind(middleware);
       middlewareStack.inspect = (...args) =>
         inspect(prevMiddlewareStack, ...args);
     }

--- a/lib/plugin-api/hydrogen-kernel.js
+++ b/lib/plugin-api/hydrogen-kernel.js
@@ -5,19 +5,26 @@ import type ZMQKernel from "./../zmq-kernel";
 
 // We define all our own types here to isolate the plugin API from internal
 // implementation details of hydrogen.
-// XXX(nikita): figure out what to do about onResults. The type definition of
-// onResults is a wierd hybrid of elements of the Jupyter messaging spec and
-// custom hydrogen stuff. It's not a good idea to have plugins relying on
-// hydrogen-specific details of `onResults` that can go away in future versions,
-// and we also need to consider what happens when the jupyter protocol specs get
-// updated
+type HydrogenResultsCallback = (
+  message: any,
+  channel: "shell" | "iopub" | "stdin"
+) => void;
+
 interface HydrogenKernelMiddlewareStack {
   interrupt: () => void;
   shutdown: () => void;
   restart: (onRestarted: ?Function) => void;
-  execute: (code: string, callWatches: boolean, onResults: Function) => void;
-  complete: (code: string, onResults: Function) => void;
-  inspect: (code: string, cursorPos: number, onResults: Function) => void;
+  execute: (
+    code: string,
+    callWatches: boolean,
+    onResults: HydrogenResultsCallback
+  ) => void;
+  complete: (code: string, onResults: HydrogenResultsCallback) => void;
+  inspect: (
+    code: string,
+    cursorPos: number,
+    onResults: HydrogenResultsCallback
+  ) => void;
 }
 
 interface HydrogenKernelMiddleware {
@@ -31,18 +38,18 @@ interface HydrogenKernelMiddleware {
     next: HydrogenKernelMiddlewareStack,
     code: string,
     callWatches: boolean,
-    onResults: Function
+    onResults: HydrogenResultsCallback
   ) => void;
   complete?: (
     next: HydrogenKernelMiddlewareStack,
     code: string,
-    onResults: Function
+    onResults: HydrogenResultsCallback
   ) => void;
   inspect?: (
     next: HydrogenKernelMiddlewareStack,
     code: string,
     cursorPos: number,
-    onResults: Function
+    onResults: HydrogenResultsCallback
   ) => void;
 }
 

--- a/lib/plugin-api/hydrogen-kernel.js
+++ b/lib/plugin-api/hydrogen-kernel.js
@@ -1,11 +1,7 @@
 /* @flow */
 
 import type Kernel from "./../kernel";
-import type {
-  HydrogenResultsCallback,
-  HydrogenKernelMiddlewareStack,
-  HydrogenKernelMiddleware
-} from "./hydrogen-types";
+import type { HydrogenKernelMiddleware } from "./hydrogen-types";
 
 /*
  * The `HydrogenKernel` class wraps Hydrogen's internal representation of kernels
@@ -52,9 +48,8 @@ export default class HydrogenKernel {
    * Add a kernel middleware, which allows intercepting and issuing commands to
    * the kernel.
    *
-   * All of the middleware object's methods are called with `this` set to the
-   * middleware object. Also note that adding or removing methods from the
-   * middleware object after this method has been called is not supported.
+   * If the methods of a `middleware` object are added/modified/deleted after
+   * `addMiddleware` has been called, the changes will take effect immediately.
    *
    * @param {HydrogenKernelMiddleware} middleware
    */

--- a/lib/plugin-api/hydrogen-kernel.js
+++ b/lib/plugin-api/hydrogen-kernel.js
@@ -2,6 +2,50 @@
 
 import type Kernel from "./../kernel";
 import type ZMQKernel from "./../zmq-kernel";
+
+// We define all our own types here to isolate the plugin API from internal
+// implementation details of hydrogen.
+// XXX(nikita): figure out what to do about onResults. The type definition of
+// onResults is a wierd hybrid of elements of the Jupyter messaging spec and
+// custom hydrogen stuff. It's not a good idea to have plugins relying on
+// hydrogen-specific details of `onResults` that can go away in future versions,
+// and we also need to consider what happens when the jupyter protocol specs get
+// updated
+interface HydrogenKernelMiddlewareStack {
+  interrupt: () => void;
+  shutdown: () => void;
+  restart: (onRestarted: ?Function) => void;
+  execute: (code: string, callWatches: boolean, onResults: Function) => void;
+  complete: (code: string, onResults: Function) => void;
+  inspect: (code: string, cursorPos: number, onResults: Function) => void;
+}
+
+interface HydrogenKernelMiddleware {
+  interrupt?: (next: HydrogenKernelMiddlewareStack) => void;
+  shutdown?: (next: HydrogenKernelMiddlewareStack) => void;
+  restart?: (
+    next: HydrogenKernelMiddlewareStack,
+    onRestarted: ?Function
+  ) => void;
+  execute?: (
+    next: HydrogenKernelMiddlewareStack,
+    code: string,
+    callWatches: boolean,
+    onResults: Function
+  ) => void;
+  complete?: (
+    next: HydrogenKernelMiddlewareStack,
+    code: string,
+    onResults: Function
+  ) => void;
+  inspect?: (
+    next: HydrogenKernelMiddlewareStack,
+    code: string,
+    cursorPos: number,
+    onResults: Function
+  ) => void;
+}
+
 /*
  * The `HydrogenKernel` class wraps Hydrogen's internal representation of kernels
  * and exposes a small set of methods that should be usable by plugins.
@@ -25,6 +69,70 @@ export default class HydrogenKernel {
         "HydrogenKernel: operation not allowed because the kernel has been destroyed"
       );
     }
+  }
+
+  /*
+   * The language of the kernel, as specified in its kernelspec
+   */
+  get language(): string {
+    this._assertNotDestroyed();
+    return this._kernel.language;
+  }
+
+  /*
+   * The display name of the kernel, as specified in its kernelspec
+   */
+  get displayName(): string {
+    this._assertNotDestroyed();
+    return this._kernel.displayName;
+  }
+
+  /*
+   * Add a kernel middleware, which allows intercepting and issuing commands to
+   * the kernel.
+   */
+  addMiddleware(middleware: HydrogenKernelMiddleware) {
+    this._assertNotDestroyed();
+
+    const prevMiddlewareStack = this._kernel.middlewareStack;
+    const middlewareStack = Object.assign({}, prevMiddlewareStack);
+
+    // The middleware object we get as an argument may later be mutated to
+    // remove/replace some of its methods. The current plugin API is designed to
+    // ignore any such changes, which requires making a copy here. We use local
+    // variables instead of copying the entire object to make flow happy.
+    if (middleware.interrupt) {
+      const interrupt = middleware.interrupt;
+      middlewareStack.interrupt = (...args) =>
+        interrupt(prevMiddlewareStack, ...args);
+    }
+    if (middleware.shutdown) {
+      const shutdown = middleware.shutdown;
+      middlewareStack.shutdown = (...args) =>
+        shutdown(prevMiddlewareStack, ...args);
+    }
+    if (middleware.restart) {
+      const restart = middleware.restart;
+      middlewareStack.restart = (...args) =>
+        restart(prevMiddlewareStack, ...args);
+    }
+    if (middleware.execute) {
+      const execute = middleware.execute;
+      middlewareStack.execute = (...args) =>
+        execute(prevMiddlewareStack, ...args);
+    }
+    if (middleware.complete) {
+      const complete = middleware.complete;
+      middlewareStack.complete = (...args) =>
+        complete(prevMiddlewareStack, ...args);
+    }
+    if (middleware.inspect) {
+      const inspect = middleware.inspect;
+      middlewareStack.inspect = (...args) =>
+        inspect(prevMiddlewareStack, ...args);
+    }
+
+    this._kernel.setMiddlewareStack(middlewareStack);
   }
 
   /*

--- a/lib/plugin-api/hydrogen-provider.js
+++ b/lib/plugin-api/hydrogen-provider.js
@@ -20,11 +20,9 @@ import { getCurrentCell } from "./../code-manager";
  */
 export default class HydrogenProvider {
   _hydrogen: any;
-  _happy: boolean;
 
   constructor(_hydrogen: any) {
     this._hydrogen = _hydrogen;
-    this._happy = true;
   }
 
   /*

--- a/lib/plugin-api/hydrogen-types.js
+++ b/lib/plugin-api/hydrogen-types.js
@@ -9,7 +9,11 @@ export type HydrogenResultsCallback = (
   channel: "shell" | "iopub" | "stdin"
 ) => void;
 
-export interface HydrogenKernelMiddlewareStack {
+// Like HydrogenKernelMiddleware, but doesn't require passing a `next` argument.
+// Hydrogen is responsible for creating these and ensuring that they delegate to
+// the next middleware in the chain (or to the kernel, if there is no more
+// middleware to call)
+export interface HydrogenKernelMiddlewareThunk {
   +interrupt: () => void;
   +shutdown: () => void;
   +restart: (onRestarted: ?Function) => void;
@@ -27,25 +31,25 @@ export interface HydrogenKernelMiddlewareStack {
 }
 
 export interface HydrogenKernelMiddleware {
-  +interrupt?: (next: HydrogenKernelMiddlewareStack) => void;
-  +shutdown?: (next: HydrogenKernelMiddlewareStack) => void;
+  +interrupt?: (next: HydrogenKernelMiddlewareThunk) => void;
+  +shutdown?: (next: HydrogenKernelMiddlewareThunk) => void;
   +restart?: (
-    next: HydrogenKernelMiddlewareStack,
+    next: HydrogenKernelMiddlewareThunk,
     onRestarted: ?Function
   ) => void;
   +execute?: (
-    next: HydrogenKernelMiddlewareStack,
+    next: HydrogenKernelMiddlewareThunk,
     code: string,
     callWatches: boolean,
     onResults: HydrogenResultsCallback
   ) => void;
   +complete?: (
-    next: HydrogenKernelMiddlewareStack,
+    next: HydrogenKernelMiddlewareThunk,
     code: string,
     onResults: HydrogenResultsCallback
   ) => void;
   +inspect?: (
-    next: HydrogenKernelMiddlewareStack,
+    next: HydrogenKernelMiddlewareThunk,
     code: string,
     cursorPos: number,
     onResults: HydrogenResultsCallback

--- a/lib/plugin-api/hydrogen-types.js
+++ b/lib/plugin-api/hydrogen-types.js
@@ -17,11 +17,7 @@ export interface HydrogenKernelMiddlewareThunk {
   +interrupt: () => void;
   +shutdown: () => void;
   +restart: (onRestarted: ?Function) => void;
-  +execute: (
-    code: string,
-    callWatches: boolean,
-    onResults: HydrogenResultsCallback
-  ) => void;
+  +execute: (code: string, onResults: HydrogenResultsCallback) => void;
   +complete: (code: string, onResults: HydrogenResultsCallback) => void;
   +inspect: (
     code: string,
@@ -40,7 +36,6 @@ export interface HydrogenKernelMiddleware {
   +execute?: (
     next: HydrogenKernelMiddlewareThunk,
     code: string,
-    callWatches: boolean,
     onResults: HydrogenResultsCallback
   ) => void;
   +complete?: (

--- a/lib/plugin-api/hydrogen-types.js
+++ b/lib/plugin-api/hydrogen-types.js
@@ -1,0 +1,53 @@
+/* @flow */
+// These type definitions live in their own file because Atom can't parse the
+// syntax used here. Note that these types do not depend on anything internal
+// to Hydrogen, which should allow the typechecker to notice if any internal
+// changes are not accompanied by appropriate compatibility changes to the
+// plugin wrappers.
+export type HydrogenResultsCallback = (
+  message: any,
+  channel: "shell" | "iopub" | "stdin"
+) => void;
+
+export interface HydrogenKernelMiddlewareStack {
+  +interrupt: () => void;
+  +shutdown: () => void;
+  +restart: (onRestarted: ?Function) => void;
+  +execute: (
+    code: string,
+    callWatches: boolean,
+    onResults: HydrogenResultsCallback
+  ) => void;
+  +complete: (code: string, onResults: HydrogenResultsCallback) => void;
+  +inspect: (
+    code: string,
+    cursorPos: number,
+    onResults: HydrogenResultsCallback
+  ) => void;
+}
+
+export interface HydrogenKernelMiddleware {
+  +interrupt?: (next: HydrogenKernelMiddlewareStack) => void;
+  +shutdown?: (next: HydrogenKernelMiddlewareStack) => void;
+  +restart?: (
+    next: HydrogenKernelMiddlewareStack,
+    onRestarted: ?Function
+  ) => void;
+  +execute?: (
+    next: HydrogenKernelMiddlewareStack,
+    code: string,
+    callWatches: boolean,
+    onResults: HydrogenResultsCallback
+  ) => void;
+  +complete?: (
+    next: HydrogenKernelMiddlewareStack,
+    code: string,
+    onResults: HydrogenResultsCallback
+  ) => void;
+  +inspect?: (
+    next: HydrogenKernelMiddlewareStack,
+    code: string,
+    cursorPos: number,
+    onResults: HydrogenResultsCallback
+  ) => void;
+}

--- a/lib/signal-list-view.js
+++ b/lib/signal-list-view.js
@@ -53,7 +53,7 @@ export default class SignalListView {
     const kernel = store.kernel;
     if (!kernel) return;
     const commands =
-      kernel instanceof WSKernel
+      kernel.transport instanceof WSKernel
         ? [...basicCommands, ...wsKernelCommands]
         : basicCommands;
 

--- a/lib/ws-kernel.js
+++ b/lib/ws-kernel.js
@@ -1,13 +1,13 @@
 /* @flow */
 
-import Kernel from "./kernel";
-import type { ResultsCallback } from "./kernel";
+import KernelTransport from "./kernel-transport";
+import type { ResultsCallback } from "./kernel-transport";
 import InputView from "./input-view";
 import { log } from "./utils";
 
 import type { Session } from "@jupyterlab/services";
 
-export default class WSKernel extends Kernel {
+export default class WSKernel extends KernelTransport {
   session: Session;
   gatewayName: string;
 
@@ -27,22 +27,22 @@ export default class WSKernel extends Kernel {
     this.setExecutionState(this.session.status); // Set initial status correctly
   }
 
-  rawInterrupt() {
+  interrupt() {
     this.session.kernel.interrupt();
   }
 
-  rawShutdown() {
+  shutdown() {
     this.session.kernel.shutdown();
   }
 
-  rawRestart(onRestarted: ?Function) {
+  restart(onRestarted: ?Function) {
     const future = this.session.kernel.restart();
     future.then(() => {
-      if (onRestarted) onRestarted(this.session.kernel);
+      if (onRestarted) onRestarted();
     });
   }
 
-  rawExecute(code: string, callWatches: boolean, onResults: ResultsCallback) {
+  execute(code: string, callWatches: boolean, onResults: ResultsCallback) {
     const future = this.session.kernel.requestExecute({ code });
 
     future.onIOPub = (message: Message) => {
@@ -54,7 +54,7 @@ export default class WSKernel extends Kernel {
         this._callWatchCallbacks();
       }
 
-      log("WSKernel: rawExecute:", message);
+      log("WSKernel: execute:", message);
       onResults(message, "iopub");
     };
 
@@ -62,7 +62,7 @@ export default class WSKernel extends Kernel {
     future.onStdin = (message: Message) => onResults(message, "stdin");
   }
 
-  rawComplete(code: string, onResults: ResultsCallback) {
+  complete(code: string, onResults: ResultsCallback) {
     this.session.kernel
       .requestComplete({
         code,
@@ -71,7 +71,7 @@ export default class WSKernel extends Kernel {
       .then((message: Message) => onResults(message, "shell"));
   }
 
-  rawInspect(code: string, cursorPos: number, onResults: ResultsCallback) {
+  inspect(code: string, cursorPos: number, onResults: ResultsCallback) {
     this.session.kernel
       .requestInspect({
         code,
@@ -81,7 +81,7 @@ export default class WSKernel extends Kernel {
       .then((message: Message) => onResults(message, "shell"));
   }
 
-  rawInputReply(input: string) {
+  inputReply(input: string) {
     this.session.kernel.sendInputReply({ value: input });
   }
 

--- a/lib/ws-kernel.js
+++ b/lib/ws-kernel.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import Kernel from "./kernel";
+import type { ResultsCallback } from "./kernel";
 import InputView from "./input-view";
 import { log } from "./utils";
 
@@ -41,7 +42,7 @@ export default class WSKernel extends Kernel {
     });
   }
 
-  rawExecute(code: string, callWatches: boolean, onResults: Function) {
+  rawExecute(code: string, callWatches: boolean, onResults: ResultsCallback) {
     const future = this.session.kernel.requestExecute({ code });
 
     future.onIOPub = (message: Message) => {
@@ -53,58 +54,35 @@ export default class WSKernel extends Kernel {
         this._callWatchCallbacks();
       }
 
-      if (onResults) {
-        log("WSKernel: rawExecute:", message);
-        const result = this._parseIOMessage(message);
-        if (result) onResults(result);
-      }
+      log("WSKernel: rawExecute:", message);
+      onResults(message, "iopub");
     };
 
-    future.onReply = (message: Message) => {
-      const result = {
-        data: message.content.status,
-        stream: "status"
-      };
-      if (onResults) onResults(result);
-    };
-
-    future.onStdin = (message: Message) => {
-      if (message.header.msg_type !== "input_request") {
-        return;
-      }
-
-      const { prompt } = message.content;
-
-      const inputView = new InputView({ prompt }, (input: string) =>
-        this.session.kernel.sendInputReply({ value: input })
-      );
-
-      inputView.attach();
-    };
+    future.onReply = (message: Message) => onResults(message, "shell");
+    future.onStdin = (message: Message) => onResults(message, "stdin");
   }
 
-  rawComplete(code: string, onResults: Function) {
+  rawComplete(code: string, onResults: ResultsCallback) {
     this.session.kernel
       .requestComplete({
         code,
         cursor_pos: code.length
       })
-      .then((message: Message) => onResults(message.content));
+      .then((message: Message) => onResults(message, "shell"));
   }
 
-  rawInspect(code: string, cursorPos: number, onResults: Function) {
+  rawInspect(code: string, cursorPos: number, onResults: ResultsCallback) {
     this.session.kernel
       .requestInspect({
         code,
         cursor_pos: cursorPos,
         detail_level: 0
       })
-      .then((message: Message) =>
-        onResults({
-          data: message.content.data,
-          found: message.content.found
-        })
-      );
+      .then((message: Message) => onResults(message, "shell"));
+  }
+
+  rawInputReply(input: string) {
+    this.session.kernel.sendInputReply({ value: input });
   }
 
   promptRename() {

--- a/lib/ws-kernel.js
+++ b/lib/ws-kernel.js
@@ -26,22 +26,22 @@ export default class WSKernel extends Kernel {
     this.setExecutionState(this.session.status); // Set initial status correctly
   }
 
-  interrupt() {
-    return this.session.kernel.interrupt();
+  rawInterrupt() {
+    this.session.kernel.interrupt();
   }
 
-  shutdown() {
-    return this.session.kernel.shutdown();
+  rawShutdown() {
+    this.session.kernel.shutdown();
   }
 
-  restart(onRestarted: ?Function) {
+  rawRestart(onRestarted: ?Function) {
     const future = this.session.kernel.restart();
     future.then(() => {
       if (onRestarted) onRestarted(this.session.kernel);
     });
   }
 
-  _execute(code: string, callWatches: boolean, onResults: Function) {
+  rawExecute(code: string, callWatches: boolean, onResults: Function) {
     const future = this.session.kernel.requestExecute({ code });
 
     future.onIOPub = (message: Message) => {
@@ -54,7 +54,7 @@ export default class WSKernel extends Kernel {
       }
 
       if (onResults) {
-        log("WSKernel: _execute:", message);
+        log("WSKernel: rawExecute:", message);
         const result = this._parseIOMessage(message);
         if (result) onResults(result);
       }
@@ -83,15 +83,7 @@ export default class WSKernel extends Kernel {
     };
   }
 
-  execute(code: string, onResults: Function) {
-    this._execute(code, true, onResults);
-  }
-
-  executeWatch(code: string, onResults: Function) {
-    this._execute(code, false, onResults);
-  }
-
-  complete(code: string, onResults: Function) {
+  rawComplete(code: string, onResults: Function) {
     this.session.kernel
       .requestComplete({
         code,
@@ -100,7 +92,7 @@ export default class WSKernel extends Kernel {
       .then((message: Message) => onResults(message.content));
   }
 
-  inspect(code: string, cursorPos: number, onResults: Function) {
+  rawInspect(code: string, cursorPos: number, onResults: Function) {
     this.session.kernel
       .requestInspect({
         code,

--- a/lib/ws-kernel.js
+++ b/lib/ws-kernel.js
@@ -42,18 +42,10 @@ export default class WSKernel extends KernelTransport {
     });
   }
 
-  execute(code: string, callWatches: boolean, onResults: ResultsCallback) {
+  execute(code: string, onResults: ResultsCallback) {
     const future = this.session.kernel.requestExecute({ code });
 
     future.onIOPub = (message: Message) => {
-      if (
-        callWatches &&
-        message.header.msg_type === "status" &&
-        message.content.execution_state === "idle"
-      ) {
-        this._callWatchCallbacks();
-      }
-
       log("WSKernel: execute:", message);
       onResults(message, "iopub");
     };

--- a/lib/zmq-kernel.js
+++ b/lib/zmq-kernel.js
@@ -279,7 +279,7 @@ export default class ZMQKernel extends KernelTransport {
   onShellMessage(message: Message) {
     log("shell message:", message);
 
-    if (!this.isValidMessage(message)) {
+    if (!this._isValidMessage(message)) {
       return;
     }
 
@@ -297,7 +297,7 @@ export default class ZMQKernel extends KernelTransport {
   onStdinMessage(message: Message) {
     log("stdin message:", message);
 
-    if (!this.isValidMessage(message)) {
+    if (!this._isValidMessage(message)) {
       return;
     }
 
@@ -337,7 +337,7 @@ export default class ZMQKernel extends KernelTransport {
   onIOMessage(message: Message) {
     log("IO message:", message);
 
-    if (!this.isValidMessage(message)) {
+    if (!this._isValidMessage(message)) {
       return;
     }
 
@@ -365,6 +365,56 @@ export default class ZMQKernel extends KernelTransport {
     if (callback) {
       callback(message, "iopub");
     }
+  }
+
+  _isValidMessage(message: Message) {
+    if (!message) {
+      log("Invalid message: null");
+      return false;
+    }
+
+    if (!message.content) {
+      log("Invalid message: Missing content");
+      return false;
+    }
+
+    if (message.content.execution_state === "starting") {
+      // Kernels send a starting status message with an empty parent_header
+      log("Dropped starting status IO message");
+      return false;
+    }
+
+    if (!message.parent_header) {
+      log("Invalid message: Missing parent_header");
+      return false;
+    }
+
+    if (!message.parent_header.msg_id) {
+      log("Invalid message: Missing parent_header.msg_id");
+      return false;
+    }
+
+    if (!message.parent_header.msg_type) {
+      log("Invalid message: Missing parent_header.msg_type");
+      return false;
+    }
+
+    if (!message.header) {
+      log("Invalid message: Missing header");
+      return false;
+    }
+
+    if (!message.header.msg_id) {
+      log("Invalid message: Missing header.msg_id");
+      return false;
+    }
+
+    if (!message.header.msg_type) {
+      log("Invalid message: Missing header.msg_type");
+      return false;
+    }
+
+    return true;
   }
 
   destroy() {

--- a/lib/zmq-kernel.js
+++ b/lib/zmq-kernel.js
@@ -6,8 +6,8 @@ import v4 from "uuid/v4";
 import { launchSpec, launchSpecFromConnectionInfo } from "spawnteract";
 
 import Config from "./config";
-import Kernel from "./kernel";
-import type { ResultsCallback } from "./kernel";
+import KernelTransport from "./kernel-transport";
+import type { ResultsCallback } from "./kernel-transport";
 import InputView from "./input-view";
 import { log } from "./utils";
 
@@ -24,7 +24,7 @@ export type Connection = {
   version: number
 };
 
-export default class ZMQKernel extends Kernel {
+export default class ZMQKernel extends KernelTransport {
   executionCallbacks: Object = {};
   connection: Connection;
   connectionFile: string;
@@ -145,7 +145,7 @@ export default class ZMQKernel extends Kernel {
     }
   }
 
-  rawInterrupt() {
+  interrupt() {
     if (process.platform === "win32") {
       atom.notifications.addWarning("Cannot interrupt this kernel", {
         detail: "Kernel interruption is currently not supported in Windows."
@@ -167,15 +167,15 @@ export default class ZMQKernel extends Kernel {
     if (startupCode) {
       log("KernelManager: Executing startup code:", startupCode);
       startupCode = `${startupCode} \n`;
-      this.rawExecute(startupCode, false, (message, channel) => {});
+      this.execute(startupCode, false, (message, channel) => {});
     }
   }
 
-  rawShutdown() {
+  shutdown() {
     this._socketShutdown();
   }
 
-  rawRestart(onRestarted: ?Function) {
+  restart(onRestarted: ?Function) {
     this._socketRestart(onRestarted);
   }
 
@@ -203,14 +203,14 @@ export default class ZMQKernel extends Kernel {
     );
     this.kernelProcess = spawn;
     this.monitor(() => {
-      if (onRestarted) onRestarted(this);
+      if (onRestarted) onRestarted();
     });
   }
 
   // onResults is a callback that may be called multiple times
   // as results come in from the kernel
-  rawExecute(code: string, callWatches: boolean, onResults: ResultsCallback) {
-    log("ZMQKernel.rawExecute:", code, callWatches);
+  execute(code: string, callWatches: boolean, onResults: ResultsCallback) {
+    log("ZMQKernel.execute:", code, callWatches);
     // requestId starting with "execute_" will trigger watches being called
     const requestId = callWatches ? `execute_${v4()}` : `watch_${v4()}`;
 
@@ -229,8 +229,8 @@ export default class ZMQKernel extends Kernel {
     this.shellSocket.send(new Message(message));
   }
 
-  rawComplete(code: string, onResults: ResultsCallback) {
-    log("ZMQKernel.rawComplete:", code);
+  complete(code: string, onResults: ResultsCallback) {
+    log("ZMQKernel.complete:", code);
 
     const requestId = `complete_${v4()}`;
 
@@ -248,8 +248,8 @@ export default class ZMQKernel extends Kernel {
     this.shellSocket.send(new Message(message));
   }
 
-  rawInspect(code: string, cursorPos: number, onResults: ResultsCallback) {
-    log("ZMQKernel.rawInspect:", code, cursorPos);
+  inspect(code: string, cursorPos: number, onResults: ResultsCallback) {
+    log("ZMQKernel.inspect:", code, cursorPos);
 
     const requestId = `inspect_${v4()}`;
 
@@ -266,7 +266,7 @@ export default class ZMQKernel extends Kernel {
     this.shellSocket.send(new Message(message));
   }
 
-  rawInputReply(input: string) {
+  inputReply(input: string) {
     const requestId = `input_reply_${v4()}`;
 
     const message = this._createMessage("input_reply", requestId);
@@ -326,7 +326,7 @@ export default class ZMQKernel extends Kernel {
         const { prompt } = message.content;
 
         const inputView = new InputView({ prompt }, (input: string) =>
-          this.rawInputReply(input)
+          this.inputReply(input)
         );
 
         inputView.attach();

--- a/lib/zmq-kernel.js
+++ b/lib/zmq-kernel.js
@@ -7,6 +7,7 @@ import { launchSpec, launchSpecFromConnectionInfo } from "spawnteract";
 
 import Config from "./config";
 import Kernel from "./kernel";
+import type { ResultsCallback } from "./kernel";
 import InputView from "./input-view";
 import { log } from "./utils";
 
@@ -166,7 +167,7 @@ export default class ZMQKernel extends Kernel {
     if (startupCode) {
       log("KernelManager: Executing startup code:", startupCode);
       startupCode = `${startupCode} \n`;
-      this.rawExecute(startupCode, false);
+      this.rawExecute(startupCode, false, (message, channel) => {});
     }
   }
 
@@ -208,7 +209,7 @@ export default class ZMQKernel extends Kernel {
 
   // onResults is a callback that may be called multiple times
   // as results come in from the kernel
-  rawExecute(code: string, callWatches: boolean, onResults: ?Function) {
+  rawExecute(code: string, callWatches: boolean, onResults: ResultsCallback) {
     log("ZMQKernel.rawExecute:", code, callWatches);
     // requestId starting with "execute_" will trigger watches being called
     const requestId = callWatches ? `execute_${v4()}` : `watch_${v4()}`;
@@ -228,7 +229,7 @@ export default class ZMQKernel extends Kernel {
     this.shellSocket.send(new Message(message));
   }
 
-  rawComplete(code: string, onResults: Function) {
+  rawComplete(code: string, onResults: ResultsCallback) {
     log("ZMQKernel.rawComplete:", code);
 
     const requestId = `complete_${v4()}`;
@@ -247,7 +248,7 @@ export default class ZMQKernel extends Kernel {
     this.shellSocket.send(new Message(message));
   }
 
-  rawInspect(code: string, cursorPos: number, onResults: Function) {
+  rawInspect(code: string, cursorPos: number, onResults: ResultsCallback) {
     log("ZMQKernel.rawInspect:", code, cursorPos);
 
     const requestId = `inspect_${v4()}`;
@@ -265,7 +266,7 @@ export default class ZMQKernel extends Kernel {
     this.shellSocket.send(new Message(message));
   }
 
-  inputReply(input: string) {
+  rawInputReply(input: string) {
     const requestId = `input_reply_${v4()}`;
 
     const message = this._createMessage("input_reply", requestId);
@@ -288,37 +289,8 @@ export default class ZMQKernel extends Kernel {
       callback = this.executionCallbacks[msg_id];
     }
 
-    if (!callback) {
-      return;
-    }
-
-    const { status } = message.content;
-    if (status === "error") {
-      callback({
-        data: "error",
-        stream: "status"
-      });
-    } else if (status === "ok") {
-      const { msg_type } = message.header;
-
-      if (msg_type === "execution_reply") {
-        callback({
-          data: "ok",
-          stream: "status"
-        });
-      } else if (msg_type === "complete_reply") {
-        callback(message.content);
-      } else if (msg_type === "inspect_reply") {
-        callback({
-          data: message.content.data,
-          found: message.content.found
-        });
-      } else {
-        callback({
-          data: "ok",
-          stream: "status"
-        });
-      }
+    if (callback) {
+      callback(message, "shell");
     }
   }
 
@@ -329,16 +301,36 @@ export default class ZMQKernel extends Kernel {
       return;
     }
 
-    const { msg_type } = message.header;
+    // input_request messages are attributable to particular execution requests,
+    // and should pass through the middleware stack to allow plugins to see them
+    const { msg_id } = message.parent_header;
+    let callback;
+    if (msg_id) {
+      callback = this.executionCallbacks[msg_id];
+    }
 
-    if (msg_type === "input_request") {
-      const { prompt } = message.content;
+    if (callback) {
+      callback(message, "stdin");
+    } else {
+      // This branch of code should technically never run, but we keep it just
+      // in case there are some edge cases where input requests do not specify
+      // a parent execute_request message. If the warnings logged here are never
+      // observed, it may be safe to remove this code.
+      const { msg_type } = message.header;
 
-      const inputView = new InputView({ prompt }, (input: string) =>
-        this.inputReply(input)
-      );
+      if (msg_type === "input_request") {
+        log(
+          "ZMQKernel: Got input_request that could not be matched with an execute_request"
+        );
+        log(message);
+        const { prompt } = message.content;
 
-      inputView.attach();
+        const inputView = new InputView({ prompt }, (input: string) =>
+          this.rawInputReply(input)
+        );
+
+        inputView.attach();
+      }
     }
   }
 
@@ -370,65 +362,9 @@ export default class ZMQKernel extends Kernel {
       callback = this.executionCallbacks[msg_id];
     }
 
-    if (!callback) {
-      return;
+    if (callback) {
+      callback(message, "iopub");
     }
-
-    const result = this._parseIOMessage(message);
-
-    if (result) {
-      callback(result);
-    }
-  }
-
-  _isValidMessage(message: Message) {
-    if (!message) {
-      log("Invalid message: null");
-      return false;
-    }
-
-    if (!message.content) {
-      log("Invalid message: Missing content");
-      return false;
-    }
-
-    if (message.content.execution_state === "starting") {
-      // Kernels send a starting status message with an empty parent_header
-      log("Dropped starting status IO message");
-      return false;
-    }
-
-    if (!message.parent_header) {
-      log("Invalid message: Missing parent_header");
-      return false;
-    }
-
-    if (!message.parent_header.msg_id) {
-      log("Invalid message: Missing parent_header.msg_id");
-      return false;
-    }
-
-    if (!message.parent_header.msg_type) {
-      log("Invalid message: Missing parent_header.msg_type");
-      return false;
-    }
-
-    if (!message.header) {
-      log("Invalid message: Missing header");
-      return false;
-    }
-
-    if (!message.header.msg_id) {
-      log("Invalid message: Missing header.msg_id");
-      return false;
-    }
-
-    if (!message.header.msg_type) {
-      log("Invalid message: Missing header.msg_type");
-      return false;
-    }
-
-    return true;
   }
 
   destroy() {

--- a/lib/zmq-kernel.js
+++ b/lib/zmq-kernel.js
@@ -167,7 +167,7 @@ export default class ZMQKernel extends KernelTransport {
     if (startupCode) {
       log("KernelManager: Executing startup code:", startupCode);
       startupCode = `${startupCode} \n`;
-      this.execute(startupCode, false, (message, channel) => {});
+      this.execute(startupCode, (message, channel) => {});
     }
   }
 
@@ -209,10 +209,9 @@ export default class ZMQKernel extends KernelTransport {
 
   // onResults is a callback that may be called multiple times
   // as results come in from the kernel
-  execute(code: string, callWatches: boolean, onResults: ResultsCallback) {
-    log("ZMQKernel.execute:", code, callWatches);
-    // requestId starting with "execute_" will trigger watches being called
-    const requestId = callWatches ? `execute_${v4()}` : `watch_${v4()}`;
+  execute(code: string, onResults: ResultsCallback) {
+    log("ZMQKernel.execute:", code);
+    const requestId = `execute_${v4()}`;
 
     const message = this._createMessage("execute_request", requestId);
 
@@ -346,14 +345,6 @@ export default class ZMQKernel extends KernelTransport {
     if (msg_type === "status") {
       const status = message.content.execution_state;
       this.setExecutionState(status);
-
-      const msg_id = message.parent_header
-        ? message.parent_header.msg_id
-        : null;
-      if (msg_id && status === "idle" && msg_id.startsWith("execute")) {
-        this._callWatchCallbacks();
-      }
-      return;
     }
 
     const { msg_id } = message.parent_header;

--- a/lib/zmq-kernel.js
+++ b/lib/zmq-kernel.js
@@ -279,7 +279,7 @@ export default class ZMQKernel extends KernelTransport {
   onShellMessage(message: Message) {
     log("shell message:", message);
 
-    if (!this._isValidMessage(message)) {
+    if (!this.isValidMessage(message)) {
       return;
     }
 
@@ -297,7 +297,7 @@ export default class ZMQKernel extends KernelTransport {
   onStdinMessage(message: Message) {
     log("stdin message:", message);
 
-    if (!this._isValidMessage(message)) {
+    if (!this.isValidMessage(message)) {
       return;
     }
 
@@ -337,7 +337,7 @@ export default class ZMQKernel extends KernelTransport {
   onIOMessage(message: Message) {
     log("IO message:", message);
 
-    if (!this._isValidMessage(message)) {
+    if (!this.isValidMessage(message)) {
       return;
     }
 

--- a/lib/zmq-kernel.js
+++ b/lib/zmq-kernel.js
@@ -8,7 +8,6 @@ import { launchSpec, launchSpecFromConnectionInfo } from "spawnteract";
 import Config from "./config";
 import KernelTransport from "./kernel-transport";
 import type { ResultsCallback } from "./kernel-transport";
-import InputView from "./input-view";
 import { log } from "./utils";
 
 export type Connection = {
@@ -310,26 +309,6 @@ export default class ZMQKernel extends KernelTransport {
 
     if (callback) {
       callback(message, "stdin");
-    } else {
-      // This branch of code should technically never run, but we keep it just
-      // in case there are some edge cases where input requests do not specify
-      // a parent execute_request message. If the warnings logged here are never
-      // observed, it may be safe to remove this code.
-      const { msg_type } = message.header;
-
-      if (msg_type === "input_request") {
-        log(
-          "ZMQKernel: Got input_request that could not be matched with an execute_request"
-        );
-        log(message);
-        const { prompt } = message.content;
-
-        const inputView = new InputView({ prompt }, (input: string) =>
-          this.inputReply(input)
-        );
-
-        inputView.attach();
-      }
     }
   }
 

--- a/lib/zmq-kernel.js
+++ b/lib/zmq-kernel.js
@@ -144,7 +144,7 @@ export default class ZMQKernel extends Kernel {
     }
   }
 
-  interrupt() {
+  rawInterrupt() {
     if (process.platform === "win32") {
       atom.notifications.addWarning("Cannot interrupt this kernel", {
         detail: "Kernel interruption is currently not supported in Windows."
@@ -166,11 +166,19 @@ export default class ZMQKernel extends Kernel {
     if (startupCode) {
       log("KernelManager: Executing startup code:", startupCode);
       startupCode = `${startupCode} \n`;
-      this.execute(startupCode);
+      this.rawExecute(startupCode, false);
     }
   }
 
-  shutdown(restart: ?boolean = false) {
+  rawShutdown() {
+    this._socketShutdown();
+  }
+
+  rawRestart(onRestarted: ?Function) {
+    this._socketRestart(onRestarted);
+  }
+
+  _socketShutdown(restart: ?boolean = false) {
     const requestId = `shutdown_${v4()}`;
     const message = this._createMessage("shutdown_request", requestId);
 
@@ -179,12 +187,12 @@ export default class ZMQKernel extends Kernel {
     this.shellSocket.send(new Message(message));
   }
 
-  restart(onRestarted: ?Function) {
+  _socketRestart(onRestarted: ?Function) {
     if (this.executionState === "restarting") {
       return;
     }
     this.setExecutionState("restarting");
-    this.shutdown(true);
+    this._socketShutdown(true);
     this._kill();
     const { spawn } = launchSpecFromConnectionInfo(
       this.kernelSpec,
@@ -200,7 +208,11 @@ export default class ZMQKernel extends Kernel {
 
   // onResults is a callback that may be called multiple times
   // as results come in from the kernel
-  _execute(code: string, requestId: string, onResults: ?Function) {
+  rawExecute(code: string, callWatches: boolean, onResults: ?Function) {
+    log("ZMQKernel.rawExecute:", code, callWatches);
+    // requestId starting with "execute_" will trigger watches being called
+    const requestId = callWatches ? `execute_${v4()}` : `watch_${v4()}`;
+
     const message = this._createMessage("execute_request", requestId);
 
     message.content = {
@@ -216,22 +228,8 @@ export default class ZMQKernel extends Kernel {
     this.shellSocket.send(new Message(message));
   }
 
-  execute(code: string, onResults: ?Function) {
-    log("Kernel.execute:", code);
-
-    const requestId = `execute_${v4()}`;
-    this._execute(code, requestId, onResults);
-  }
-
-  executeWatch(code: string, onResults: Function) {
-    log("Kernel.executeWatch:", code);
-
-    const requestId = `watch_${v4()}`;
-    this._execute(code, requestId, onResults);
-  }
-
-  complete(code: string, onResults: Function) {
-    log("Kernel.complete:", code);
+  rawComplete(code: string, onResults: Function) {
+    log("ZMQKernel.rawComplete:", code);
 
     const requestId = `complete_${v4()}`;
 
@@ -249,8 +247,8 @@ export default class ZMQKernel extends Kernel {
     this.shellSocket.send(new Message(message));
   }
 
-  inspect(code: string, cursorPos: number, onResults: Function) {
-    log("Kernel.inspect:", code, cursorPos);
+  rawInspect(code: string, cursorPos: number, onResults: Function) {
+    log("ZMQKernel.rawInspect:", code, cursorPos);
 
     const requestId = `inspect_${v4()}`;
 

--- a/package.json
+++ b/package.json
@@ -90,7 +90,8 @@
     },
     "hydrogen.provider": {
       "versions": {
-        "1.1.0": "provideHydrogen"
+        "1.1.0": "provideHydrogen",
+        "1.2.0": "provideHydrogen"
       }
     }
   },

--- a/spec/commands-spec.js
+++ b/spec/commands-spec.js
@@ -2,6 +2,7 @@
 
 import { Store } from "../lib/store";
 import { toggleInspector } from "../lib/commands";
+import KernelTransport from "../lib/kernel-transport";
 import Kernel from "../lib/kernel";
 
 describe("commands", () => {
@@ -12,10 +13,12 @@ describe("commands", () => {
     filePath = "fake.py";
     grammar = atom.grammars.grammarForScopeName("source.python");
     editor = atom.workspace.buildTextEditor();
-    mockKernel = new Kernel({
-      display_name: "Python 3",
-      language: "python"
-    });
+    mockKernel = new Kernel(
+      new KernelTransport({
+        display_name: "Python 3",
+        language: "python"
+      })
+    );
 
     spyOn(editor, "getPath").and.returnValue(filePath);
     spyOn(storeMock.subscriptions, "dispose");

--- a/spec/components/output-area-spec.js
+++ b/spec/components/output-area-spec.js
@@ -5,6 +5,7 @@ import Enzyme, { shallow } from "enzyme";
 
 import OutputArea from "../../lib/components/output-area";
 import { Store } from "../../lib/store";
+import KernelTransport from "../../lib/kernel-transport";
 import Kernel from "../../lib/kernel";
 
 describe("Output area component", () => {
@@ -39,10 +40,12 @@ describe("Output area component", () => {
 
   beforeAll(() => {
     storeMock = new Store();
-    mockKernel = new Kernel({
-      display_name: "Python 3",
-      language: "python"
-    });
+    mockKernel = new Kernel(
+      new KernelTransport({
+        display_name: "Python 3",
+        language: "python"
+      })
+    );
     spyOn(mockKernel, "inspect");
 
     grammar = atom.grammars.grammarForScopeName("source.python");

--- a/spec/components/status-bar-spec.js
+++ b/spec/components/status-bar-spec.js
@@ -7,6 +7,7 @@ import Adapter from "enzyme-adapter-react-16";
 Enzyme.configure({ adapter: new Adapter() });
 
 import store from "../../lib/store";
+import KernelTransport from "../../lib/kernel-transport";
 import Kernel from "../../lib/kernel";
 import StatusBar from "../../lib/components/status-bar";
 
@@ -44,17 +45,21 @@ describe("Status Bar", () => {
     expect(component.type()).toBeNull();
     expect(component.text()).toBe("");
 
-    const kernel = new Kernel({
-      display_name: "Python 3",
-      language: "python"
-    });
-    kernel.executionState = "starting";
+    const kernel = new Kernel(
+      new KernelTransport({
+        display_name: "Python 3",
+        language: "python"
+      })
+    );
+    kernel.setExecutionState("starting");
 
-    const kernel2 = new Kernel({
-      display_name: "Javascript",
-      language: "Javascript"
-    });
-    kernel2.executionState = "idle";
+    const kernel2 = new Kernel(
+      new KernelTransport({
+        display_name: "Javascript",
+        language: "Javascript"
+      })
+    );
+    kernel2.setExecutionState("idle");
 
     store.kernelMapping = new Map([
       ["foo.py", kernel],
@@ -72,7 +77,7 @@ describe("Status Bar", () => {
     expect(component.text()).toBe("Python 3 | starting");
 
     // update execution state
-    store.kernel.executionState = "idle";
+    store.kernel.setExecutionState("idle");
 
     // FixMe: Enzyme https://github.com/airbnb/enzyme/issues/1184
     component.setState();

--- a/spec/store/index-spec.js
+++ b/spec/store/index-spec.js
@@ -3,6 +3,7 @@
 import { CompositeDisposable } from "atom";
 import { isObservableMap, isObservable, isComputed } from "mobx";
 import store from "./../../lib/store";
+import KernelTransport from "./../../lib/kernel-transport";
 import Kernel from "./../../lib/kernel";
 import MarkerStore from "./../../lib/store/markers";
 const commutable = require("@nteract/commutable");
@@ -151,18 +152,24 @@ describe("Store", () => {
 
   describe("deleteKernel", () => {
     it("should delete kernel", () => {
-      const kernel1 = new Kernel({
-        display_name: "Python 3",
-        language: "python"
-      });
-      const kernel2 = new Kernel({
-        display_name: "Python 3",
-        language: "python"
-      });
-      const kernel3 = new Kernel({
-        display_name: "JS",
-        language: "Javascript"
-      });
+      const kernel1 = new Kernel(
+        new KernelTransport({
+          display_name: "Python 3",
+          language: "python"
+        })
+      );
+      const kernel2 = new Kernel(
+        new KernelTransport({
+          display_name: "Python 3",
+          language: "python"
+        })
+      );
+      const kernel3 = new Kernel(
+        new KernelTransport({
+          display_name: "JS",
+          language: "Javascript"
+        })
+      );
 
       store.runningKernels.replace([kernel1, kernel2, kernel3]);
       store.kernelMapping = new Map([
@@ -185,14 +192,18 @@ describe("Store", () => {
 
   describe("getFilesForKernel", () => {
     it("should return files related to kernel", () => {
-      const kernel1 = new Kernel({
-        display_name: "Python 3",
-        language: "python"
-      });
-      const kernel2 = new Kernel({
-        display_name: "Python 3",
-        language: "python"
-      });
+      const kernel1 = new Kernel(
+        new KernelTransport({
+          display_name: "Python 3",
+          language: "python"
+        })
+      );
+      const kernel2 = new Kernel(
+        new KernelTransport({
+          display_name: "Python 3",
+          language: "python"
+        })
+      );
 
       store.kernelMapping = new Map([
         ["foo.py", kernel1],
@@ -305,30 +316,36 @@ describe("Store", () => {
 
     it("should return kernel", () => {
       store.editor = { getPath: () => "foo.py" };
-      const kernel = new Kernel({
-        display_name: "Python 3",
-        language: "python"
-      });
+      const kernel = new Kernel(
+        new KernelTransport({
+          display_name: "Python 3",
+          language: "python"
+        })
+      );
       store.kernelMapping = new Map([["foo.py", kernel]]);
       expect(store.kernel).toEqual(kernel);
     });
 
     it("should return null if no kernel for file", () => {
       store.editor = { getPath: () => "foo.py" };
-      const kernel = new Kernel({
-        display_name: "Python 3",
-        language: "python"
-      });
+      const kernel = new Kernel(
+        new KernelTransport({
+          display_name: "Python 3",
+          language: "python"
+        })
+      );
       store.kernelMapping = new Map([["bar.py", kernel]]);
       expect(store.kernel).toBeUndefined();
     });
 
     it("should return null if no kernel for file", () => {
       store.editor = { getPath: () => "foo.md" };
-      const kernel = new Kernel({
-        display_name: "Python 3",
-        language: "python"
-      });
+      const kernel = new Kernel(
+        new KernelTransport({
+          display_name: "Python 3",
+          language: "python"
+        })
+      );
       store.kernelMapping = new Map([["foo.md", { python: kernel }]]);
       store.grammar = { name: "python" };
       expect(store.kernel).toEqual(kernel);


### PR DESCRIPTION
The goal of these changes is to make the plugin API more generally useful, by allowing plugins to intercept or issue kernel commands.

Here are just some of the plugin ideas that these changes aim to make possible:
* A plugin that fixes indentation by removing common leading whitespace (see #862). This is useful if you'd like to highlight and run some code that's inside a function, meaning that it's indented by some amount.
* Moving watches behavior into a plugin
* Remapping executing `expr?` to opening the inspector for `expr`, for those of us with lots of muscle memory from using notebooks

An example of how to use the updated API is currently in the diff for `lib/main.js` (actual location for examples is TBD).

These changes have similar goals to my previous approach, but I'm now basing them on the concept of middleware classes rather than event handlers. I think this is a more hassle-free approach.

Note that I'm enforcing separation between the plugin interface and hydrogen internals: in particular, the way to extend hydrogen does not involve inheriting from any classes defined in hydrogen core. This introduces an extra level of indirection, but I think it's the right approach in the long run because it allows hydrogen core to evolve at a different pace from the plugin API. It also allows multiple versions of the plugin API to coexist, which I think is good practice for maintaining backwards compatibility.

The WIP tag reflects the fact that there are still two unresolved questions that I'd like feedback on (assuming the overall approach is sound).

1. ~~Figuring out the precise syntax for defining middleware (options are presented at `hydrogen-kernel.js` line 73)~~
2. ~~~Figuring out what to do about results handlers (see `hydrogen-kernel.js` line 11). Results handlers are currently tightly coupled to hydrogen internals, but I think the plugin API should avoid such tight coupling.~~~