### PR TITLE
Global kernel mode

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -117,6 +117,12 @@ const Config = {
       title: "Disable the Hydrogen status bar",
       type: "boolean",
       default: false
+    },
+    globalMode: {
+      title:
+        "If enabled, all files of the same grammar will share a single global kernel (requires atom restart)",
+      type: "boolean",
+      default: false
     }
   }
 };

--- a/lib/store/index.js
+++ b/lib/store/index.js
@@ -148,6 +148,12 @@ export class Store {
   updateEditor(editor: ?atom$TextEditor) {
     this.editor = editor;
     this.setGrammar(editor);
+
+    if (this.globalMode && this.kernel && editor) {
+      const fileName = editor.getPath();
+      if (!fileName) return;
+      this.kernelMapping.set(fileName, this.kernel);
+    }
   }
 
   @action

--- a/lib/store/index.js
+++ b/lib/store/index.js
@@ -31,9 +31,18 @@ export class Store {
   @observable editor = atom.workspace.getActiveTextEditor();
   @observable grammar: ?atom$Grammar;
   @observable configMapping: Map<string, ?mixed> = new Map();
+  globalMode: boolean = Boolean(atom.config.get("Hydrogen.globalMode"));
 
   @computed
   get kernel(): ?Kernel {
+    if (this.globalMode) {
+      if (!this.grammar) return null;
+      const currentScopeName = this.grammar.scopeName;
+      return this.runningKernels.filter(
+        k => k.grammar.scopeName === currentScopeName
+      )[0];
+    }
+
     if (!this.filePath) return null;
     const kernelOrMap = this.kernelMapping.get(this.filePath);
     if (!kernelOrMap || kernelOrMap instanceof Kernel) return kernelOrMap;

--- a/spec/store/index-spec.js
+++ b/spec/store/index-spec.js
@@ -415,6 +415,13 @@ describe("Store", () => {
 
       mockStore.updateEditor(editor2);
       expect(mockStore.kernel).toEqual(kernel1);
+
+      // store should still keep track of all filePaths
+      expect(mockStore.filePaths).toEqual(["foo.py", "bar.py"]);
+      expect(mockStore.getFilesForKernel(mockStore.kernel)).toEqual([
+        "foo.py",
+        "bar.py"
+      ]);
     });
   });
 });


### PR DESCRIPTION
See #1057 , this PR introduces a config to use a single global kernel between files of the same grammar.

For now you have to restart if you change globalMode after hydrogen has been activated.

To try it out, checkout this branch then set global mode with: `atom.config.set("Hydrogen.globalMode", true)` (or in settings view)