### PR TITLE
Import Jupyter Notebook files into Atom

### DIFF
--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -118,7 +118,7 @@ export function getCodeToInspect(editor: atom$TextEditor) {
   return [code, cursorPosition];
 }
 
-export function getRegexString(editor: atom$TextEditor) {
+export function getCommentStartString(editor: atom$TextEditor): ?string {
   const {
     commentStartString
     // $FlowFixMe: This is an unofficial API
@@ -130,10 +130,14 @@ export function getRegexString(editor: atom$TextEditor) {
     log("CellManager: No comment string defined in root scope");
     return null;
   }
+  return commentStartString.trimRight();
+}
 
-  const escapedCommentStartString = escapeStringRegexp(
-    commentStartString.trimRight()
-  );
+export function getRegexString(editor: atom$TextEditor) {
+  const commentStartString = getCommentStartString(editor);
+  if (!commentStartString) return null;
+
+  const escapedCommentStartString = escapeStringRegexp(commentStartString);
 
   const regexString = `${escapedCommentStartString}(%%| %%| <codecell>| In\[[0-9 ]*\]:?)`;
 

--- a/lib/import-notebook.js
+++ b/lib/import-notebook.js
@@ -34,8 +34,11 @@ async function loadNotebook(err, data) {
     });
     return;
   }
-  // TODO: Check notebook v3
   const nb = parseNotebook(data);
+  if (nb.nbformat < 4) {
+    atom.notifications.addError("Only notebook version 4 currently supported");
+    return;
+  }
   const editor = await atom.workspace.open();
   const grammar = getGrammarForNotebook(nb);
   if (!grammar) return;

--- a/lib/import-notebook.js
+++ b/lib/import-notebook.js
@@ -19,9 +19,11 @@ export default function importNotebook() {
       return;
     }
     const filename = filenames[0];
-    const ext = path.extname(filename) === "" ? ".ipynb" : "";
-    const fname = `${filename}${ext}`;
-    readFile(fname, loadNotebook);
+    if (path.extname(filename) !== ".ipynb") {
+      atom.notifications.addError("Selected file must have extension .ipynb");
+      return;
+    }
+    readFile(filename, loadNotebook);
   });
 }
 

--- a/lib/import-notebook.js
+++ b/lib/import-notebook.js
@@ -1,0 +1,122 @@
+/* @flow */
+
+import * as path from "path";
+import { readFile } from "fs";
+import _ from "lodash";
+
+const { dialog } = require("electron").remote;
+const { parseNotebook } = require("@nteract/commutable");
+
+import store from "./store";
+import { getCommentStartString } from "./code-manager";
+
+const linesep = process.platform === "win32" ? "\r\n" : "\n";
+
+export default function importNotebook() {
+  dialog.showOpenDialog({ properties: ["openFile"] }, filenames => {
+    if (filenames.length === 0) {
+      atom.notifications.addError("No filenames selected");
+      return;
+    }
+    const filename = filenames[0];
+    const ext = path.extname(filename) === "" ? ".ipynb" : "";
+    const fname = `${filename}${ext}`;
+    readFile(fname, loadNotebook);
+  });
+}
+
+async function loadNotebook(err, data) {
+  if (err) {
+    atom.notifications.addError("Error reading file", {
+      detail: err.message
+    });
+    return;
+  }
+  // TODO: Check notebook v3
+  const nb = parseNotebook(data);
+  const editor = await atom.workspace.open();
+  const grammar = getGrammarForNotebook(nb);
+  if (!grammar) return;
+  editor.setGrammar(grammar);
+  const commentStartString = getCommentStartString(editor);
+  if (!commentStartString) {
+    atom.notifications.addError("No comment symbol defined in root scope");
+    return;
+  }
+  const sources = _.map(nb.cells, cell => {
+    return getCellSource(cell, commentStartString + " ");
+  });
+  editor.setText(sources.join(linesep));
+}
+
+function getGrammarForNotebook(nb) {
+  if (!nb.metadata.kernelspec || !nb.metadata.language_info) {
+    atom.notifications.addWarning(
+      "No language metadata in notebook; assuming Python"
+    );
+    return atom.grammars.grammarForScopeName("source.python");
+  }
+
+  let matchedGrammar = null;
+  // metadata.language_info.file_extension is not a required metadata field, but
+  // if it exists is the best way to match with Atom Grammar
+  if (nb.metadata.language_info && nb.metadata.language_info.file_extension) {
+    matchedGrammar = getGrammarForFileExtension(
+      nb.metadata.language_info.file_extension
+    );
+    if (matchedGrammar) return matchedGrammar;
+  }
+
+  // If metadata exists, then metadata.kernelspec.name is required (in v4)
+  if (nb.metadata.kernelspec.name) {
+    matchedGrammar = getGrammarForKernelspecName(nb.metadata.kernelspec.name);
+    if (matchedGrammar) return matchedGrammar;
+  }
+
+  atom.notifications.addError("Unable to set language grammar");
+  return atom.grammars.grammarForScopeName("source.python");
+}
+
+function getGrammarForFileExtension(ext: string): ?atom$Grammar {
+  ext = ext.startsWith(".") ? ext.slice(1) : ext;
+  const grammars = atom.grammars.getGrammars();
+  return _.find(grammars, grammar => {
+    return _.includes(grammar.fileTypes, ext);
+  });
+}
+
+function getGrammarForKernelspecName(name: string): atom$Grammar {
+  // Check if there exists an Atom grammar named source.${name}
+  const grammars = atom.grammars.getGrammars();
+  const matchedGrammar = _.find(grammars, { scopeName: `source.${name}` });
+  if (matchedGrammar) return matchedGrammar;
+
+  // Otherwise attempt manual matching from kernelspec name to Atom scope
+  const crosswalk = {
+    python2: "source.python",
+    python3: "source.python",
+    bash: "source.shell",
+    javascript: "source.js",
+    ir: "source.r"
+  };
+  if (crosswalk.name) {
+    return atom.grammars.grammarForScopeName(crosswalk.name);
+  }
+  return;
+}
+
+function getCellSource(cell, commentStartString: string): string {
+  const cellType = cell.cell_type;
+  const cellMarkerKeyword = cellType === "markdown" ? "markdown" : null;
+  const cellMarker = getCellMarker(commentStartString, cellMarkerKeyword);
+  var source = cell.source;
+  if (cellType === "markdown") {
+    source = _.map(source, line => commentStartString + line);
+  }
+  return cellMarker + linesep + source.join("");
+}
+
+function getCellMarker(commentStartString: string, keyword: ?string) {
+  const marker = commentStartString + "%%";
+  return keyword ? marker + ` ${keyword}` : marker;
+}

