### PR TITLE
Update mobx

### DIFF
--- a/lib/components/output-area.js
+++ b/lib/components/output-area.js
@@ -15,7 +15,7 @@ import type { IObservableValue } from "mobx";
 
 @observer
 class OutputArea extends React.Component<{ store: store }> {
-  showHistory: IObservableValue<boolean> = observable(true);
+  showHistory: IObservableValue<boolean> = observable.box(true);
   @action
   setHistory = () => {
     this.showHistory.set(true);

--- a/lib/components/result-view/list.js
+++ b/lib/components/result-view/list.js
@@ -2,7 +2,7 @@
 
 import React from "react";
 import { observer } from "mobx-react";
-import { toJS } from "mobx";
+import { values } from "mobx";
 import { Display } from "@nteract/display-area";
 import { transforms, displayOrder } from "./transforms";
 
@@ -44,7 +44,7 @@ class ScrollList extends React.Component<Props> {
         }}
       >
         <Display
-          outputs={toJS(this.props.outputs)}
+          outputs={values(this.props.outputs)}
           displayOrder={displayOrder}
           transforms={transforms}
           theme="light"

--- a/lib/components/result-view/result-view.js
+++ b/lib/components/result-view/result-view.js
@@ -3,7 +3,7 @@
 import { CompositeDisposable } from "atom";
 import React from "react";
 import { observer } from "mobx-react";
-import { action, observable, toJS } from "mobx";
+import { action, observable, values } from "mobx";
 import { Display } from "@nteract/display-area";
 import { transforms, displayOrder } from "./transforms";
 import Status from "./status";
@@ -27,7 +27,7 @@ class ResultViewComponent extends React.Component<Props> {
   containerTooltip = new CompositeDisposable();
   buttonTooltip = new CompositeDisposable();
   closeTooltip = new CompositeDisposable();
-  expanded: IObservableValue<boolean> = observable(false);
+  expanded: IObservableValue<boolean> = observable.box(false);
 
   getAllText = () => {
     if (!this.el) return "";
@@ -160,7 +160,7 @@ class ResultViewComponent extends React.Component<Props> {
           }}
         >
           <Display
-            outputs={toJS(outputs)}
+            outputs={values(outputs)}
             displayOrder={displayOrder}
             transforms={transforms}
             theme="light"

--- a/lib/store/index.js
+++ b/lib/store/index.js
@@ -1,7 +1,14 @@
 /* @flow */
 
 import { CompositeDisposable } from "atom";
-import { observable, computed, action } from "mobx";
+import {
+  observable,
+  computed,
+  action,
+  isObservableMap,
+  keys,
+  values
+} from "mobx";
 import { isMultilanguageGrammar, getEmbeddedScope } from "./../utils";
 import _ from "lodash";
 
@@ -39,6 +46,11 @@ export class Store {
   }
 
   @computed
+  get filePaths(): Array<?string> {
+    return keys(this.kernelMapping);
+  }
+
+  @computed
   get notebook() {
     const editor = this.editor;
     if (!editor) {
@@ -70,10 +82,11 @@ export class Store {
     grammar: atom$Grammar
   ) {
     if (isMultilanguageGrammar(editor.getGrammar())) {
-      const old = this.kernelMapping.get(filePath);
-      const newMap = old && old instanceof Kernel === false ? old : {};
-      newMap[grammar.name] = kernel;
-      this.kernelMapping.set(filePath, newMap);
+      if (!this.kernelMapping.has(filePath)) {
+        this.kernelMapping.set(filePath, new Map());
+      }
+      const multiLanguageMap = this.kernelMapping.get(filePath);
+      multiLanguageMap.set(grammar.name, kernel);
     } else {
       this.kernelMapping.set(filePath, kernel);
     }
@@ -87,44 +100,30 @@ export class Store {
 
   @action
   deleteKernel(kernel: Kernel) {
-    this._iterateOverKernels(
-      kernel,
-      (_, file) => {
+    const grammar = kernel.grammar.name;
+    const files = this.getFilesForKernel(kernel);
+
+    files.forEach(file => {
+      const kernelOrMap = this.kernelMapping.get(file);
+      if (!kernelOrMap) return;
+      if (kernelOrMap instanceof Kernel) {
         this.kernelMapping.delete(file);
-      },
-      (map, _, grammar) => {
-        map[grammar] = null;
-        delete map[grammar];
+      } else {
+        kernelOrMap.delete(grammar);
       }
-    );
+    });
 
     this.runningKernels.remove(kernel);
   }
 
-  _iterateOverKernels(
-    kernel: Kernel,
-    func: (kernel: Kernel | KernelObj, file: string) => mixed,
-    func2: (obj: KernelObj, file: string, grammar: string) => mixed = func
-  ) {
-    this.kernelMapping.forEach((kernelOrObj, file) => {
-      if (kernelOrObj === kernel) {
-        func(kernel, file);
-      }
-
-      if (kernelOrObj instanceof Kernel === false) {
-        _.forEach(kernelOrObj, (k, grammar) => {
-          if (k === kernel) {
-            func2(kernelOrObj, file, grammar);
-          }
-        });
-      }
-    });
-  }
-
   getFilesForKernel(kernel: Kernel) {
-    const files = [];
-    this._iterateOverKernels(kernel, (_, file) => files.push(file));
-    return files;
+    const grammar = kernel.grammar.name;
+    return this.filePaths.filter(file => {
+      const kernelOrMap = this.kernelMapping.get(file);
+      return kernelOrMap instanceof Kernel
+        ? kernelOrMap === kernel
+        : kernelOrMap.get(grammar) === kernel;
+    });
   }
 
   @action

--- a/package.json
+++ b/package.json
@@ -64,8 +64,8 @@
     "jmp": "^1.0.0",
     "kernelspecs": "^2.0.0",
     "lodash": "^4.14.0",
-    "mobx": "^3.3.0",
-    "mobx-react": "^4.3.5",
+    "mobx": "^4.1.1",
+    "mobx-react": "^5.0.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-rangeslider": "^2.1.0",
@@ -103,7 +103,7 @@
     "husky": "^0.14.0",
     "lint-staged": "^7.0.0",
     "markdox": "^0.1.10",
-    "mobx-react-devtools": "^4.2.11",
+    "mobx-react-devtools": "^5.0.0",
     "prettier": "^1.8.2",
     "react-test-renderer": "^16.0.0"
   }

--- a/spec/components/output-area-spec.js
+++ b/spec/components/output-area-spec.js
@@ -41,10 +41,13 @@ describe("Output area component", () => {
   beforeAll(() => {
     storeMock = new Store();
     mockKernel = new Kernel(
-      new KernelTransport({
-        display_name: "Python 3",
-        language: "python"
-      })
+      new KernelTransport(
+        {
+          display_name: "Python 3",
+          language: "python"
+        },
+        { name: "python" }
+      )
     );
     spyOn(mockKernel, "inspect");
 

--- a/spec/store/index-spec.js
+++ b/spec/store/index-spec.js
@@ -1,7 +1,7 @@
 "use babel";
 
 import { CompositeDisposable } from "atom";
-import { isObservableMap, isObservable, isComputed } from "mobx";
+import { isObservableMap, isObservableProp, isComputedProp, keys } from "mobx";
 import store from "./../../lib/store";
 import KernelTransport from "./../../lib/kernel-transport";
 import Kernel from "./../../lib/kernel";
@@ -15,9 +15,9 @@ describe("Store initialize", () => {
     expect(store.runningKernels.slice()).toEqual([]);
     expect(isObservableMap(store.startingKernels)).toBeTruthy();
     expect(isObservableMap(store.kernelMapping)).toBeTruthy();
-    expect(isObservable(store, "editor")).toBeTruthy();
-    expect(isObservable(store, "grammar")).toBeTruthy();
-    expect(isComputed(store, "kernel")).toBeTruthy();
+    expect(isObservableProp(store, "editor")).toBeTruthy();
+    expect(isObservableProp(store, "grammar")).toBeTruthy();
+    expect(isComputedProp(store, "kernel")).toBeTruthy();
   });
 });
 


### PR DESCRIPTION
The [new release of mobx](https://medium.com/@mweststrate/mobx-4-better-simpler-faster-smaller-c1fbc08008da) brought in some major api changes so i've updated us here.

Much of the changes are just naming, e.g. `isObservable > isObservableProp` 

Once the simple stuff was done our tests broke because `store.deleteKernel` and `store.getFilesForKernel` were not not working properly.  I did some refactoring in `lib/store/index.js` to fix these things.