### PR TITLE
Add code cell folding

### DIFF
--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -336,7 +336,7 @@ export function foldCurrentCell(editor: atom$TextEditor) {
   const cellRange = getCurrentCell(editor);
   const newRange = adjustCellFoldRange(editor, cellRange);
   editor.setSelectedBufferRange(newRange);
-  const selection = editor.selections[0];
+  const selection = editor.getSelections()[0];
   selection.fold();
 }
 
@@ -351,9 +351,10 @@ export function foldAllButCurrentCell(editor: atom$TextEditor) {
     newRanges.push(adjustCellFoldRange(editor, allButCurrentCell[i]));
   }
 
+  const selections = editor.getSelections()
   editor.setSelectedBufferRanges(newRanges);
-  for (var i = 0; i < editor.selections.length; i++) {
-    editor.selections[i].fold()
+  for (var i = 0; i < selections.length; i++) {
+    selections[i].fold()
   }
 
   // Restore selections

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -336,8 +336,7 @@ export function foldCurrentCell(editor: atom$TextEditor) {
   const cellRange = getCurrentCell(editor);
   const newRange = adjustCellFoldRange(editor, cellRange);
   editor.setSelectedBufferRange(newRange);
-  const selection = editor.getSelections()[0];
-  selection.fold();
+  editor.getSelections()[0].fold();
 }
 
 export function foldAllButCurrentCell(editor: atom$TextEditor) {
@@ -345,17 +344,12 @@ export function foldAllButCurrentCell(editor: atom$TextEditor) {
 
   const allCellRanges = getCells(editor).slice(1);
   const currentCellRange = getCurrentCell(editor);
-  const allButCurrentCell = allCellRanges.filter(item => !item.isEqual(currentCellRange))
-  var newRanges = [];
-  for (var i = 0; i < allButCurrentCell.length; i++) {
-    newRanges.push(adjustCellFoldRange(editor, allButCurrentCell[i]));
-  }
+  const newRanges = allCellRanges
+    .filter(cellRange => !cellRange.isEqual(currentCellRange))
+    .map(cellRange => adjustCellFoldRange(editor, cellRange));
 
-  const selections = editor.getSelections()
   editor.setSelectedBufferRanges(newRanges);
-  for (var i = 0; i < selections.length; i++) {
-    selections[i].fold()
-  }
+  editor.getSelections().forEach(selection => selection.fold());
 
   // Restore selections
   editor.setSelectedBufferRanges(initialSelections)

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -331,3 +331,40 @@ export function findCodeBlock(editor: atom$TextEditor) {
   }
   return [getRow(editor, row), row];
 }
+
+export function foldCurrentCell(editor: atom$TextEditor) {
+  const cellRange = getCurrentCell(editor);
+  const newRange = adjustCellFoldRange(editor, cellRange);
+  editor.setSelectedBufferRange(newRange);
+  const selection = editor.selections[0];
+  selection.fold();
+}
+
+export function foldAllButCurrentCell(editor: atom$TextEditor) {
+  const initialSelections = editor.getSelectedBufferRanges()
+
+  const allCellRanges = getCells(editor).slice(1);
+  const currentCellRange = getCurrentCell(editor);
+  const allButCurrentCell = allCellRanges.filter(item => !item.isEqual(currentCellRange))
+  var newRanges = [];
+  for (var i = 0; i < allButCurrentCell.length; i++) {
+    newRanges.push(adjustCellFoldRange(editor, allButCurrentCell[i]));
+  }
+
+  editor.setSelectedBufferRanges(newRanges);
+  for (var i = 0; i < editor.selections.length; i++) {
+    editor.selections[i].fold()
+  }
+
+  // Restore selections
+  editor.setSelectedBufferRanges(initialSelections)
+}
+
+function adjustCellFoldRange(editor, range){
+  const startRow = range.start.row - 1;
+  const startWidth = editor.lineTextForBufferRow(startRow).length;
+  return new Range(
+    new Point(startRow, startWidth),
+    new Point(range.end.row - 1, range.end.column)
+  );
+}

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -340,8 +340,10 @@ export function foldCurrentCell(editor: atom$TextEditor) {
 }
 
 export function foldAllButCurrentCell(editor: atom$TextEditor) {
-  const initialSelections = editor.getSelectedBufferRanges()
+  const initialSelections = editor.getSelectedBufferRanges();
 
+  // I take .slice(1) because there's always an empty cell range from [0,0] to
+  // [0,0]
   const allCellRanges = getCells(editor).slice(1);
   const currentCellRange = getCurrentCell(editor);
   const newRanges = allCellRanges
@@ -352,14 +354,19 @@ export function foldAllButCurrentCell(editor: atom$TextEditor) {
   editor.getSelections().forEach(selection => selection.fold());
 
   // Restore selections
-  editor.setSelectedBufferRanges(initialSelections)
+  editor.setSelectedBufferRanges(initialSelections);
 }
 
-function adjustCellFoldRange(editor, range){
-  const startRow = range.start.row - 1;
+function adjustCellFoldRange(editor, range) {
+  const startRow = range.start.row > 0 ? range.start.row - 1 : 0;
   const startWidth = editor.lineTextForBufferRow(startRow).length;
+  const endRow =
+    range.end.row == editor.getLastBufferRow()
+      ? range.end.row
+      : range.end.row - 1;
+
   return new Range(
     new Point(startRow, startWidth),
-    new Point(range.end.row - 1, range.end.column)
+    new Point(endRow, range.end.column)
   );
 }

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -357,7 +357,7 @@ export function foldAllButCurrentCell(editor: atom$TextEditor) {
   editor.setSelectedBufferRanges(initialSelections);
 }
 
-function adjustCellFoldRange(editor, range) {
+function adjustCellFoldRange(editor: atom$TextEditor, range: atom$Range) {
   const startRow = range.start.row > 0 ? range.start.row - 1 : 0;
   const startWidth = editor.lineTextForBufferRow(startRow).length;
   const endRow =

--- a/lib/main.js
+++ b/lib/main.js
@@ -140,7 +140,9 @@ const Hydrogen = {
         "hydrogen:shutdown-kernel": () =>
           this.handleKernelCommand({ command: "shutdown-kernel" }),
         "hydrogen:toggle-bubble": () => this.toggleBubble(),
-        "hydrogen:export-notebook": () => exportNotebook()
+        "hydrogen:export-notebook": () => exportNotebook(),
+        "hydrogen:fold-current-cell": () => this.foldCurrentCell(),
+        "hydrogen:fold-all-but-current-cell": () => this.foldAllButCurrentCell()
       })
     );
 
@@ -525,6 +527,18 @@ const Hydrogen = {
       }
       this.createResultBubble(editor, code, endRow);
     }
+  },
+
+  foldCurrentCell() {
+    const editor = store.editor;
+    if (!editor) return;
+    codeManager.foldCurrentCell(editor);
+  },
+
+  foldAllButCurrentCell() {
+    const editor = store.editor;
+    if (!editor) return;
+    codeManager.foldAllButCurrentCell(editor);
   },
 
   startZMQKernel() {

--- a/spec/code-manager-spec.js
+++ b/spec/code-manager-spec.js
@@ -115,5 +115,109 @@ describe("CodeManager", () => {
         });
       });
     });
