### PR TITLE
:fire: old unused config

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -14,7 +14,6 @@ const Config = {
   },
 
   schema: {
-    kernelspec: {},
     autocomplete: {
       title: "Enable Autocomplete",
       includeTitle: false,


### PR DESCRIPTION
This causes a warning message that shows up in unrelated issue error logs.