### PR TITLE
Remove trailing newline for each cell in notebook export if it exists.

### DIFF
--- a/lib/store/index.js
+++ b/lib/store/index.js
@@ -66,9 +66,7 @@ export class Store {
   @computed
   get notebook() {
     const editor = this.editor;
-    if (!editor) {
-      return null;
-    }
+    if (!editor) return null;
     let notebook = commutable.emptyNotebook;
     if (this.kernel) {
       notebook = notebook.setIn(
@@ -81,6 +79,7 @@ export class Store {
       const { start, end } = cell;
       let source = codeManager.getTextInRange(editor, start, end);
       source = source ? source : "";
+      if (source.slice(-1) === "\n") source = source.slice(0, -1);
       const cellType = codeManager.getMetadataForRow(editor, start);
       let newCell;
       if (cellType === "code") {


### PR DESCRIPTION
Fixes #1512 

```py
# %%
print('hello world')
# %%
print('foo bar')
# %%
print('baz')
```

exports to:
![image](https://user-images.githubusercontent.com/15164633/52230698-13893a80-2886-11e9-8877-d514a843e6a4.png)

and then imports back to the exact original text. 

Note that
```py
# %%
print('hello world')# %%
print('foo bar')# %%
print('baz')
```
is exported to the same as in the screenshot, though the import always places each cell marker on its own line.
