### PR TITLE
Include kernelspec as metadata of notebook export

### DIFF
--- a/lib/kernel-manager.js
+++ b/lib/kernel-manager.js
@@ -89,7 +89,12 @@ export class KernelManager {
   async update(): Promise<Kernelspec[]> {
     const kernelSpecs = await ks.findAll();
     this.kernelSpecs = _.sortBy(
-      _.map(kernelSpecs, "spec"),
+      _.map(
+        _.mapKeys(kernelSpecs, function(value, key) {
+          return (value.spec.name = key);
+        }),
+        "spec"
+      ),
       spec => spec.display_name
     );
     return this.kernelSpecs;

--- a/lib/store/index.js
+++ b/lib/store/index.js
@@ -71,10 +71,12 @@ export class Store {
     }
     // Should we consider starting off with a monocellNotebook ?
     let notebook = commutable.emptyNotebook;
-    notebook = notebook.setIn(
-      ["metadata", "kernelspec"],
-      this.kernel.transport.kernelSpec
-    );
+    if (this.kernel) {
+      notebook = notebook.setIn(
+        ["metadata", "kernelspec"],
+        this.kernel.transport.kernelSpec
+      );
+    }
     const cellRanges = codeManager.getCells(editor);
     _.forEach(cellRanges, cell => {
       const { start, end } = cell;

--- a/lib/store/index.js
+++ b/lib/store/index.js
@@ -71,6 +71,10 @@ export class Store {
     }
     // Should we consider starting off with a monocellNotebook ?
     let notebook = commutable.emptyNotebook;
+    notebook = notebook.setIn(
+      ["metadata", "kernelspec"],
+      this.kernel.transport.kernelSpec
+    );
     const cellRanges = codeManager.getCells(editor);
     _.forEach(cellRanges, cell => {
       const { start, end } = cell;


### PR DESCRIPTION
This PR does two things:
- Add `store.kernel.kernelSpec` to the `metadata` field of an exported `.ipynb` file
- Adds the kernel name as a field of the `kernelSpec` attribute

### Export metadata with notebook

Currently, the `export-notebook` command does not export any metadata. It's an empty object/dict. So the on-disk format for a very simple `.ipynb` file might look something like this:

```json
{
  "cells": [
    {
      "cell_type": "code",
      "source": [
        "print('hello world')\n",
        "\n"
      ],
      "outputs": [],
      "execution_count": null,
      "metadata": {
        "collapsed": false,
        "outputHidden": false,
        "inputHidden": false
      }
    }
  ],
  "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 4
}
```

A problem arises when exporting a notebook from some kernel other than Python. Since there's no metadata, Jupyter doesn't know what language to associate the file with, and associates it with Python by default.

With this change, the kernelspec field of the metadata is populated with the kernelspec of the running kernel. 

However, when opening the file in the Jupyter Notebook app, an error is raised because the `name` field of the kernelspec is empty.

### Adding kernel name to kernelspec attribute

A kernelspec looks like this:
```json
"ir": {
    "resource_dir": "/Users/kyle/Library/Jupyter/kernels/ir",
    "spec": {
      "argv": [
        "/Library/Frameworks/R.framework/Resources/bin/R",
        "--slave",
        "-e",
        "IRkernel::main()",
        "--args",
        "{connection_file}"
      ],
      "env": {},
      "display_name": "R",
      "language": "R",
      "interrupt_mode": "signal",
      "metadata": {}
    }
}
```

The kernel name here is `ir`, the top-most key. In Hydrogen, this name is lost because `_.map` only keeps the value of the `spec` dict here:
https://github.com/nteract/hydrogen/blob/ea0004326a666c679119fbec582530123c4e7cca/lib/kernel-manager.js#L91-L94

This adds the name of the kernel to the `spec` object under key `name`:
```js
{argv: Array(5), display_name: "Python 3", language: "python", name: "python3"}
```

### Conclusion

With these changes the output of `export-notebook` from this text:
```py
# %%
print('hello world')
```
is
```json
{
  "cells": [
    {
      "cell_type": "code",
      "source": [],
      "outputs": [],
      "execution_count": null,
      "metadata": {
        "collapsed": false,
        "outputHidden": false,
        "inputHidden": false
      }
    },
    {
      "cell_type": "code",
      "source": [
        "print('hello world')\n"
      ],
      "outputs": [],
      "execution_count": null,
      "metadata": {
        "collapsed": false,
        "outputHidden": false,
        "inputHidden": false
      }
    }
  ],
  "metadata": {
    "kernelspec": {
      "argv": [
        "python",
        "-m",
        "ipykernel_launcher",
        "-f",
        "{connection_file}"
      ],
      "display_name": "Python 3",
      "language": "python",
      "name": "python3"
    }
  },
  "nbformat": 4,
  "nbformat_minor": 4
}
```

This fixes notebook-kernel association, i.e. with R:
![image](https://user-images.githubusercontent.com/15164633/50433491-bb7a1400-0895-11e9-9bb4-798149618690.png)
