### PR TITLE
Fix session name display in WSKernelPicker

### DIFF
--- a/lib/ws-kernel-picker.js
+++ b/lib/ws-kernel-picker.js
@@ -282,7 +282,9 @@ export default class WSKernelPicker {
         });
         const items = sessionModels.map(model => {
           let name;
-          if (model.notebook && model.notebook.path) {
+          if (model.path) {
+            name = tildify(model.path);
+          } else if (model.notebook && model.notebook.path) {
             name = tildify(model.notebook.path);
           } else {
             name = `Session ${model.id}`;


### PR DESCRIPTION
This is in response to #1245 

`model.notebook.path` does not exist for kernels spawned from hydrogen, but `model.path` does.

In general, the schema for session model objects has undergone some changes in the past year or so. Once Jupyterlab and `@jupyter/services` get to the point of actually having a stable developer API, we can consider additional changes (such as taking advantage of the `name` field instead of pretending that everything is a path)