### PR TITLE
Remove initial empty cell from codeManager.getCells()

### DIFF
--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -253,7 +253,7 @@ export function getCellsForBreakPoints(
   let start = new Point(0, 0);
   // Let start be earliest row with text
   editor.scan(/\S/, match => {
-    start = match.range.start;
+    start = new Point(match.range.start.row, 0);
     match.stop();
   });
   return _.compact(

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -243,18 +243,26 @@ export function getCells(
   } else {
     breakpoints = getBreakpoints(editor);
   }
-  return getCellsForBreakPoints(breakpoints);
+  return getCellsForBreakPoints(editor, breakpoints);
 }
 
 export function getCellsForBreakPoints(
+  editor: atom$TextEditor,
   breakpoints: Array<atom$Point>
 ): Array<atom$Range> {
   let start = new Point(0, 0);
-  return _.map(breakpoints, end => {
-    const cell = new Range(start, end);
-    start = new Point(end.row + 1, 0);
-    return cell;
+  // Let start be earliest row with text
+  editor.scan(/\S/, match => {
+    start = match.range.start;
+    match.stop();
   });
+  return _.compact(
+    _.map(breakpoints, end => {
+      const cell = end.isEqual(start) ? null : new Range(start, end);
+      start = new Point(end.row + 1, 0);
+      return cell;
+    })
+  );
 }
 
 export function moveDown(editor: atom$TextEditor, row: number) {


### PR DESCRIPTION
Currently, if you have the following text
```py
# %%
print('hello world')
# %%
print('foo bar')
```
and call `codeManager.getCells`, you get _three_ cells, not two. Calling `codeManager.getBreakpoints` returns two breakpoints: `Point(0, 0)` and `Point(2, 0)`. Then calling `codeManager.getCellsForBreakPoints` creates an extra empty cell corresponding to the range from `Point(0, 0)` to `Point(0, 0)`. 

This also means that exporting the above code to a notebook gives _three_ cells, not two. Here's a similar example from #1498 (note the empty first cell despite `print('hello world'` being on the first line of the editor):
![image](https://user-images.githubusercontent.com/15164633/50408564-00744c80-07a9-11e9-8cd1-2413314c1444.png)

This PR fixes this behavior by setting the first cell to start with the first non-empty line. So all the following code excerpts would give the same output to `codeManager.getCells`
```py
print('hello world')
# %%
print('foo bar')
```

```py
(extra spaces that don't show up in Github Markdown by default)


print('hello world')
# %%
print('foo bar')
```

```py
(extra spaces that don't show up in Github Markdown by default)


# %%
print('hello world')
# %%
print('foo bar')
```