### PR TITLE
Fix #1128

### DIFF
--- a/styles/hydrogen.less
+++ b/styles/hydrogen.less
@@ -64,6 +64,12 @@ svg:first-child {
     }
 }
 
+.js-plotly-plot {
+    svg {
+        background-color: unset;
+    }
+}
+
 .nteract-display-area-stderr {
   color: @hydrogen-error-color;
 }


### PR DESCRIPTION
Fixes Plotly 3D inline charts display by unsetting the earlier background-color attribute applied to svg.  Tested on Atom 1.23.3 / Plotly 2.2.3 / Python 3.6.3