### PR TITLE
kernel-manager.js: clarify 'no kernel found' error description

### DIFF
--- a/lib/kernel-manager.js
+++ b/lib/kernel-manager.js
@@ -32,7 +32,7 @@ export class KernelManager {
           grammar && /python/g.test(grammar.scopeName)
             ? "\n\nTo detect your current Python install you will need to run:<pre>python -m pip install ipykernel\npython -m ipykernel install --user</pre>"
             : "";
-        const description = `Check that the language for this file is set in Atom and that you have a Jupyter kernel installed for it.${pythonDescription}`;
+        const description = `Check that the language for this file is set in Atom, that you have a Jupyter kernel installed for it, and that you have configured the language mapping in Hydrogen preferences.${pythonDescription}`;
         atom.notifications.addError(message, {
           description,
           dismissable: pythonDescription !== ""


### PR DESCRIPTION
This adds the information that language mappings can be manually configured to the error message.

Corresponds to issue #1420 