### PR TITLE
Fix kernel restart issue

### DIFF
--- a/lib/kernel-manager.js
+++ b/lib/kernel-manager.js
@@ -2,7 +2,6 @@
 
 import _ from "lodash";
 import * as kernelspecs from "kernelspecs";
-import { launchSpec } from "spawnteract";
 import { shell } from "electron";
 
 import ZMQKernel from "./zmq-kernel";

--- a/lib/zmq-kernel.js
+++ b/lib/zmq-kernel.js
@@ -42,6 +42,8 @@ export default class ZMQKernel extends KernelTransport {
   ) {
     super(kernelSpec, grammar);
     this.options = options || {};
+    // Otherwise spawnteract deletes the file and hydrogen's restart kernel fails
+    options.cleanupConnectionFile = false;
 
     launchSpec(kernelSpec, options).then(
       ({ config, connectionFile, spawn }) => {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "react-dom": "^16.2.0",
     "react-hot-loader": "^4.3.3",
     "react-rangeslider": "^2.1.0",
-    "spawnteract": "^5.0.0",
+    "spawnteract": "^5.1.0",
     "styled-jsx": "^2.2.7",
     "tildify": "^1.2.0",
     "uuid": "^3.2.1",


### PR DESCRIPTION
- this PR fixes a bug that prevents kernel restart from working properly.
- spawnteract will remove the connection file on process exit by default as of v5.0.0
- we need to handle this manually right now since we recycle the connection file between restarts