### PR TITLE
Don't trim code selection before sending to kernel

### DIFF
--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -14,7 +14,7 @@ import {
 
 export function normalizeString(code: ?string) {
   if (code) {
-    return code.replace(/\r\n|\r/g, "\n").trim();
+    return code.replace(/\r\n|\r/g, "\n");
   }
   return null;
 }


### PR DESCRIPTION
### Description of the Change

Don't remove whitespace from start and end of string before sending to kernel. Would fix #862.

I spent several hours trying to figure out enough JavaScript to remove common leading whitespace (that's on [this branch](https://github.com/kylebarron/hydrogen/tree/strip_common_whitespace), and I'd submit that as a PR if preferred) when I realized that the IPython kernel can deal with common whitespace just fine:

<img width="270" alt="image" src="https://user-images.githubusercontent.com/15164633/43374619-97256488-937e-11e8-8b35-f79052f76b7a.png">

The issue is that Hydrogen trims strings by default before sending them to kernels.
https://github.com/nteract/hydrogen/blob/ad6217f61131a5a8e8bf3134f10a764b168d0184/lib/code-manager.js#L15-L20

So what IPython actually receives is:
<img width="344" alt="image" src="https://user-images.githubusercontent.com/15164633/43374758-5399546c-937f-11e8-8c94-3860a83eb404.png">


### Alternate Designs

I wrote code that actually removes common leading whitespace. That's on [this branch](https://github.com/kylebarron/hydrogen/tree/strip_common_whitespace). 

The hydrogen-python extension package tries to deal with this but has some [limitations](https://github.com/nikitakit/hydrogen-python#limitations) that prevent its use.

### Benefits

Selection-based Python code would work regardless of the amount of common indentation.

### Possible Drawbacks

Other kernels might be expecting strings without any leading or trailing whitespace. I would imagine that kernels would account for extra whitespace if necessary and that it wouldn't be an issue.

Otherwise, to preserve true backwards compatibility we could have only the Python kernel not trim whitespace. Or have a user-defined config setting. Maintainers probably have the best idea for what is best.

### Applicable Issues

Would fix #862, half of #1341, #1285.

### Examples

<img width="198" alt="image" src="https://user-images.githubusercontent.com/15164633/43375288-1f17fd6c-9382-11e8-8050-b4967dff788e.png">
<img width="365" alt="image" src="https://user-images.githubusercontent.com/15164633/43375293-24a12538-9382-11e8-97d7-8e1e03101ba3.png">

(This is the same behavior as the IPython kernel)
<img width="266" alt="image" src="https://user-images.githubusercontent.com/15164633/43375297-2b1bb16c-9382-11e8-8c76-0a5dcb2cca14.png">



<img width="505" alt="image" src="https://user-images.githubusercontent.com/15164633/43375309-395cce82-9382-11e8-98a7-1cb7c7d6de44.png">
