### PR TITLE
Add new grammars to list of markupGrammars

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -113,7 +113,9 @@ const markupGrammars = new Set([
   "source.pweave.noweb",
   "source.pweave.md",
   "source.pweave.latex",
-  "source.pweave.restructuredtext"
+  "source.pweave.restructuredtext",
+  "source.dyndoc.md.stata",
+  "source.dyndoc.latex.stata"
 ]);
 
 export function isMultilanguageGrammar(grammar: atom$Grammar) {


### PR DESCRIPTION
This PR just adds two new grammar names to the list of `markupGrammars` that Hydrogen will run code inside of. This should have no side effects. Fixes https://github.com/kylebarron/stata_kernel/issues/186