### PR TITLE
kernelspecs sort by display_name

### DIFF
--- a/lib/kernel-manager.js
+++ b/lib/kernel-manager.js
@@ -88,7 +88,7 @@ export class KernelManager {
 
   async update() {
     const kernelSpecs = await ks.findAll();
-    this.kernelSpecs = _.map(kernelSpecs, "spec");
+    this.kernelSpecs = _.sortBy(_.map(kernelSpecs, "spec"), spec => spec.display_name);
     return this.kernelSpecs;
   }
 


### PR DESCRIPTION
To avoid inconsistent ordering of kernels, and allow users to dictate which kernels appear first, sort the kernel specs by their display_name.

I generate a lot of kernels, but current behaviour lists default kernels (eg `Python 3`) last, which is inconvenient. 