### PR TITLE
Fix cell boundaries when regex matches outside comment

### DIFF
--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -190,7 +190,9 @@ export function getBreakpoints(editor: atom$TextEditor) {
   if (regexString) {
     const regex = new RegExp(regexString, "g");
     buffer.scan(regex, ({ range }) => {
-      breakpoints.push(range.start);
+      if (isComment(editor, range.start)) {
+        breakpoints.push(range.start);
+      }
     });
   }
 

--- a/spec/code-manager-spec.js
+++ b/spec/code-manager-spec.js
@@ -132,6 +132,12 @@ describe("CodeManager", () => {
           );
           expect(CM.getCells(editor)).toEqual(cellsExpected);
         });
+        it("doesn't start a cell outside of a line comment scope", () => {
+          const code = ["# %%", "print('# %%')"];
+          editor.setText(code.join("\n") + "\n");
+          const cellsExpected = [[[1, 0], [2, 0]]].map(toRange);
+          expect(CM.getCells(editor)).toEqual(cellsExpected);
+        });
       });
       describe("with arg(= breakpoints)", () => {
         it("return cells(range) from passed breakpoints(with auto-sort-by-position)", () => {


### PR DESCRIPTION
Uses `isComment()` per @n-riesco's suggestion. Replaces #1466 