### PR TITLE
Add a spec for ResultViewComponent

### DIFF
--- a/spec/components/result-view/result-view-spec.js
+++ b/spec/components/result-view/result-view-spec.js
@@ -1,0 +1,72 @@
+"use babel";
+
+import React from "react";
+import { shallow } from "enzyme";
+
+import ResultViewComponent from "../../../lib/components/result-view/result-view";
+
+describe("ResultViewComponent", () => {
+  it("should render", () => {
+    const mockStore = {
+      index: 0,
+      outputs: [{}, {}],
+      status: "",
+      executionCount: 0,
+      position: {
+        lineHeight: 0,
+        lineLength: 0,
+        editorWidth: 0,
+        charWidth: 0
+      }
+    };
+
+    const mockKernel = {};
+
+    const destroy = () => {};
+
+    const component = shallow(
+      <ResultViewComponent
+        store={mockStore}
+        kernel={mockKernel}
+        destroy={destroy}
+        showResult={true}
+      />
+    );
+
+    expect(component.type()).not.toBeNull();
+  });
+
+  it("should destroy itself when x is clicked.", () => {
+    const mockStore = {
+      index: 0,
+      outputs: [{}, {}],
+      status: "",
+      executionCount: 0,
+      position: {
+        lineHeight: 0,
+        lineLength: 0,
+        editorWidth: 0,
+        charWidth: 0
+      }
+    };
+
+    const mockKernel = {};
+
+    let destroyInvoked = false;
+    const destroy = () => {
+      destroyInvoked = true;
+    };
+
+    const component = shallow(
+      <ResultViewComponent
+        store={mockStore}
+        kernel={mockKernel}
+        destroy={destroy}
+        showResult={true}
+      />
+    );
+
+    component.find(".icon-x").simulate("click");
+    expect(destroyInvoked).toBe(true);
+  });
+});

--- a/spec/components/result-view/result-view-spec.js
+++ b/spec/components/result-view/result-view-spec.js
@@ -52,10 +52,7 @@ describe("ResultViewComponent", () => {
 
     const mockKernel = {};
 
-    let destroyInvoked = false;
-    const destroy = () => {
-      destroyInvoked = true;
-    };
+    const destroy = jasmine.createSpy("destroy");
 
     const component = shallow(
       <ResultViewComponent
@@ -67,6 +64,6 @@ describe("ResultViewComponent", () => {
     );
 
     component.find(".icon-x").simulate("click");
-    expect(destroyInvoked).toBe(true);
+    expect(destroy).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
#813

This adds a basic test for ResultViewComponent. I was hoping to get farther and write more useful tests, but ran into issues with mocking some internals of the class.

For instance, I wanted to demonstrate the clicking on the topmost `<div>` actually ran `openInEditor`, but struggled to mock `openInEditor`. I also wanted to demonstrate that clicking `icon-clippy` actually copied stuff to the clipboard, but figuring out how to make that actually button appear for a test was outside of my React skills (I got to a point where it looked like it had something to do with`ref = { ref => {]}`) 😕.

I'd be more than happy if someone had some advice to offer in terms of adding more value to these tests. Or if someone thinks this is useful enough to merge without more tests - I suppose that'd be fine too.