+
+    describe("foldCells", () => {
+      // runAsync is borrowed and modified from link below.
+      // https://github.com/jasmine/jasmine/issues/923#issuecomment-169634461
+      function waitAsync(fn) {
+        return done => {
+          fn().then(done, function rejected(e) {
+            fail(e);
+            done();
+          });
+        };
+      }
+      beforeEach(
+        waitAsync(async () => {
+          await atom.packages.activatePackage("language-python");
+          editor.setGrammar(atom.grammars.grammarForScopeName("source.python"));
+          const code = [
+            "# %% Block 1",
+            "print('hi')",
+            "",
+            "# %% Block 2",
+            "print('hi')",
+            "",
+            "# %% Block 3",
+            "print('hi')"
+          ];
+          editor.setText(code.join("\n") + "\n");
+          // # %% Block 1
+          // print('hi')
+          //
+          // # %% Block 2
+          // print('hi')
+          //
+          // # %% Block 3
+          // print('hi')
+          //
+        })
+      );
+      describe("foldCurrentCell", () => {
+        it("folds cell range correctly", () => {
+          editor.setCursorBufferPosition([1, 0]);
+          CM.foldCurrentCell(editor);
+          const screenRowsExpected = [
+            "# %% Block 1",
+            "# %% Block 2",
+            "print('hi')",
+            "",
+            "# %% Block 3",
+            "print('hi')",
+            ""
+          ];
+          expect(editor.getScreenLineCount()).toEqual(
+            screenRowsExpected.length
+          );
+          for (var i = 0; i < screenRowsExpected.length; i++) {
+            expect(editor.lineTextForScreenRow(i).trim()).toEqual(
+              screenRowsExpected[i]
+            );
+          }
+        });
+        it("folds last cell range correctly", () => {
+          editor.setCursorBufferPosition([6, 0]);
+          CM.foldCurrentCell(editor);
+          const screenRowsExpected = [
+            "# %% Block 1",
+            "print('hi')",
+            "",
+            "# %% Block 2",
+            "print('hi')",
+            "",
+            "# %% Block 3"
+          ];
+          expect(editor.getScreenLineCount()).toEqual(
+            screenRowsExpected.length
+          );
+          for (var i = 0; i < screenRowsExpected.length; i++) {
+            expect(editor.lineTextForScreenRow(i).trim()).toEqual(
+              screenRowsExpected[i]
+            );
+          }
+        });
+      });
+      describe("foldAllButCurrentCell", () => {
+        it("folds cell ranges correctly", () => {
+          editor.setCursorBufferPosition([1, 0]);
+          CM.foldAllButCurrentCell(editor);
+          const screenRowsExpected = [
+            "# %% Block 1",
+            "print('hi')",
+            "",
+            "# %% Block 2",
+            "# %% Block 3"
+          ];
+          expect(editor.getScreenLineCount()).toEqual(
+            screenRowsExpected.length
+          );
+          for (var i = 0; i < screenRowsExpected.length; i++) {
+            expect(editor.lineTextForScreenRow(i).trim()).toEqual(
+              screenRowsExpected[i]
+            );
+          }
+        });
+      });
+    });
   });
 });

