### PR TITLE
Provide ordering to configuration settings

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -20,7 +20,8 @@ const Config = {
       description:
         "If enabled, use autocomplete options provided by the current kernel.",
       type: "boolean",
-      default: true
+      default: true,
+      order: 0
     },
     showAutocompleteFirst: {
       title: "Show Hydrogen's autocomplete suggestions first",
@@ -28,7 +29,24 @@ const Config = {
       description:
         "If enabled, Hydrogen's autocomplete suggestions will be listed before those of other providers, like snippets.",
       type: "boolean",
-      default: true
+      default: true,
+      order: 1
+    },
+    statusBarDisable: {
+      title: "Disable the Hydrogen status bar",
+      description:
+        "If enabled, no kernel information will be provided in Atom's status bar.",
+      type: "boolean",
+      default: false,
+      order: 2
+    },
+    debug: {
+      title: "Enable Debug Messages",
+      includeTitle: false,
+      description: "If enabled, log debug messages onto the dev console.",
+      type: "boolean",
+      default: false,
+      order: 3
     },
     autoScroll: {
       title: "Enable Autoscroll",
@@ -36,7 +54,24 @@ const Config = {
       description:
         "If enabled, Hydrogen will automatically scroll to the bottom of the result view.",
       type: "boolean",
-      default: true
+      default: true,
+      order: 4
+    },
+    outputAreaDefault: {
+      title: "View output in the dock by default",
+      description:
+        "If enabled, output will be displayed in the dock by default rather than inline",
+      type: "boolean",
+      default: false,
+      order: 5
+    },
+    outputAreaDock: {
+      title: "Leave output dock open",
+      description:
+        "Do not close dock when switching to an editor without a running kernel",
+      type: "boolean",
+      default: false,
+      order: 6
     },
     outputAreaFontSize: {
       title: "Output area fontsize",
@@ -44,14 +79,25 @@ const Config = {
       description: "Change the fontsize of the Output area.",
       type: "integer",
       minimum: 0,
-      default: 0
+      default: 0,
+      order: 7
     },
-    debug: {
-      title: "Enable Debug Messages",
-      includeTitle: false,
-      description: "If enabled, log debug messages onto the dev console.",
+    globalMode: {
+      title: "Enable Global Kernel",
+      description:
+        "If enabled, all files of the same grammar will share a single global kernel (requires Atom restart)",
       type: "boolean",
-      default: false
+      default: false,
+      order: 8
+    },
+    kernelNotifications: {
+      title: "Enable Kernel Notifications",
+      includeTitle: false,
+      description:
+        "Notify if kernels writes to stdout. By default, kernel notifications are only displayed in the developer console.",
+      type: "boolean",
+      default: false,
+      order: 9
     },
     startDir: {
       title: "Directory to start kernel in",
@@ -72,23 +118,8 @@ const Config = {
           description: "Current directory of the file"
         }
       ],
-      default: "firstProjectDir"
-    },
-    kernelNotifications: {
-      title: "Enable Kernel Notifications",
-      includeTitle: false,
-      description:
-        "Notify if kernels writes to stdout. By default, kernel notifications are only displayed in the developer console.",
-      type: "boolean",
-      default: false
-    },
-    gateways: {
-      title: "Kernel Gateways",
-      includeTitle: false,
-      description:
-        'Hydrogen can connect to remote notebook servers and kernel gateways. Each gateway needs at minimum a name and a value for options.baseUrl. The options are passed directly to the `jupyter-js-services` npm package, which includes documentation for additional fields. Example value: ``` [{ "name": "Remote notebook", "options": { "baseUrl": "http://mysite.com:8888" } }] ```',
-      type: "string",
-      default: "[]"
+      default: "firstProjectDir",
+      order: 10
     },
     languageMappings: {
       title: "Language Mappings",
@@ -96,7 +127,8 @@ const Config = {
       description:
         'Custom Atom grammars and some kernels use non-standard language names. That leaves Hydrogen unable to figure out what kernel to start for your code. This field should be a valid JSON mapping from a kernel language name to Atom\'s grammar name ``` { "kernel name": "grammar name" } ```. For example ``` { "scala211": "scala", "javascript": "babel es6 javascript", "python": "magicpython" } ```.',
       type: "string",
-      default: '{ "python": "magicpython" }'
+      default: '{ "python": "magicpython" }',
+      order: 11
     },
     startupCode: {
       title: "Startup Code",
@@ -104,32 +136,17 @@ const Config = {
       description:
         'This code will be executed on kernel startup. Format: `{"kernel": "your code \\nmore code"}`. Example: `{"Python 2": "%matplotlib inline"}`',
       type: "string",
-      default: "{}"
+      default: "{}",
+      order: 12
     },
-    outputAreaDock: {
-      title: "Leave output dock open",
+    gateways: {
+      title: "Kernel Gateways",
+      includeTitle: false,
       description:
-        "Do not close dock when switching to an editor without a running kernel",
-      type: "boolean",
-      default: false
-    },
-    outputAreaDefault: {
-      title: "View output in the dock by default",
-      description:
-        "If enabled, output will be displayed in the dock by default rather than inline",
-      type: "boolean",
-      default: false
-    },
-    statusBarDisable: {
-      title: "Disable the Hydrogen status bar",
-      type: "boolean",
-      default: false
-    },
-    globalMode: {
-      title:
-        "If enabled, all files of the same grammar will share a single global kernel (requires atom restart)",
-      type: "boolean",
-      default: false
+        'Hydrogen can connect to remote notebook servers and kernel gateways. Each gateway needs at minimum a name and a value for options.baseUrl. The options are passed directly to the `jupyter-js-services` npm package, which includes documentation for additional fields. Example value: ``` [{ "name": "Remote notebook", "options": { "baseUrl": "http://mysite.com:8888" } }] ```',
+      type: "string",
+      default: "[]",
+      order: 13
     }
   }
 };


### PR DESCRIPTION
Hydrogen has grown to the point where there are 14 configuration settings. Currently, no ordering is provided, so I think they're ordered alphabetically in terms of the config key. I think this is more confusing than it has to be for users.

This PR attempts to group settings logically and then order them with the `order` value in the dictionary. The idea is "general settings" then "output settings" then "kernel settings", and within each ordered by most used to least used. 

The order is:
- `autocomplete`
- `showAutocompleteFirst`
- `statusBarDisable`
- `debug`
- `autoScroll`
- `outputAreaDefault`
- `outputAreaDock`
- `outputAreaFontSize`
- `globalMode`
- `kernelNotifications`
- `startDir`
- `languageMappings`
- `startupCode`
- `gateways`
