### PR TITLE
Remove duplicated data explorer docs example

### DIFF
--- a/docs/Usage/Examples.md
+++ b/docs/Usage/Examples.md
@@ -196,17 +196,3 @@ df1 = pd.read_csv(iris_url)
 df1
 {%- endcodetabs %}
 (https://blog.nteract.io/designing-the-nteract-data-explorer-f4476d53f897)
-
-{% codetabs name="Python", type="py" -%}
-import pandas as pd
-
-pd.options.display.html.table_schema = True
-pd.options.display.max_rows = None
-
-
-iris_url = "https://archive.ics.uci.edu/ml/machine-learning-databases/iris/iris.data"
-
-df1 = pd.read_csv(iris_url)
-
-df1
-{%- endcodetabs %}


### PR DESCRIPTION
The data explorer example is listed twice
![image](https://user-images.githubusercontent.com/15164633/49744702-628e6700-fc6b-11e8-93fc-d0b097a92c83.png)
