### PR TITLE
Add MagicPython language mapping by default.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -89,7 +89,7 @@ const Config = {
       description:
         'Custom Atom grammars and some kernels use non-standard language names. That leaves Hydrogen unable to figure out what kernel to start for your code. This field should be a valid JSON mapping from a kernel language name to Atom\'s grammar name ``` { "kernel name": "grammar name" } ```. For example ``` { "scala211": "scala", "javascript": "babel es6 javascript", "python": "magicpython" } ```.',
       type: "string",
-      default: "{}"
+      default: '{ "python": "magicpython" }'
     },
     startupCode: {
       title: "Startup Code",


### PR DESCRIPTION
Low hanging fruit. Fixes #1065.