### PR TITLE
Allow for autocomplete within string scope

### DIFF
--- a/lib/autocomplete-provider.js
+++ b/lib/autocomplete-provider.js
@@ -70,7 +70,7 @@ function parseCompletions(results: CompleteReply, prefix: string) {
 export default function() {
   const autocompleteProvider = {
     selector: ".source",
-    disableForSelector: ".comment, .string",
+    disableForSelector: ".comment",
 
     // `excludeLowerPriority: false` won't suppress providers with lower
     // priority.


### PR DESCRIPTION
Fixes https://github.com/nteract/hydrogen/issues/1383

In my personal branch, I also have `inclusionPriority: 0` because I was tired of having to scroll down to use the Hydrogen autocomplete when it was often the most accurate. But that is a different discussion and isn't included here.