--- a/types/atom.js.flow
+++ b/types/atom.js.flow
@@ -2063,6 +2063,7 @@ declare class atom$Token {
 
 declare class atom$Selection {
   clear(): void,
+  fold(): void,
   getText(): string,
   getBufferRange(): atom$Range,
   insertText(


### PR DESCRIPTION
Fixes #1001.

This adds two new top-level functions: `hydrogen:fold-current-cell` and `hydrogen:fold-all-but-current-cell`. This uses `codeManager.getCurrentCell` and `codeManager.getCells` to find code cell boundaries, then modifies those boundaries slightly so that the text on the initial line of the cell is still showing.

A couple things to do still:

- [x] Flow types. I'm getting errors from flow IDE that the `selections` property of `TextEditor` is missing. Do I have to add that to `atom.js.flow`?
- [x] Tests. I don't really know how to add these. I'll try to decipher the current code in `code-manager-spec.js`, but might need some guidance on that too.
- [x] Javascript style. This is my first non-trivial change in the Javascript, so I figure I should make sure the general style is ok. Like if I'm creating an array to be filled in with a for loop, should it be initialized with `var` or `let`?

![codecell_folding](https://user-images.githubusercontent.com/15164633/47398574-a1d81700-d702-11e8-815f-aeeeedfb258f.gif)
