### PR TITLE
Update prettier and remove travis prettifications.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,6 @@ script:
   - curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh
   - npm run flow
 
-after_success:
-  - curl -s https://raw.githubusercontent.com/lgeiger/prettier-greenkeeper/master/travis.sh | sh
-
 env:
   matrix:
     - ATOM_CHANNEL=stable

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "lint-staged": "^7.0.0",
     "markdox": "^0.1.10",
     "mobx-react-devtools": "^6.0.0",
-    "prettier": "^1.8.2",
+    "prettier": "^1.14.3",
     "react-test-renderer": "^16.0.0"
   }
 }


### PR DESCRIPTION
Prettier has become quite stable recently so no need to constantly run prettier on green-keeper PRs.