### PR TITLE
Add option to show Hydrogen's autocomplete suggestions first

### DIFF
--- a/lib/autocomplete-provider.js
+++ b/lib/autocomplete-provider.js
@@ -76,6 +76,9 @@ export default function() {
     // priority.
     // The default provider has a priority of 0.
     inclusionPriority: 1,
+    suggestionPriority: atom.config.get("Hydrogen.showAutocompleteFirst")
+      ? 3
+      : 1,
     excludeLowerPriority: false,
 
     // Required: Return a promise, an array of suggestions, or null.

--- a/lib/config.js
+++ b/lib/config.js
@@ -23,6 +23,14 @@ const Config = {
       type: "boolean",
       default: true
     },
+    showAutocompleteFirst: {
+      title: "Show Hydrogen's autocomplete suggestions first",
+      includeTitle: false,
+      description:
+        "If enabled, Hydrogen's autocomplete suggestions will be listed before those of other providers, like snippets.",
+      type: "boolean",
+      default: true
+    },
     autoScroll: {
       title: "Enable Autoscroll",
       includeTitle: false,


### PR DESCRIPTION
Fixes https://github.com/nteract/hydrogen/issues/1455.

To me, I usually find autocomplete suggestions from Hydrogen to be more accurate than other providers or snippets. This adds a setting in the configuration (currently on by default) to set the `suggestionPriority` higher than that of the Snippets autocomplete provider.