### PR TITLE
Add import-notebook as opener for .ipynb files

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -130,6 +130,13 @@ const Config = {
         "If enabled, all files of the same grammar will share a single global kernel (requires atom restart)",
       type: "boolean",
       default: false
+    },
+    importNotebookURI: {
+      title: "Enable Notebook Auto-import",
+      description:
+        "If enabled, opening a Jupyter Notebook file in Atom (with extension `.ipynb`) will instead import the file's source into a new tab.",
+      type: "boolean",
+      default: true
     }
   }
 };

--- a/lib/config.js
+++ b/lib/config.js
@@ -134,7 +134,7 @@ const Config = {
     importNotebookURI: {
       title: "Enable Notebook Auto-import",
       description:
-        "If enabled, opening a Jupyter Notebook file in Atom (with extension `.ipynb`) will instead import the file's source into a new tab.",
+        "If enabled, opening a file with extension `.ipynb` will [import the notebook](https://nteract.gitbooks.io/hydrogen/docs/Usage/NotebookFiles.html#notebook-import) file's source into a new tab. If disabled, or if the Hydrogen package is not activated, the raw file will open in Atom as normal.",
       type: "boolean",
       default: true
     }

--- a/lib/import-notebook.js
+++ b/lib/import-notebook.js
@@ -15,6 +15,15 @@ import { getCommentStartString } from "./code-manager";
 const readFileP = promisify(readFile);
 const linesep = process.platform === "win32" ? "\r\n" : "\n";
 
+export function ipynbOpener(uri: string) {
+  if (
+    path.extname(uri).toLowerCase() === ".ipynb" &&
+    atom.config.get("Hydrogen.importNotebookURI") === true
+  ) {
+    return _loadNotebook(uri);
+  }
+}
+
 export function importNotebook() {
   dialog.showOpenDialog(
     {
@@ -32,12 +41,12 @@ export function importNotebook() {
         return;
       }
 
-      loadNotebook(filename);
+      _loadNotebook(filename);
     }
   );
 }
 
-export async function loadNotebook(filename: string) {
+export async function _loadNotebook(filename: string) {
   let data;
   try {
     data = await readFileP(filename);

--- a/lib/main.js
+++ b/lib/main.js
@@ -11,7 +11,6 @@ import {
 import _ from "lodash";
 import { autorun } from "mobx";
 import React from "react";
-import * as path from "path";
 
 import KernelPicker from "./kernel-picker";
 import WSKernelPicker from "./ws-kernel-picker";
@@ -56,7 +55,7 @@ import {
 } from "./utils";
 
 import exportNotebook from "./export-notebook";
-import { importNotebook, loadNotebook } from "./import-notebook";
+import { importNotebook, ipynbOpener } from "./import-notebook";
 
 const Hydrogen = {
   config: Config.schema,
@@ -222,17 +221,7 @@ const Hydrogen = {
         }
       })
     );
-
-    store.subscriptions.add(
-      atom.workspace.addOpener(uri => {
-        if (
-          path.extname(uri).toLowerCase() === ".ipynb" &&
-          atom.config.get("Hydrogen.importNotebookURI") === true
-        ) {
-          return loadNotebook(uri);
-        }
-      })
-    );
+    store.subscriptions.add(atom.workspace.addOpener(ipynbOpener));
 
     store.subscriptions.add(
       // Destroy any Panes when the package is deactivated.

--- a/lib/main.js
+++ b/lib/main.js
@@ -11,6 +11,7 @@ import {
 import _ from "lodash";
 import { autorun } from "mobx";
 import React from "react";
+import * as path from "path";
 
 import KernelPicker from "./kernel-picker";
 import WSKernelPicker from "./ws-kernel-picker";
@@ -55,7 +56,7 @@ import {
 } from "./utils";
 
 import exportNotebook from "./export-notebook";
-import { importNotebook } from "./import-notebook";
+import { importNotebook, loadNotebook } from "./import-notebook";
 
 const Hydrogen = {
   config: Config.schema,
@@ -218,6 +219,14 @@ const Hydrogen = {
             return new OutputPane(store);
           case KERNEL_MONITOR_URI:
             return new KernelMonitorPane(store);
+        }
+      })
+    );
+
+    store.subscriptions.add(
+      atom.workspace.addOpener(uri => {
+        if (path.extname(uri).toLowerCase() === ".ipynb") {
+          return loadNotebook(uri);
         }
       })
     );

--- a/lib/main.js
+++ b/lib/main.js
@@ -225,7 +225,10 @@ const Hydrogen = {
 
     store.subscriptions.add(
       atom.workspace.addOpener(uri => {
-        if (path.extname(uri).toLowerCase() === ".ipynb") {
+        if (
+          path.extname(uri).toLowerCase() === ".ipynb" &&
+          atom.config.get("Hydrogen.importNotebookURI") === true
+        ) {
           return loadNotebook(uri);
         }
       })


### PR DESCRIPTION
When a `.ipynb` file is opened, it calls `loadNotebook` instead of loading the JSON into a TextEditor.

Should this be automatic or should it be a config setting?