### PR TITLE
Use monospace font in output area

### DIFF
--- a/styles/hydrogen.less
+++ b/styles/hydrogen.less
@@ -251,6 +251,7 @@ svg:first-child {
     flex: 0 0 auto;
   }
   .multiline-container {
+    font-family: monospace;
     flex: 0 1 auto;
   }
   .scroll-list {


### PR DESCRIPTION
Fixes https://github.com/nteract/hydrogen/issues/1366.
Fixes https://github.com/nteract/hydrogen/issues/1288.

This submits the fix found by @bigheadming in https://github.com/nteract/hydrogen/issues/1366. He also raised the issue of bad contrast with output colors, but that is a separate issue (https://github.com/nteract/hydrogen/issues/894).