### PR TITLE
Require cell regex to be at beginning of line

### DIFF
--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -135,7 +135,7 @@ export function getRegexString(editor: atom$TextEditor) {
     commentStartString.trimRight()
   );
 
-  const regexString = `${escapedCommentStartString}(%%| %%| <codecell>| In\[[0-9 ]*\]:?)`;
+  const regexString = `^\s*${escapedCommentStartString}(%%| %%| <codecell>| In\[[0-9 ]*\]:?)`;
 
   return regexString;
 }

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -135,7 +135,7 @@ export function getRegexString(editor: atom$TextEditor) {
     commentStartString.trimRight()
   );
 
-  const regexString = `^\s*${escapedCommentStartString}(%%| %%| <codecell>| In\[[0-9 ]*\]:?)`;
+  const regexString = `^\\s*${escapedCommentStartString}(%%| %%| <codecell>| In\[[0-9 ]*\]:?)`;
 
   return regexString;
 }


### PR DESCRIPTION
Currently, the regular expression used to delimit cells matches the comment symbol plus `%%` or other symbols _anywhere_ on the line. That means that using `export-notebook` on the following splits the string:
```py
# %%

import pandas as pd
import numpy as np

print('# %%')
print('this should be one cell')
```

Before:
![image](https://user-images.githubusercontent.com/15164633/47889937-d8a8de00-de22-11e8-8982-52a7de62b67f.png)

After:
![image](https://user-images.githubusercontent.com/15164633/47889943-dfcfec00-de22-11e8-81ba-099a5ad9ea9e.png)

Presumably, `run-cell` would also fail on this.