### PR TITLE
set undefined for onClick instead of false

### DIFF
--- a/lib/components/result-view/result-view.js
+++ b/lib/components/result-view/result-view.js
@@ -126,7 +126,7 @@ class ResultViewComponent extends React.Component<Props> {
     return (
       <div
         className={isPlain ? "inline-container" : "multiline-container"}
-        onClick={isPlain ? this.handleClick : false}
+        onClick={isPlain ? this.handleClick : undefined}
         style={
           isPlain
             ? inlineStyle


### PR DESCRIPTION
While trying to work on improving the MathJax support in Hydrogen, I noticed warnings from React when setting `false` instead of `undefined` for event callbacks.