### PR TITLE
Add class to status bar item

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -255,7 +255,7 @@ const Hydrogen = {
 
   consumeStatusBar(statusBar: atom$StatusBar) {
     const statusBarElement = document.createElement("div");
-    statusBarElement.className = "inline-block";
+    statusBarElement.classList.add("inline-block", "hydrogen");
 
     statusBar.addLeftTile({
       item: statusBarElement,


### PR DESCRIPTION
Add .hydrogen class to distinguish it and prevent clashing with other items in the status bar.