### PR TITLE
Fix package repo URL link

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "build:docs": "markdox lib/plugin-api/hydrogen-provider.js lib/plugin-api/hydrogen-kernel.js -o docs/PluginAPI.md"
   },
   "atomTestRunner": "atom-jasmine3-test-runner",
-  "repository": "git@github.com:nteract/hydrogen.git",
+  "repository": "https://github.com/nteract/hydrogen",
   "license": "MIT",
   "engines": {
     "atom": ">=1.20.0 <2.0.0"


### PR DESCRIPTION
Correct the link in Atom package info
![screenshot from 2019-01-26 17-03-43](https://user-images.githubusercontent.com/5124946/51793311-83176f80-218c-11e9-9af3-9532caee2dbf.png)
