### PR TITLE
Update Atom flow type definitions

### DIFF
--- a/types/atom.js.flow
+++ b/types/atom.js.flow
@@ -55,6 +55,13 @@ type atom$Octicon = 'alert' | 'alignment-align' | 'alignment-aligned-to' | 'alig
 
 type atom$PaneLocation = 'left' | 'right' | 'bottom' | 'center';
 
+declare type atom$Color  = {
+  // Returns a String in the form '#abcdef'.
+  toHexString(): string;
+  // Returns a String in the form 'rgba(25, 50, 75, .9)'.
+  toRGBAString(): string;
+}
+
 declare class atom$Model {
   destroy(): void,
   isDestroyed(): boolean,
@@ -64,6 +71,7 @@ declare class atom$Package {
   path: string,
   activateTime: number,
   mainModule: any,
+  mainModulePath: string,
   metadata: Object,
   name: string,
   loadTime: number,
@@ -74,7 +82,9 @@ declare class atom$Package {
   onDidDeactivate(cb: () => mixed): IDisposable,
   activateNow(): void,
   // Undocumented
+  bundledPackage: boolean,
   getCanDeferMainModuleRequireStorageKey(): string,
+  initializeIfNeeded(): void,
 }
 
 /**
@@ -117,13 +127,18 @@ declare class atom$CommandRegistry {
 
 declare class atom$CompositeDisposable {
   constructor(...disposables: Array<IDisposable>): void,
-  disposables: ?Set<IDisposable>,
   dispose(): void,
 
   add(...disposables: Array<IDisposable>): void,
   remove(disposable: IDisposable): void,
   clear(): void,
 }
+
+type atom$ConfigParams = {
+  saveCallback?: Object => void,
+  mainSource?: string,
+  projectHomeSchema?: atom$ConfigSchema,
+};
 
 type atom$ConfigType =
   'boolean' | 'string' | 'integer' | 'number' |
@@ -140,18 +155,27 @@ type atom$ConfigSchema = {
   type: Array<atom$ConfigType> | atom$ConfigType,
 };
 
-  declare class atom$Config {
+declare class atom$Config {
+  defaultSettings: Object,
+  settings: Object,
+
   // Config Subscription
   observe(
     keyPath: string,
-    optionsOrCallback?: Object | (value: any) => void,
-    callback?: (value: any) => void
+    optionsOrCallback?:
+      | {scope?: atom$ScopeDescriptorLike}
+      | (value: mixed) => void,
+    callback?: (value: mixed) => mixed,
   ): IDisposable,
 
   onDidChange(
-    keyPathOrCallback: string | (event: Object) => void,
-    optionsOrCallback?: Object | (event: Object) => void,
-    callback?: (event: Object) => void
+    keyPathOrCallback:
+      | string
+      | (event: {oldValue: mixed, newValue: mixed}) => mixed,
+    optionsOrCallback?:
+      | {scope?: atom$ScopeDescriptorLike}
+      | (event: {oldValue: mixed, newValue: mixed}) => mixed,
+    callback?: (event: {oldValue: mixed, newValue: mixed}) => mixed
   ): IDisposable,
 
   // Managing Settings
@@ -160,7 +184,7 @@ type atom$ConfigSchema = {
     options?: {
       excludeSources?: Array<string>,
       sources?: Array<string>,
-      scope?: Object,
+      scope?: atom$ScopeDescriptorLike,
     }
   ): mixed,
 
@@ -184,6 +208,7 @@ type atom$ConfigSchema = {
   getUserConfigPath(): string,
 
   // Undocumented Methods
+  constructor(params?: atom$ConfigParams): atom$Config,
   getRawValue(keyPath: ?string, options: {excludeSources?: string, sources?: string}): mixed,
   getSchema(keyPath: string): atom$ConfigSchema,
   save(): void,
@@ -193,6 +218,9 @@ type atom$ConfigSchema = {
     schema: atom$ConfigSchema,
   ): void,
   removeAtKeyPath(keyPath: ?string, value: ?mixed): mixed,
+
+  // Used by nuclide-config to set the initial settings from disk
+  resetUserSettings(newSettings: Object, options?: {source?: string}): void,
 }
 
 declare class atom$Cursor {
@@ -214,7 +242,6 @@ declare class atom$Cursor {
   getBufferPosition(): atom$Point,
 
   // Cursor Position Details
-  getIndentLevel(): number,
   // Moving the Cursor
 
   // Local Positions and Ranges
@@ -242,18 +269,31 @@ declare class atom$DisplayMarkerLayer {
   destroy(): void,
   clear(): void,
   isDestroyed(): boolean,
-  markBufferRange(range: atom$Range | atom$RangeLike, options: MarkerOptions): atom$Marker,
+  markBufferPosition(position: atom$PointLike, options?: MarkerOptions): atom$Marker,
+  markBufferRange(range: atom$Range | atom$RangeLike, options?: MarkerOptions): atom$Marker,
+  findMarkers(options: MarkerOptions): Array<atom$Marker>,
   getMarkers(): Array<atom$Marker>,
+  onDidUpdate(callback: () => mixed): IDisposable
+}
+
+declare class atom$LayerDecoration {
+  destroy(): void,
+  isDestroyed(): boolean,
+  getProperties(): Object,
+  setProperties(properties: mixed): void,
+  setPropertiesForMarker(marker: atom$Marker, properties: mixed): void,
 }
 
 declare class atom$Disposable {
   constructor(disposalAction?: (...args: Array<any>) => any): void,
+  disposed: boolean,
   dispose(): void,
 }
 
 declare class atom$Emitter {
   dispose(): void,
   on(name: string, callback: (v: any) => mixed): IDisposable,
+  once(name: string, callback: (v: any) => mixed): IDisposable,
   preempt(name: string, callback: (v: any) => void): IDisposable,
   // This is a flow hack to prevent emitting more than one value.
   // `EventEmitter` allows emitting any number of values - making this a land
@@ -268,31 +308,33 @@ declare class atom$Gutter {
   destroy(): void,
   decorateMarker(
     marker: atom$Marker,
-    options?: {'class'?: string, item?: Object | HTMLElement},
+    options?: {type?: string, 'class'?: string, item?: Object | HTMLElement},
   ): atom$Decoration,
   show(): void,
   hide(): void,
   onDidDestroy(callback: () => void): IDisposable,
 }
 
+declare type atom$MarkerChangeEvent = {
+  oldHeadScreenPosition: atom$Point,
+  newHeadScreenPosition: atom$Point,
+  oldTailScreenPosition: atom$Point,
+  newTailScreenPosition: atom$Point,
+
+  oldHeadBufferPosition: atom$Point,
+  newHeadBufferPosition: atom$Point,
+  oldTailBufferPosition: atom$Point,
+  newTailBufferPosition: atom$Point,
+
+  isValid: boolean,
+  textChanged: boolean,
+}
+
 declare class atom$Marker {
   destroy(): void,
   getBufferRange(): atom$Range,
   getStartBufferPosition(): atom$Point,
-  onDidChange(callback: (event: {
-    oldHeadScreenPosition: atom$Point,
-    newHeadScreenPosition: atom$Point,
-    oldTailScreenPosition: atom$Point,
-    newTailScreenPosition: atom$Point,
-
-    oldHeadBufferPosition: atom$Point,
-    newHeadBufferPosition: atom$Point,
-    oldTailBufferPosition: atom$Point,
-    newTailBufferPosition: atom$Point,
-
-    isValid: boolean,
-    textChanged: boolean,
-  }) => void): IDisposable,
+  onDidChange(callback: (event: atom$MarkerChangeEvent) => mixed): IDisposable,
   isValid(): boolean,
   isDestroyed(): boolean,
   onDidDestroy(callback: () => mixed): IDisposable,
@@ -318,12 +360,15 @@ type atom$PackageMetadata = {
 };
 
 declare class atom$PackageManager {
+  +initialPackagesActivated: boolean,
+
   // Event Subscription
   onDidLoadInitialPackages(callback: () => void): IDisposable,
   onDidActivateInitialPackages(callback: () => void): IDisposable,
   onDidActivatePackage(callback: (pkg: atom$Package) => mixed): IDisposable,
   onDidDeactivatePackage(callback: (pkg: atom$Package) => mixed): IDisposable,
   onDidLoadPackage(callback: (pkg: atom$Package) => mixed): IDisposable,
+  onDidUnloadPackage(callback: (pkg: atom$Package) => mixed): IDisposable,
   onDidTriggerActivationHook(activationHook: string, callback: () => mixed): IDisposable,
 
   // Package system data
@@ -343,6 +388,7 @@ declare class atom$PackageManager {
   getActivePackage(name: string): ?atom$Package,
   getActivePackages(): Array<atom$Package>,
   isPackageActive(name: string): boolean,
+  hasActivatedInitialPackages(): boolean,
 
   // Activating and deactivating packages
   activatePackage(name: string): Promise<atom$Package>,
@@ -404,6 +450,15 @@ type atom$PaneSplitSide = 'before' | 'after';
 // Undocumented class
 declare class atom$applicationDelegate {
   focusWindow(): Promise<mixed>,
+  open(params: {
+    pathsToOpen: Array<string>,
+    newWindow?: boolean,
+    devMode?: boolean,
+    safeMode?: boolean,
+  }): void,
+
+  // Used by nuclide-config to replicate atom.config saveCallback
+  setUserSettings(config: atom$Config, configFilePath: string): Promise<mixed>;
 }
 
 type atom$PaneParams = {
@@ -429,14 +484,14 @@ declare class atom$Pane {
   activateItem(item: Object): ?Object,
   activateItemAtIndex(index: number): void,
   moveItemToPane(item: Object, pane: atom$Pane, index: number): void,
-  destroyItem(item: Object, force?: boolean): boolean | Promise<boolean>,
+  destroyItem(item: Object, force?: boolean): Promise<boolean>,
   itemForURI(uri: string): Object,
 
   // Event subscriptions.
   onDidAddItem(cb: (event: {item: Object, index: number}) => void): IDisposable,
   onDidRemoveItem(cb: (event: {item: Object, index: number}) => void): IDisposable,
   onWillRemoveItem(cb: (event: {item: Object, index: number}) => void): IDisposable,
-  onDidDestroy(cb: () => void): IDisposable,
+  onDidDestroy(cb: () => mixed): IDisposable,
   onDidChangeFlexScale(cb: (newFlexScale: number) => void): IDisposable,
   onWillDestroy(cb: () => void): IDisposable,
   observeActiveItem(cb: (item: ?Object) => void): IDisposable,
@@ -445,6 +500,7 @@ declare class atom$Pane {
   isActive(): boolean,
   activate(): void,
   destroy(): void,
+  isDestroyed(): void,
 
   // Splitting
   splitLeft(params?: atom$PaneSplitParams): atom$Pane,
@@ -459,8 +515,11 @@ declare class atom$Pane {
 
   // Undocumented Methods
   constructor(params: atom$PaneParams): atom$Pane,
+  getPendingItem(): atom$PaneItem,
+  setPendingItem(item: atom$PaneItem): void,
   clearPendingItem(): void,
   getFlexScale(): number,
+  getElement(): HTMLElement,
   getParent(): Object,
   removeItem(item: Object, moved: ?boolean): void,
   setActiveItem(item: Object): Object,
@@ -476,10 +535,12 @@ declare interface atom$PaneItem {
   +getTitle: () => string,
   +getLongTitle?: () => string,
   +getIconName?: () => string,
-  +getURI?: () => string,
+  +getURI?: () => ?string,
   +onDidChangeIcon?: (cb: (icon: string) => void) => IDisposable,
   +onDidChangeTitle?: (cb: (title: string) => void) => IDisposable,
+  +onDidTerminatePendingState?: (() => mixed) => IDisposable;
   +serialize?: () => Object,
+  +terminatePendingState?: () => void,
 }
 
 // Undocumented class
@@ -611,8 +672,9 @@ type atom$StatusBarTile = {
 declare class atom$ScopeDescriptor {
   constructor(object: {scopes: Array<string>}): void,
   getScopesArray(): Array<string>,
-  getScopeChain(): string
 }
+
+type atom$ScopeDescriptorLike = atom$ScopeDescriptor | Array<string>;
 
 /**
  * This API is defined at https://github.com/atom/status-bar.
@@ -684,6 +746,7 @@ type atom$TooltipsAddOptions = {
 };
 
 type atom$Tooltip = {
+  show(): void;
   hide(): void;
   getTooltipElement(): HTMLElement,
 };
@@ -694,6 +757,7 @@ declare class atom$TooltipManager {
     target: HTMLElement,
     options: atom$TooltipsAddOptions,
   ): IDisposable,
+  findTooltips(HTMLElement): Array<atom$Tooltip>,
 }
 
 type InsertTextOptions = {
@@ -731,6 +795,9 @@ type DecorateMarkerParams = {
   type: 'block',
   item: HTMLElement,
   position?: 'before' | 'after', // Defaults to 'before' when unspecified.
+} | {
+  type: 'line-number',
+  class?: string,
 };
 
 type ChangeCursorPositionEvent = {
@@ -742,14 +809,14 @@ type ChangeCursorPositionEvent = {
   cursor: atom$Cursor,
 };
 
-type MarkerOptions = {|
+type MarkerOptions = {
   reversed?: boolean,
   tailed?: boolean,
   invalidate?: 'never' | 'surround' | 'overlap' | 'inside' | 'touch',
   exclusive?: boolean,
-|};
+};
 
-type ChangeSelectionRangeEvent = {|
+type atom$ChangeSelectionRangeEvent = {|
   oldBufferRange: atom$Range,
   oldScreenRange: atom$Range,
   newBufferRange: atom$Range,
@@ -758,33 +825,25 @@ type ChangeSelectionRangeEvent = {|
 |};
 
 declare class atom$TextEditor extends atom$Model {
-  constructor(params?: atom$TextEditorParams): atom$TextEditor,
-  // Undocumented properties
-  languageMode: atom$LanguageMode,
-  element: atom$TextEditorElement,
-  width: number,
-
   id: number,
   verticalScrollMargin: number,
 
   // Event Subscription
-  onDidChangeTitle(callback: (title: string) => void): IDisposable,
   onDidChange(callback: () => void): IDisposable,
   onDidChangePath(callback: (newPath: string) => mixed): IDisposable,
-  onDidStopChanging(callback: () => void): IDisposable,
+  onDidStopChanging(callback: () => mixed): IDisposable,
   onDidChangeCursorPosition(callback: (event: ChangeCursorPositionEvent) => mixed):
     IDisposable,
   onDidDestroy(callback: () => mixed): IDisposable,
   onDidSave(callback: (event: {path: string}) => mixed): IDisposable,
   getBuffer(): atom$TextBuffer,
   observeGrammar(callback: (grammar: atom$Grammar) => mixed): IDisposable,
-  onDidChangeGrammar(callback: (grammar: atom$Grammar) => mixed): IDisposable,
   onWillInsertText(callback: (event: {cancel: () => void, text: string}) => void):
       IDisposable,
   // Note that the range property of the event is undocumented.
   onDidInsertText(callback: (event: {text: string, range: atom$Range}) => mixed): IDisposable,
   onDidChangeSoftWrapped(callback: (softWrapped: boolean) => mixed): IDisposable,
-  onDidChangeSelectionRange(callback: (event: ChangeSelectionRangeEvent) => mixed): IDisposable,
+  onDidChangeSelectionRange(callback: (event: atom$ChangeSelectionRangeEvent) => mixed): IDisposable,
   observeSelections(callback: (selection: atom$Selection) => mixed): IDisposable,
 
   // File Details
@@ -804,6 +863,9 @@ declare class atom$TextEditor extends atom$Model {
   setEncoding(encoding: string): void,
   getTabLength() : number,
   getSoftTabs(): boolean,
+  getIconName(): string,
+  onDidChangeIcon(cb: (icon: string) => void): IDisposable,
+  onDidChangeTitle(cb: (title: string) => void): IDisposable,
 
   // File Operations
   save(): Promise<void>,
@@ -814,11 +876,12 @@ declare class atom$TextEditor extends atom$Model {
   getText(): string,
   getTextInBufferRange(range: atom$RangeLike): string,
   getLineCount(): number,
+  getLastScreenRow(): number,
 
   // Mutating Text
   setText(text: string, options?: InsertTextOptions): void,
   setTextInBufferRange(
-    range: atom$Range | Array<atom$Point>,
+    range: atom$RangeLike,
     text: string,
     options?: {
       normalizeLineEndings?: boolean,
@@ -834,8 +897,10 @@ declare class atom$TextEditor extends atom$Model {
   // History
   createCheckpoint(): atom$TextBufferCheckpoint,
   revertToCheckpoint(checkpoint: atom$TextBufferCheckpoint): boolean,
+  terminatePendingState(): void,
   transact(fn: () => mixed, _: void): void,
   transact(groupingInterval: number, fn: () => mixed): void,
+  onDidTerminatePendingState(() => mixed): IDisposable;
 
   // TextEditor Coordinates
   screenPositionForBufferPosition(
@@ -861,6 +926,10 @@ declare class atom$TextEditor extends atom$Model {
 
   // Decorations
   decorateMarker(marker: atom$Marker, decorationParams: DecorateMarkerParams): atom$Decoration,
+  decorateMarkerLayer(
+    markerLayer: atom$DisplayMarkerLayer,
+    decorationParams: DecorateMarkerParams,
+  ): atom$LayerDecoration,
   decorationsForScreenRowRange(
     startScreenRow: number,
     endScreenRow: number,
@@ -868,11 +937,14 @@ declare class atom$TextEditor extends atom$Model {
   getDecorations(options?: {class?: string, type?: string}): Array<atom$Decoration>,
 
   // Markers
+  addMarkerLayer(): atom$DisplayMarkerLayer,
   getDefaultMarkerLayer(): atom$DisplayMarkerLayer,
   markBufferPosition(position: atom$PointLike, options?: MarkerOptions): atom$Marker,
   markBufferRange(range: atom$RangeLike, options?: MarkerOptions): atom$Marker,
   markScreenRange(range: atom$RangeLike, options?: MarkerOptions): atom$Marker,
   markScreenPosition(position: atom$PointLike, options?: MarkerOptions): atom$Marker,
+  findMarkers(options: MarkerOptions): Array<atom$Marker>,
+  getMarkerCount(): number,
 
   // Cursors
   getCursors(): Array<atom$Cursor>,
@@ -890,7 +962,6 @@ declare class atom$TextEditor extends atom$Model {
   getCursorScreenPositions(): Array<atom$Point>,
   getLastCursor(): atom$Cursor,
   addCursorAtBufferPosition(point: atom$PointLike): atom$Cursor,
-  getLastSelection(): atom$Selection,
   moveToBeginningOfLine(): void,
   moveToEndOfLine(): void,
   moveToBottom(): void,
@@ -922,6 +993,7 @@ declare class atom$TextEditor extends atom$Model {
       preserveFolds?: boolean,
     },
   ): void,
+  selectWordsContainingCursors(): void,
 
   // Folds
   unfoldAll(): void,
@@ -966,8 +1038,10 @@ declare class atom$TextEditor extends atom$Model {
 
   // Clipboard Operations
   pasteText: (options?: Object) => void,
+  copySelectedText: () => void,
 
   // Managing Syntax Scopes
+  getRootScopeDescriptor(): atom$ScopeDescriptor,
   scopeDescriptorForBufferPosition(
     bufferPosition: atom$PointLike,
   ): atom$ScopeDescriptor,
@@ -983,9 +1057,6 @@ declare class atom$TextEditor extends atom$Model {
   gutterWithName(name: string): ?atom$Gutter,
 
   // Scrolling the TextEditor
-  scrollToCursorPosition(
-    options?: {center?: boolean}
-  ): void,
   scrollToBufferPosition(
     position: atom$Point | [?number, ?number],
     options?: {center?: boolean}
@@ -1018,16 +1089,13 @@ declare class atom$TextEditor extends atom$Model {
   getElement(): atom$TextEditorElement,
   getDefaultCharWidth(): number,
   getLineHeightInPixels(): number,
-  getEditorWidthInChars(): number,
   moveToTop(): void,
   tokenForBufferPosition(position: atom$Point | [?number, ?number]): atom$Token,
   onDidConflict(callback: () => void): IDisposable,
-  serialize: () => mixed,
+  serialize(): Object,
   foldBufferRowRange(startRow: number, endRow: number): void,
-  getNonWordCharacters(scope?: atom$ScopeDescriptor): string,
-  isBufferRowCommented(row: number): boolean,
-  getRootScopeDescriptor(): atom$ScopeDescriptor,
-  isFoldableAtBufferRow(row: number): boolean,
+  getNonWordCharacters(position?: atom$PointLike): string,
+  scheduleComponentUpdate(): void,
 }
 
 /**
@@ -1055,6 +1123,12 @@ declare class atom$TextEditorComponent {
   invalidateBlockDecorationDimensions(decoration: atom$Decoration): void,
   element: atom$TextEditorElement,
   didFocus(): void,
+  setScrollTop(scrollTop: number): void,
+  getScrollTop(): number,
+
+  setScrollLeft(scrollLeft: number): void,
+  getScrollLeft(): number,
+  updateSync(useScheduler?: boolean): void,
 }
 
 /**
@@ -1127,8 +1201,6 @@ declare class atom$TextEditorElement extends HTMLElement {
   // `undefined` means no explicit width. `null` sets a zero width (which is almost certainly a
   // mistake) so we don't allow it.
   setWidth(width: number | void): void,
-
-  getWidth(): number,
 }
 
 declare class atom$ViewProvider {
@@ -1187,11 +1259,22 @@ type AddTextEditorEvent = {
   index: number,
 };
 
+type atom$WorkspaceOpenOptions = {
+  activatePane?: ?boolean,
+  activateItem?: ?boolean,
+  initialLine?: ?number,
+  initialColumn?: ?number,
+  pending?: ?boolean,
+  split?: ?string,
+  searchAllPanes?: ?boolean,
+  location?: atom$PaneLocation,
+}
+
 declare class atom$Workspace {
   // Event Subscription
   observePanes(cb: (pane: atom$Pane) => void): IDisposable,
   observeTextEditors(callback: (editor: atom$TextEditor) => mixed): IDisposable,
-  observeActiveTextEditor(callback: (editor: atom$TextEditor) => mixed): IDisposable,
+  observeActiveTextEditor(callback: (editor: ?atom$TextEditor) => mixed): IDisposable,
   onDidAddTextEditor(callback: (event: AddTextEditorEvent) => mixed): IDisposable,
   onDidChangeActivePaneItem(callback: (item: mixed) => mixed): IDisposable,
   onDidDestroyPaneItem(callback: (event: DestroyPaneItemEvent) => mixed): IDisposable,
@@ -1209,14 +1292,7 @@ declare class atom$Workspace {
   // Opening
   open(
     uri?: string,
-    options?: {
-      activatePane?: ?boolean,
-      initialLine?: ?number,
-      initialColumn?: ?number,
-      pending?: ?boolean,
-      split?: ?string,
-      searchAllPanes?: ?boolean,
-    }
+    options?: atom$WorkspaceOpenOptions,
   ): Promise<atom$TextEditor>,
   openURIInPane(
     uri?: string,
@@ -1228,11 +1304,9 @@ declare class atom$Workspace {
       searchAllPanes?: boolean,
     }
   ): Promise<atom$TextEditor>,
-  toggle(itemOrURI: string | atom$PaneItem): boolean,
-  hide(itemOrURI: string | atom$PaneItem): boolean,
   isTextEditor(item: ?mixed): boolean,
   /* Optional method because this was added post-1.0. */
-  buildTextEditor: ((params: atom$TextEditorParams) => atom$TextEditor),
+  buildTextEditor: ((params: ?atom$TextEditorParams) => atom$TextEditor),
   /* Optional method because this was added in 1.9.0 */
   handleGrammarUsed?: (grammar: atom$Grammar) => void,
   reopenItem(): Promise<?atom$TextEditor>,
@@ -1247,18 +1321,19 @@ declare class atom$Workspace {
   // Pane Items
   getPaneItems(): Array<Object>,
   getActivePaneItem(): ?Object,
+  getActivePaneContainer(): atom$PaneContainer,
   getTextEditors(): Array<atom$TextEditor>,
   getActiveTextEditor(): ?atom$TextEditor,
+  createItemForURI(uri: string, options: atom$WorkspaceOpenOptions): atom$PaneItem,
 
   // Panes
   getPanes(): Array<atom$Pane>,
   getActivePane(): atom$Pane,
   activateNextPane(): boolean,
   activatePreviousPane(): boolean,
-  paneForURI(uri: string): ?atom$Pane,
+  paneForURI(uri: string): atom$Pane,
   paneForItem(item: mixed): ?atom$Pane,
-  paneContainerForItem(item: mixed): ?atom$Dock | ?atom$WorkspaceCenter,
-  paneContainerForURI(uri: string): ?atom$Dock | ?atom$WorkspaceCenter,
+  paneContainers: {[location: atom$PaneLocation]: atom$AbstractPaneContainer},
 
   // Panels
   panelContainers: {[location: string]: atom$PanelContainer},
@@ -1272,6 +1347,8 @@ declare class atom$Workspace {
   addTopPanel(options: atom$WorkspaceAddPanelOptions): atom$Panel,
   getModalPanels(): Array<atom$Panel>,
   addModalPanel(options: atom$WorkspaceAddPanelOptions): atom$Panel,
+  getHeaderPanels(): Array<atom$Panel>,
+  addHeaderPanel(options: atom$WorkspaceAddPanelOptions): atom$Panel,
 
   getLeftDock(): atom$Dock,
   getRightDock(): atom$Dock,
@@ -1340,9 +1417,15 @@ declare class atom$WorkspaceCenter extends atom$AbstractPaneContainer {
 
   observeActivePaneItem(callback: atom$PaneItem => mixed): IDisposable;
   onDidChangeActivePaneItem(callback: (item: mixed) => mixed): IDisposable;
+  onDidAddTextEditor(
+    callback: (item: {
+      textEditor: atom$TextEditor,
+      pane: atom$Pane,
+      index: number,
+    }) => mixed,
+  ): IDisposable;
   // This should be removed soon anyway, it's currently deprecated.
   paneContainer: Object;
-  paneForItem(item: mixed): ?atom$Pane;
 }
 
 /**
@@ -1513,6 +1596,13 @@ declare class atom$Grammar {
   name: string,
   scopeName: string,
   tokenizeLines(text: string): Array<Array<atom$GrammarToken>>,
+  tokenizeLine(line: string, ruleStack: mixed, firstLine: boolean): {
+    line: string,
+    tags: Array<number>,
+    // Dynamic property: invoking it will incur additional overhead
+    tokens: Array<atom$GrammarToken>,
+    ruleStack: mixed
+  },
 }
 
 type atom$GrammarToken = {
@@ -1529,6 +1619,12 @@ declare class atom$GrammarRegistry {
   removeGrammarForScopeName(scopeName: string): ?atom$Grammar,
   loadGrammarSync(grammarPath: string): atom$Grammar,
   selectGrammar(filePath: string, fileContents: string): atom$Grammar,
+  autoAssignLanguageMode(buffer: atom$TextBuffer): void,
+  assignLanguageMode(buffer: atom$TextBuffer, languageId: string): void,
+
+  // Extended
+  getGrammarScore(grammar: atom$Grammar, filePath: string, contents?: string): number,
+  forEachGrammar(callback: (grammar: atom$Grammar) => mixed): void,
 
   // Private API
   clear(): IDisposable,
@@ -1590,6 +1686,7 @@ declare class atom$KeymapManager {
 
   // Adding and Removing Bindings
   add(source: string, bindings: Object): IDisposable,
+  removeBindingsFromSource(source: string): void,
 
   // Accessing Bindings
   getKeyBindings(): Array<atom$KeyBinding>,
@@ -1628,19 +1725,30 @@ declare class atom$MenuManager {
   template: Array<Object>,
 }
 
+type atom$ProjectSpecification = {
+  originPath: string,
+  paths?: Array<string>,
+  config?: {[string]: mixed}
+};
+
 declare class atom$Project {
   // Event Subscription
   onDidChangePaths(callback: (projectPaths: Array<string>) => mixed): IDisposable,
   onDidAddBuffer(callback: (buffer: atom$TextBuffer) => mixed): IDisposable,
+  onDidReplace((settings: atom$ProjectSpecification) => mixed): IDisposable,
   observeBuffers(callback: (buffer: atom$TextBuffer) => mixed): IDisposable,
-
+  replace?: (newSettings: atom$ProjectSpecification) => void,
   // Accessing the git repository
   getRepositories(): Array<?atom$Repository>,
   repositoryForDirectory(directory: atom$Directory): Promise<?atom$Repository>,
 
   // Managing Paths
   getPaths(): Array<string>,
-  addPath(projectPath: string): void,
+  addPath(projectPath: string, options?: {
+    emitEvent?: boolean,
+    exact?: boolean,
+    mustExist?: boolean,
+  }): void,
   setPaths(paths: Array<string>): void,
   removePath(projectPath: string): void,
   getDirectories(): Array<atom$Directory>,
@@ -1679,6 +1787,10 @@ type atom$TextEditEvent = {
 type atom$AggregatedTextEditEvent = {
   changes: Array<atom$TextEditEvent>,
 };
+
+declare class atom$LanguageMode {
+  getLanguageId(): string,
+}
 
 declare class atom$TextBuffer {
   constructor(text?: string): atom$TextBuffer,
@@ -1721,6 +1833,7 @@ declare class atom$TextBuffer {
   getEncoding(): string,
   getUri(): string,
   getId(): string,
+  getLanguageMode(): atom$LanguageMode,
 
   // Reading Text
   isEmpty(): boolean,
@@ -1776,7 +1889,7 @@ declare class atom$TextBuffer {
   getLastRow(): number,
   getRange(): atom$Range,
   rangeForRow(row: number, includeNewLine?: boolean): atom$Range,
-getEndPosition(): atom$Point,
+  getLength(): number,
 
   // Position/Index mapping
   characterIndexForPosition(position: atom$PointLike): number,
@@ -1815,6 +1928,7 @@ declare class atom$Notification {
   getMessage(): string,
   getOptions(): Object,
   dismiss(): void,
+  isDismissed(): boolean,
 }
 
 type atom$NotificationButton = {
@@ -1828,6 +1942,7 @@ type atom$NotificationOptions = {
   dismissable?: boolean,
   description?: string,
   icon?: string,
+  stack?: string,
   buttons?: Array<atom$NotificationButton>,
 };
 
@@ -1842,6 +1957,7 @@ declare class atom$NotificationManager {
   addWarning(message: string, options?: atom$NotificationOptions): atom$Notification,
   addError(message: string, options?: atom$NotificationOptions): atom$Notification,
   addFatalError(message: string, options?: atom$NotificationOptions): atom$Notification,
+  addNotification(notification: atom$Notification): atom$Notification,
 
   // Getting Notifications
   getNotifications(): Array<atom$Notification>,
@@ -1924,11 +2040,21 @@ type AtomGlobal = {
   getCurrentWindow: void,
 
   // Messaging the User
-  confirm(options: {
-    buttons?: Array<string> | {[buttonName: string]: () => mixed},
-    detailedMessage?: string,
-    message: string,
-  }): ?number,
+  +confirm:
+    & ((
+      {
+        message: string,
+        detail?: string,
+        buttons?: Array<string>,
+      },
+      (number) => void,
+    ) => void)
+    // The synchronous form. You really shouldn't use this.
+    & (({
+        message: string,
+        detailedMessage?: string,
+        buttons?: Array<string> | {[buttonName: string]: () => mixed},
+      }) => ?number),
 
   open(params: {
     pathsToOpen?: Array<string>,
@@ -2022,13 +2148,14 @@ type atom$AutocompleteSuggestion = {
   className?: ?string,
   iconHTML?: ?string,
   description?: ?string,
+  descriptionMarkdown?: ?string,
   descriptionMoreURL?: ?string,
 };
 
 type atom$AutocompleteRequest = {
   editor: TextEditor,
   bufferPosition: atom$Point,
-  scopeDescriptor: string,
+  scopeDescriptor: atom$ScopeDescriptor,
   prefix: string,
   activatedManually?: boolean,
 };
@@ -2038,6 +2165,9 @@ type atom$AutocompleteProvider = {
   +getSuggestions: (
     request: atom$AutocompleteRequest,
   ) => Promise<?Array<atom$AutocompleteSuggestion>> | ?Array<atom$AutocompleteSuggestion>,
+  +getSuggestionDetailsOnSelect?: (
+    suggestion: atom$AutocompleteSuggestion
+  ) => Promise<?atom$AutocompleteSuggestion>,
   +disableForSelector?: string,
   +inclusionPriority?: number,
   +excludeLowerPriority?: boolean,
@@ -2054,6 +2184,12 @@ type atom$SuggestionInsertedRequest = {
   +triggerPosition: atom$Point,
   +suggestion: atom$AutocompleteSuggestion,
 };
+
+// https://github.com/atom/autocomplete-plus/blob/master/README.md#the-watcheditor-api
+type atom$AutocompleteWatchEditor = (
+  editor: atom$TextEditor,
+  labels?: Array<string>,
+) => IDisposable;
 
 // Undocumented API.
 declare class atom$Token {
@@ -2076,13 +2212,6 @@ declare class atom$Selection {
       undo?: boolean,
     },
   ): string,
-  getBufferRowRange(): [number, number]
-}
-
-declare class atom$LanguageMode {
- constructor(editor: atom$TextEditor) : void,
- buffer: atom$TextBuffer,
- rowRangeForCodeFoldAtBufferRow(row: number): ?Array<number>, // Returns an {Array} of the [startRow, endRow]. Returns null if no range.
 }
 
 declare class atom$PanelContainer {


### PR DESCRIPTION
This PR includes updated Atom flow type definitions from Nuclide: https://github.com/facebook/nuclide/blob/master/flow-libs/electron-v2.0.9.js.flow

#1458 uses a part of the selections API that didn't exist in the previous set of type definitions.