### PR TITLE
Remove references to `controlSocket` (it's unused)

### DIFF
--- a/lib/zmq-kernel.js
+++ b/lib/zmq-kernel.js
@@ -31,7 +31,6 @@ export default class ZMQKernel extends KernelTransport {
   options: Object;
 
   shellSocket: Socket;
-  controlSocket: Socket;
   stdinSocket: Socket;
   ioSocket: Socket;
 
@@ -66,19 +65,16 @@ export default class ZMQKernel extends KernelTransport {
     const { key } = this.connection;
 
     this.shellSocket = new Socket("dealer", scheme, key);
-    this.controlSocket = new Socket("dealer", scheme, key);
     this.stdinSocket = new Socket("dealer", scheme, key);
     this.ioSocket = new Socket("sub", scheme, key);
 
     const id = v4();
     this.shellSocket.identity = `dealer${id}`;
-    this.controlSocket.identity = `control${id}`;
     this.stdinSocket.identity = `dealer${id}`;
     this.ioSocket.identity = `sub${id}`;
 
     const address = `${this.connection.transport}://${this.connection.ip}:`;
     this.shellSocket.connect(address + this.connection.shell_port);
-    this.controlSocket.connect(address + this.connection.control_port);
     this.ioSocket.connect(address + this.connection.iopub_port);
     this.ioSocket.subscribe("");
     this.stdinSocket.connect(address + this.connection.stdin_port);
@@ -114,7 +110,7 @@ export default class ZMQKernel extends KernelTransport {
 
   monitor(done: ?Function) {
     try {
-      let socketNames = ["shellSocket", "controlSocket", "ioSocket"];
+      let socketNames = ["shellSocket", "ioSocket"];
 
       let waitGroup = socketNames.length;
 
@@ -137,7 +133,6 @@ export default class ZMQKernel extends KernelTransport {
       };
 
       monitor("shellSocket", this.shellSocket);
-      monitor("controlSocket", this.controlSocket);
       monitor("ioSocket", this.ioSocket);
     } catch (err) {
       console.error("ZMQKernel:", err);
@@ -396,7 +391,6 @@ export default class ZMQKernel extends KernelTransport {
     fs.unlinkSync(this.connectionFile);
 
     this.shellSocket.close();
-    this.controlSocket.close();
     this.ioSocket.close();
     this.stdinSocket.close();
 


### PR DESCRIPTION
The references to `controlSocket` are currently unused, however, they [prevent evaluation via the Ruby kernel in Atom](https://github.com/nteract/hydrogen/issues/1359#issuecomment-408440189).

In this PR, I've removed all references to `controlSocket` in the `lib/zmq-kernel.js` file.

