### PR TITLE
Prompt for installed plugins in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -17,6 +17,11 @@ Which OS and which version of Hydrogen and Atom are you running?
 
 You can get this information from copy and pasting the output of `atom --version`  from the command line.
 
+Do you have any Hydrogen plugins installed and active?
+- [ ] hydrogen-python
+- [ ] Hydrogen Launcher
+- [ ] Data Explorer
+
 **Logs:**
 
 Please post any error logs and the output of the developer tools as described in our [Debugging Guide](https://nteract.gitbooks.io/hydrogen/docs/Troubleshooting.html).


### PR DESCRIPTION
With the growing popularity of hydrogen-python, it would be good to have a section of the bug report template that explicitly asks if any plugins are installed.