### PR TITLE
Support exporting markdown cells to notebook file

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -5,6 +5,7 @@
 * Usage
   * [Getting Started](docs/Usage/GettingStarted.md)
   * [Examples](docs/Usage/Examples.md)
+  * [Notebook Export](docs/Usage/NotebookFiles.md)
   * [Remote Kernels](docs/Usage/RemoteKernelConnection.md)
 * [Troubleshooting Guide](docs/Troubleshooting.md)
 * [Style Customization](docs/StyleCustomization.md)

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -33,6 +33,7 @@ Tested and works with:
 - [IElixir](https://github.com/pprzetacznik/IElixir)
 - [jupyter-scala](https://github.com/alexarchambault/jupyter-scala)
 - [kotlin-jupyter](https://github.com/ligee/kotlin-jupyter)
+- [stata-kernel](https://github.com/kylebarron/stata_kernel)
 
 But it _should_ work with any [kernel](https://github.com/jupyter/jupyter/wiki/Jupyter-kernels). If you are using Hydrogen with another kernel please add it to this list or [post an issue](https://github.com/nteract/hydrogen/issues) if anything is broken!
 

--- a/docs/Usage/GettingStarted.md
+++ b/docs/Usage/GettingStarted.md
@@ -31,11 +31,13 @@ The following is an example for `python` but it will work in any language, just 
 
 When you place the cursor inside a cell and hit **"Run Cell"**, Hydrogen will execute this cell. The command **"Hydrogen: Run Cell And Move Down"** will move the cursor to the next cell after execution.
 
+The addition of these cell markers also allows you to export your text file as a Jupyter Notebook file. See [Notebook Export](NotebookFiles.md#notebook-export) for more detail.
+
 ## "Hydrogen: Run All" and "Hydrogen: Run All Above"
 These commands will run all code inside the editor or all code above the cursor.
 
 ## "Hydrogen: Toggle Output Area"
-An external output area can be used to display output instead of the inline result view. 
+An external output area can be used to display output instead of the inline result view.
 The output can be displayed either in a scrolling view or a sliding history.
 
 <img width=560 src=https://user-images.githubusercontent.com/13436188/31737963-799d2ad2-b449-11e7-9b4c-78e51851e204.gif>

--- a/docs/Usage/NotebookFiles.md
+++ b/docs/Usage/NotebookFiles.md
@@ -1,0 +1,78 @@
+# Notebook Export
+
+Hydrogen makes it easy to export text files to Jupyter Notebook files (`.ipynb` files).
+
+With text like the following, running **"Hydrogen: Export Notebook"** will export code and markdown cells to a Notebook file of your choosing.
+```py
+# %%
+print('Hello, world!')
+# %% markdown
+# A **Markdown** cell!
+```
+
+## Cell Markers
+
+Use a special inline comment to distinguish the beginning of code cells and markdown cells. The inline comment must start with the comment character registered in the language's grammar file.
+
+- Python: `#`
+- R: `#`
+- Julia: `#`
+- Javascript: `//`
+- Stata: `//`
+
+### Code Cells
+
+After the comment character, you need to add one space plus any of the following markers on the same line:
+
+- `%%`
+- `<codecell>`
+- `In[]` (you can have any number of digits or spaces in the brackets)
+
+For example, the following text corresponds to three code cells in a Python file
+```py
+# %%
+print('Hello, world!')
+# <codecell>
+print('foo')
+# In[1]
+print('bar')
+```
+
+These are the same cell markers used by [**"Hydrogen: Run Cell"**](GettingStarted.md#hydrogen-run-cell).
+
+### Markdown Cells
+
+You can also create cells with [Markdown](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet)-formatted text. Just as for code cells, there are a range of allowed markers to delimit the start of a markdown cell:
+
+- `%% md`
+- `%% [md]`
+- `%% markdown`
+- `%% [markdown]`
+- `<md>`
+- `<markdown>`
+
+Each line of text in the cell's body should be prefixed by the language's comment character. Any common leading whitespace in the cell will be stripped, so the body text can include a space after the comment symbol without having leading whitespace in the output and with indented lists keeping their structure.
+
+For example, here are two markdown cells in a Python file
+```py
+# %% [markdown]
+# _italic text_
+# **bold text**
+# <markdown>
+# - Indented
+#     - Lists
+```
+
+the two cells would be exported without any common leading whitespace as
+```md
+_italic text_
+**bold text**
+```
+```md
+- Indented
+    - Lists
+```
+
+### Raw Cells
+
+Hydrogen doesn't support the export of [raw cells](https://nbformat.readthedocs.io/en/latest/format_description.html#raw-nbconvert-cells) at this time.

--- a/grammars/breakpoints.cson
+++ b/grammars/breakpoints.cson
@@ -3,7 +3,7 @@
 'injectionSelector': 'comment.line'
 'patterns': [
   {
-    'match': '%%| %%| <codecell>| In\\[[0-9 ]*\\]:?'
+    'match': '%%| %%| <(codecell|md|markdown)>| In\\[[0-9 ]*\\]:?'
     'name': 'entity.name.section.breakpoint'
   }
 ]

--- a/grammars/breakpoints.cson
+++ b/grammars/breakpoints.cson
@@ -1,9 +1,9 @@
-'scopeName': 'hydrogen.breakpoints'
-'name': 'Hydrogen breakpoints'
-'injectionSelector': 'comment.line'
-'patterns': [
+scopeName: 'hydrogen.breakpoints'
+name: 'Hydrogen breakpoints'
+injectionSelector: 'comment.line'
+patterns: [
   {
-    'match': '%%| %%| <(codecell|md|markdown)>| In\\[[0-9 ]*\\]:?'
-    'name': 'entity.name.section.breakpoint'
+    match: ' ?%%(\\s*\\[?(md|markdown)\\]?)?| <(codecell|md|markdown)>| In\\[[0-9 ]*\\]:?'
+    name: 'entity.name.section.breakpoint'
   }
 ]

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -3,6 +3,7 @@
 import { Point, Range } from "atom";
 
 import escapeStringRegexp from "escape-string-regexp";
+import stripIndent from "strip-indent";
 import _ from "lodash";
 
 import {
@@ -83,33 +84,7 @@ export function removeCommentsMarkdownCell(
       editedLines.push(line);
     }
   });
-  return dedentCommonLeadingWhitespace(editedLines).join("\n");
-}
-
-function dedentCommonLeadingWhitespace(lines: Array<string>): Array<string> {
-  const leadingWhitespaceRegex = /^([ \t]*)(?=[^ \t\n])/;
-  const onlyWhitespace = /^[\s]*$/;
-  const leadingSpaces = _.compact(
-    _.map(lines, line => {
-      if (!line.match(onlyWhitespace)) {
-        const match = line.match(leadingWhitespaceRegex);
-        return match ? match[1] : null;
-      }
-    })
-  );
-  const leadingSubstring = getLongestCommonStartingSubstring(leadingSpaces);
-  return _.map(lines, line => line.replace(leadingSubstring, ""));
-}
-
-// https://stackoverflow.com/questions/1916218/find-the-longest-common-starting-substring-in-a-set-of-strings
-function getLongestCommonStartingSubstring(array: Array<string>): string {
-  const A = array.concat().sort();
-  const a1 = A[0];
-  const a2 = A[A.length - 1];
-  const L = a1.length;
-  let i = 0;
-  while (i < L && a1.charAt(i) === a2.charAt(i)) i++;
-  return a1.substring(0, i);
+  return stripIndent(editedLines.join("\n"));
 }
 
 export function getSelectedText(editor: atom$TextEditor) {

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -50,6 +50,42 @@ export function getRows(
   return normalizeString(code);
 }
 
+export function getMetadataForRow(
+  editor: atom$TextEditor,
+  start: atom$Point
+): string {
+  // `start` is a Point on the first line of the cell. The cell marker is on the
+  // previous line
+  if (start.row === 0) {
+    return "code";
+  }
+  var rowText = getRow(editor, start.row - 1);
+  if (_.includes(rowText, "md") || _.includes(rowText, "markdown")) {
+    return "markdown";
+  } else {
+    return "code";
+  }
+}
+
+export function removeCommentsMarkdownCell(
+  editor: atom$TextEditor,
+  text: string
+): string {
+  const commentStartString = getCommentStartString(editor).trimRight();
+
+  const lines = text.split("\n");
+  const editedLines = [];
+  _.forEach(lines, line => {
+    if (line.startsWith(commentStartString)) {
+      // Remove comment from start of line
+      editedLines.push(line.slice(commentStartString.length).trimLeft());
+    } else {
+      editedLines.push(line);
+    }
+  });
+  return editedLines.join("\n");
+}
+
 export function getSelectedText(editor: atom$TextEditor) {
   return normalizeString(editor.getSelectedText());
 }
@@ -118,13 +154,15 @@ export function getCodeToInspect(editor: atom$TextEditor) {
   return [code, cursorPosition];
 }
 
-export function getRegexString(editor: atom$TextEditor) {
-  const {
-    commentStartString
-    // $FlowFixMe: This is an unofficial API
-  } = editor.tokenizedBuffer.commentStringsForPosition(
+function getCommentStartString(editor: atom$TextEditor): string {
+  // $FlowFixMe: This is an unofficial API
+  return editor.tokenizedBuffer.commentStringsForPosition(
     editor.getCursorBufferPosition()
-  );
+  ).commentStartString;
+}
+
+export function getRegexString(editor: atom$TextEditor) {
+  const commentStartString = getCommentStartString(editor);
 
   if (!commentStartString) {
     log("CellManager: No comment string defined in root scope");

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -174,7 +174,7 @@ export function getRegexString(editor: atom$TextEditor) {
     commentStartString.trimRight()
   );
 
-  const regexString = `${escapedCommentStartString}(%%| %%| <codecell>| In\[[0-9 ]*\]:?)`;
+  const regexString = `${escapedCommentStartString}(%%| %%| <(?:codecell|md|markdown)>| In\[[0-9 ]*\]:?)`;
 
   return regexString;
 }

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -78,12 +78,38 @@ export function removeCommentsMarkdownCell(
   _.forEach(lines, line => {
     if (line.startsWith(commentStartString)) {
       // Remove comment from start of line
-      editedLines.push(line.slice(commentStartString.length).trimLeft());
+      editedLines.push(line.slice(commentStartString.length));
     } else {
       editedLines.push(line);
     }
   });
-  return editedLines.join("\n");
+  return dedentCommonLeadingWhitespace(editedLines).join("\n");
+}
+
+function dedentCommonLeadingWhitespace(lines: Array<string>): Array<string> {
+  const leadingWhitespaceRegex = /^([ \t]*)(?=[^ \t\n])/;
+  const onlyWhitespace = /^[\s]*$/;
+  const leadingSpaces = _.compact(
+    _.map(lines, line => {
+      if (!line.match(onlyWhitespace)) {
+        const match = line.match(leadingWhitespaceRegex);
+        return match ? match[1] : null;
+      }
+    })
+  );
+  const leadingSubstring = getLongestCommonStartingSubstring(leadingSpaces);
+  return _.map(lines, line => line.replace(leadingSubstring, ""));
+}
+
+// https://stackoverflow.com/questions/1916218/find-the-longest-common-starting-substring-in-a-set-of-strings
+function getLongestCommonStartingSubstring(array: Array<string>): string {
+  const A = array.concat().sort();
+  const a1 = A[0];
+  const a2 = A[A.length - 1];
+  const L = a1.length;
+  let i = 0;
+  while (i < L && a1.charAt(i) === a2.charAt(i)) i++;
+  return a1.substring(0, i);
 }
 
 export function getSelectedText(editor: atom$TextEditor) {

--- a/lib/store/index.js
+++ b/lib/store/index.js
@@ -76,7 +76,13 @@ export class Store {
       const { start, end } = cell;
       let source = codeManager.getTextInRange(editor, start, end);
       source = source ? source : "";
-      const newCell = commutable.emptyCodeCell.set("source", source);
+      const cellType = codeManager.getMetadataForRow(editor, start);
+      if (cellType === "code") {
+        var newCell = commutable.emptyCodeCell.set("source", source);
+      } else if (cellType === "markdown") {
+        source = codeManager.removeCommentsMarkdownCell(editor, source);
+        var newCell = commutable.emptyMarkdownCell.set("source", source);
+      }
       notebook = commutable.appendCellToNotebook(notebook, newCell);
     });
     return commutable.toJS(notebook);

--- a/lib/store/index.js
+++ b/lib/store/index.js
@@ -69,7 +69,6 @@ export class Store {
     if (!editor) {
       return null;
     }
-    // Should we consider starting off with a monocellNotebook ?
     let notebook = commutable.emptyNotebook;
     const cellRanges = codeManager.getCells(editor);
     _.forEach(cellRanges, cell => {
@@ -77,11 +76,12 @@ export class Store {
       let source = codeManager.getTextInRange(editor, start, end);
       source = source ? source : "";
       const cellType = codeManager.getMetadataForRow(editor, start);
+      let newCell;
       if (cellType === "code") {
-        var newCell = commutable.emptyCodeCell.set("source", source);
+        newCell = commutable.emptyCodeCell.set("source", source);
       } else if (cellType === "markdown") {
         source = codeManager.removeCommentsMarkdownCell(editor, source);
-        var newCell = commutable.emptyMarkdownCell.set("source", source);
+        newCell = commutable.emptyMarkdownCell.set("source", source);
       }
       notebook = commutable.appendCellToNotebook(notebook, newCell);
     });

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "react-hot-loader": "^4.3.3",
     "react-rangeslider": "^2.1.0",
     "spawnteract": "^5.1.0",
+    "strip-indent": "^2.0.0",
     "tildify": "^1.2.0",
     "uuid": "^3.2.1",
     "ws": "^3.3.1",

--- a/spec/store/index-spec.js
+++ b/spec/store/index-spec.js
@@ -329,12 +329,8 @@ describe("Store", () => {
     it("should return a fully-fledged notebook when the file isn't empty", () => {
       const source1 = 'print("Hola World! I <3 ZMQ!")\n';
       const source2 = "2 + 2\n";
-      editor.insertText("# %%\n");
-      editor.insertText(source1);
-      editor.insertText("# %%\n");
-      editor.insertText(source2);
+      editor.setText(`# %%\n${source1}# %%\n${source2}`);
       store.updateEditor(editor);
-      // Build a notebook with these two cells.
       const codeCell1 = commutable.emptyCodeCell.set("source", source1);
       const codeCell2 = commutable.emptyCodeCell.set("source", source2);
       // The outputted notebook will have three cells because currently a cell
@@ -344,6 +340,23 @@ describe("Store", () => {
         codeCell1
       );
       nb = commutable.appendCellToNotebook(nb, codeCell2);
+      expect(store.notebook).toEqual(commutable.toJS(nb));
+    });
+
+    it("should export markdown to markdown cells", () => {
+      const source1 = 'print("Hola World! I <3 ZMQ!")\n';
+      const source2 = "2 + 2\n";
+      editor.setText(`# %%\n${source1}# %% markdown\n${source2}`);
+      store.updateEditor(editor);
+      const codeCell = commutable.emptyCodeCell.set("source", source1);
+      const markdownCell = commutable.emptyMarkdownCell.set("source", source2);
+      // The outputted notebook will have three cells because currently a cell
+      // is always created before the first `# %%`
+      let nb = commutable.appendCellToNotebook(
+        commutable.monocellNotebook,
+        codeCell
+      );
+      nb = commutable.appendCellToNotebook(nb, markdownCell);
       expect(store.notebook).toEqual(commutable.toJS(nb));
     });
   });

--- a/spec/store/index-spec.js
+++ b/spec/store/index-spec.js
@@ -307,13 +307,15 @@ describe("Store", () => {
       expect(store.notebook).toEqual(commutable.toJS(nb));
     });
 
-    xit("should return a fully-fledged notebook when the file isn't empty", () => {
+    it("should return a fully-fledged notebook when the file isn't empty", () => {
       // This editor will have some cells.
       const editor = atom.workspace.buildTextEditor();
       editor.setGrammar(atom.grammars.grammarForScopeName("source.python"));
       // Add some code to the editor.
       const source1 = 'print "Hola World! I <3 ZMQ!"';
       const source2 = "2 + 2";
+      editor.insertText("# %%");
+      editor.insertNewline();
       editor.insertText(source1);
       editor.insertNewline();
       editor.insertText("# %%");
@@ -323,8 +325,10 @@ describe("Store", () => {
       // Build a notebook with these two cells.
       const codeCell1 = commutable.emptyCodeCell.set("source", source1);
       const codeCell2 = commutable.emptyCodeCell.set("source", source2);
+      // The outputted notebook will have three cells because currently a cell
+      // is always created before the first `# %%`
       let nb = commutable.appendCellToNotebook(
-        commutable.emptyNotebook,
+        commutable.monocellNotebook,
         codeCell1
       );
       nb = commutable.appendCellToNotebook(nb, codeCell2);


### PR DESCRIPTION
This adds support for Markdown cells in the `export-notebook` command (closes #1296).

- This requires the substring `md` or `markdown` to be present on the cell marker line, i.e. any of the following would work correctly:
	```py
    # %% md
    # %% markdown
    # %% [md]
    # %% [markdown]
    # In[1] md
    # In[1] markdown
    # In[1] [md]
    # In[1] [markdown]
    # <codecell> md
    # <codecell> markdown
    # <codecell> [md]
    # <codecell> [markdown]
	```

	Right now, `# <md>` and `# <markdown>` are **not** supported. It wouldn't be hard to support them; I'd just have to change this regex list:
	https://github.com/nteract/hydrogen/blob/ea0004326a666c679119fbec582530123c4e7cca/lib/code-manager.js#L138

- If there's a comment symbol as the first characters on a line, it and any left whitespace will be removed.
- There's always a cell created before the first `# %%` marker, even if it's on the first line. To me that's a bug, but that should be solved in another PR.

Any comments/code improvement suggestions are welcome. Hopefully this JS is a little more idiomatic than my last PR.

```py
# %%
print('hello world')

# %% markdown
# # Headline1
# - bullet point
# **bold text**

# %%
print('bye world')
```

In Jupyter Notebook:
![image](https://user-images.githubusercontent.com/15164633/50408564-00744c80-07a9-11e9-8cd1-2413314c1444.png)

cc: @mwouts, @Madhu94 	