### PR TITLE
Workaround: Add react-hot-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "mobx-react": "^5.0.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
+    "react-hot-loader": "^4.3.3",
     "react-rangeslider": "^2.1.0",
     "spawnteract": "^4.0.0",
     "tildify": "^1.2.0",


### PR DESCRIPTION
The new release of `@nteract/` packages requires `react-hot-loader` as a dependency due to the [babel config](https://github.com/nteract/nteract/blob/master/.babelrc#L4) used during publishing.

This adds `react-hot-loader` as a dependency for now.

Closes #1335
Closes #1333
Closes #1334