### PR TITLE
Update Altair example in docs

### DIFF
--- a/docs/Usage/Examples.md
+++ b/docs/Usage/Examples.md
@@ -70,6 +70,28 @@ t = np.linspace(0, 20, 500)
 
 plt.plot(t, np.sin(t))
 plt.show()
+{%- language name="Python using altair >= 2.0", type="py" -%}
+import altair as alt
+from vega_datasets import data
+
+iris = data.iris()
+
+alt.Chart(iris).mark_point().encode(
+    x='petalLength',
+    y='petalWidth',
+    color='species'
+)
+{%- language name="Python using altair >= v1.3 < 2.0", type="py" -%}
+from altair import Chart, load_dataset, enable_mime_rendering
+enable_mime_rendering()
+
+cars = load_dataset('cars')
+spec = Chart(cars).mark_point().encode(
+    x='Horsepower',
+    y='Miles_per_Gallon',
+    color='Origin',
+)
+spec
 {%- language name="Python using altair < v1.3", type="py" -%}
 from IPython.display import display
 from altair import Chart, load_dataset
@@ -84,19 +106,7 @@ spec = Chart(cars).mark_point().encode(
     y='Miles_per_Gallon',
     color='Origin',
 )
-
 vegify(spec)
-{%- language name="Python using altair v1.3+", type="py" -%}
-from altair import Chart, load_dataset, enable_mime_rendering
-enable_mime_rendering()
-
-cars = load_dataset('cars')
-spec = Chart(cars).mark_point().encode(
-    x='Horsepower',
-    y='Miles_per_Gallon',
-    color='Origin',
-)
-spec
 {%- endcodetabs %}
 
 ## LaTeX
@@ -170,7 +180,7 @@ print("Hello World!")
 console.log("Hello World!");
 {%- endcodetabs %}
 
-## Automatic visualization with the nteract [Data Explorer](https://blog.nteract.io/designing-the-nteract-data-explorer-f4476d53f897) 
+## Automatic visualization with the nteract [Data Explorer](https://blog.nteract.io/designing-the-nteract-data-explorer-f4476d53f897)
 
 {% codetabs name="Python", type="py" -%}
 import pandas as pd
@@ -185,7 +195,7 @@ df1 = pd.read_csv(iris_url)
 
 df1
 {%- endcodetabs %}
-(https://blog.nteract.io/designing-the-nteract-data-explorer-f4476d53f897) 
+(https://blog.nteract.io/designing-the-nteract-data-explorer-f4476d53f897)
 
 {% codetabs name="Python", type="py" -%}
 import pandas as pd


### PR DESCRIPTION
Fixes https://github.com/nteract/hydrogen/issues/1481.

I couldn't figure out how to downgrade from Altair 2.2.2 to Altair 2.0 (I tried creating a conda environment, but even when starting Atom from the terminal with the env active, Python was still finding Altair 2.2.2), so I think the example given works back to 2.0.