--- a/lib/main.js
+++ b/lib/main.js
@@ -55,6 +55,7 @@ import {
 } from "./utils";
 
 import exportNotebook from "./export-notebook";
+import importNotebook from "./import-notebook";
 
 const Hydrogen = {
   config: Config.schema,
@@ -141,6 +142,7 @@ const Hydrogen = {
           this.handleKernelCommand({ command: "shutdown-kernel" }),
         "hydrogen:toggle-bubble": () => this.toggleBubble(),
         "hydrogen:export-notebook": () => exportNotebook(),
+        "hydrogen:import-notebook": () => importNotebook(),
         "hydrogen:fold-current-cell": () => this.foldCurrentCell(),
         "hydrogen:fold-all-but-current-cell": () => this.foldAllButCurrentCell()
       })

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
       "hydrogen:run-cell",
       "hydrogen:run-cell-and-move-down",
       "hydrogen:restart-kernel-and-re-evaluate-bubbles",
-      "hydrogen:toggle-bubble"
+      "hydrogen:toggle-bubble",
+      "hydrogen:import-notebook"
     ]
   },
   "scripts": {


### PR DESCRIPTION
This PR adds functionality to import Jupyter Notebook files as text files in Atom.

It imports the new file into a new TextEditor. In order to support Markdown blocks, I need to know the correct comment symbol, so I need to find the correct Atom Grammar for the notebook file. I first try to match file extensions between the notebook file's metadata and the file extensions that each Grammar is applied for. But since the file extension is an optional metadata field for the notebook, I also attempt to match on kernelspec name. These two together should work for the vast majority of notebooks.

Given the grammar, I get the source text for code and markdown cells, prepending each line of text in the markdown cell with the `commentStartString`, right trimmed plus a space. I add a cell marker line before each cell, either `# %%` or `# %% markdown`. It uses `\r\n` as the line separator on Windows; `\n` otherwise (for newlines created between cells).

To do:

- I want to add tests, especially testing that the round-trip import-export and export-import from Hydrogen is idempotent, but that depends on the result of #1498 and #1499. Regardless, if there are any substantial requested changes to this PR, I want to make the changes before making the tests.

Limitations:

- Currently only version 4 of the notebook format is supported.
- Only imports source text of code cells and Markdown cells. Doesn't import raw cells or code cell outputs.

### Python
![image](https://user-images.githubusercontent.com/15164633/50504254-8a324d00-0a29-11e9-9937-403836328664.png)
```py
# %% markdown
# # Example Notebook
# 
# This is an example Python Notebook!
# %%
print('hello world!')
# %%
```

### Bash:
![image](https://user-images.githubusercontent.com/15164633/50504202-30318780-0a29-11e9-97b7-d76867d0eac3.png)
```bash
# %% markdown
# # Example Notebook
# 
# This is an example Bash Notebook.
# %%
echo "hello world!"
# %%
```

### Javascript:
![image](https://user-images.githubusercontent.com/15164633/50504222-4c352900-0a29-11e9-8658-7dee6aaba6f2.png)

```js
// %% markdown
// # Example Notebook
// 
// This is an example Javascript Notebook.
// %%
console.log('hello world!');
// %%
```

### R:
![image](https://user-images.githubusercontent.com/15164633/50504233-67a03400-0a29-11e9-9148-fc6ee6202909.png)
```r
# %% markdown
# # Example Notebook
# 
# This is an example R Notebook!
# %%
print('hello world!')
# %%
```


Closes #1457, ref #1404.