### PR TITLE
Toggle hydrogen output mode

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -1,7 +1,14 @@
 /* @flow */
 
-import { log, reactFactory, INSPECTOR_URI } from "./utils";
+import {
+  log,
+  reactFactory,
+  INSPECTOR_URI,
+  OUTPUT_AREA_URI,
+  openOrShowDock
+} from "./utils";
 import { getCodeToInspect } from "./code-manager";
+import OutputPane from "./panes/output-area";
 
 import typeof store from "./store";
 
@@ -33,4 +40,17 @@ export function toggleInspector(store: store) {
       kernel.setInspectorResult(result.data, editor);
     }
   );
+}
+
+export function toggleOutputMode(): void {
+  // There should never be more than one instance of OutputArea
+  const outputArea = atom.workspace
+    .getPaneItems()
+    .find(paneItem => paneItem instanceof OutputPane);
+
+  if (outputArea) {
+    return outputArea.destroy();
+  } else {
+    openOrShowDock(OUTPUT_AREA_URI);
+  }
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -27,7 +27,7 @@ import WatchesPane from "./panes/watches";
 import OutputPane from "./panes/output-area";
 import KernelMonitorPane from "./panes/kernel-monitor";
 
-import { toggleInspector } from "./commands";
+import { toggleInspector, toggleOutputMode } from "./commands";
 
 import store from "./store";
 import OutputStore from "./store/output";
@@ -111,6 +111,7 @@ const Hydrogen = {
         "hydrogen:toggle-watches": () => atom.workspace.toggle(WATCHES_URI),
         "hydrogen:toggle-output-area": () =>
           atom.workspace.toggle(OUTPUT_AREA_URI),
+        "hydrogen:toggle-output-mode": () => toggleOutputMode(),
         "hydrogen:toggle-kernel-monitor": () =>
           atom.workspace.toggle(KERNEL_MONITOR_URI),
         "hydrogen:start-local-kernel": () => this.startZMQKernel(),

--- a/lib/main.js
+++ b/lib/main.js
@@ -109,9 +109,7 @@ const Hydrogen = {
         "hydrogen:run-cell": () => this.runCell(),
         "hydrogen:run-cell-and-move-down": () => this.runCell(true),
         "hydrogen:toggle-watches": () => atom.workspace.toggle(WATCHES_URI),
-        "hydrogen:toggle-output-area": () =>
-          atom.workspace.toggle(OUTPUT_AREA_URI),
-        "hydrogen:toggle-output-mode": () => toggleOutputMode(),
+        "hydrogen:toggle-output-area": () => toggleOutputMode(),
         "hydrogen:toggle-kernel-monitor": () =>
           atom.workspace.toggle(KERNEL_MONITOR_URI),
         "hydrogen:start-local-kernel": () => this.startZMQKernel(),

--- a/lib/panes/output-area.js
+++ b/lib/panes/output-area.js
@@ -52,6 +52,12 @@ export default class OutputPane {
 
   destroy() {
     this.disposer.dispose();
-    this.element.remove();
+
+    // When a user manually clicks the close icon, the pane holding the OutputArea
+    // is destroyed along with the OutputArea item. We mimic this here so that we can call
+    //  outputArea.destroy() and fully clean up the OutputArea without user clicking
+    const pane = atom.workspace.paneForURI(OUTPUT_AREA_URI);
+    if (!pane) return;
+    pane.destroyItem(this);
   }
 }

--- a/spec/commands-spec.js
+++ b/spec/commands-spec.js
@@ -1,9 +1,11 @@
 "use babel";
 
 import { Store } from "../lib/store";
-import { toggleInspector } from "../lib/commands";
+import { toggleInspector, toggleOutputMode } from "../lib/commands";
 import KernelTransport from "../lib/kernel-transport";
 import Kernel from "../lib/kernel";
+import { OUTPUT_AREA_URI } from "../lib/utils";
+import OutputPane from "../lib/panes/output-area";
 
 describe("commands", () => {
   let storeMock, mockKernel, filePath, grammar, editor;
@@ -43,6 +45,26 @@ describe("commands", () => {
         codeText.length,
         jasmine.any(Function)
       );
+    });
+  });
+
+  describe("toggle output-area", () => {
+    it("should open the output area if it was not already", () => {
+      spyOn(atom.workspace, "open");
+      spyOn(atom.workspace, "getPaneItems").and.returnValue([]);
+      toggleOutputMode();
+      expect(atom.workspace.open).toHaveBeenCalledWith(
+        OUTPUT_AREA_URI,
+        jasmine.any(Object)
+      );
+    });
+    it("should destroy output-pane if it was active", () => {
+      const outputPane = new OutputPane(storeMock);
+      const workspacePaneItems = [outputPane];
+      spyOn(atom.workspace, "getPaneItems").and.returnValue(workspacePaneItems);
+      spyOn(outputPane, "destroy").and.callThrough();
+      toggleOutputMode();
+      expect(outputPane.destroy).toHaveBeenCalled();
     });
   });
 });

--- a/spec/commands-spec.js
+++ b/spec/commands-spec.js
@@ -62,7 +62,7 @@ describe("commands", () => {
       const outputPane = new OutputPane(storeMock);
       const workspacePaneItems = [outputPane];
       spyOn(atom.workspace, "getPaneItems").and.returnValue(workspacePaneItems);
-      spyOn(outputPane, "destroy").and.callThrough();
+      spyOn(outputPane, "destroy");
       toggleOutputMode();
       expect(outputPane.destroy).toHaveBeenCalled();
     });

--- a/spec/panes-spec.js
+++ b/spec/panes-spec.js
@@ -29,7 +29,6 @@ describe("Panes", () => {
         spyOn(pane.element, "remove");
         pane.destroy();
         expect(pane.disposer.dispose).toHaveBeenCalled();
-        expect(pane.element.remove).toHaveBeenCalled();
       });
     });
   });


### PR DESCRIPTION
There is a discussion on this in #1486. 

In short: the command `hydrogen:toggle-output-area` only toggles visibility of the dock. Some users find this confusing because the command is the only way to enable the output area, but it cannot be used to switch back to inline output mode.