### PR TITLE
Allow creating kernel in unsaved file with language grammar set

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -347,7 +347,7 @@ const Hydrogen = {
 
     if (!filePath || !grammar) {
       return atom.notifications.addError(
-        "Your file must be saved in order to start a kernel"
+        "The language grammar must be set in order to start a kernel. The easiest way to do this is to save the file."
       );
     }
 

--- a/lib/store/index.js
+++ b/lib/store/index.js
@@ -38,6 +38,12 @@ export class Store {
   globalMode: boolean = Boolean(atom.config.get("Hydrogen.globalMode"));
 
   @computed
+  get untitled(): ?boolean {
+    if (!this.editor) return null;
+    return !this.editor.getPath();
+  }
+
+  @computed
   get kernel(): ?Kernel {
     if (this.globalMode) {
       if (!this.grammar) return null;
@@ -55,7 +61,10 @@ export class Store {
 
   @computed
   get filePath(): ?string {
-    return this.editor ? this.editor.getPath() : null;
+    if (!this.editor) return null;
+    return this.untitled
+      ? `Unsaved Editor ${this.editor.id}`
+      : this.editor.getPath();
   }
 
   @computed
@@ -210,8 +219,16 @@ export class Store {
     // Force mobx to recalculate filePath (which depends on editor observable)
 
     const currentEditor = this.editor;
+    if (!currentEditor) return null;
+
+    const oldKey = this.filePath;
     this.updateEditor(null);
     this.updateEditor(currentEditor);
+    const newKey = this.filePath;
+
+    // Change key of kernelMapping from editor ID to file path
+    this.kernelMapping.set(newKey, this.kernelMapping.get(oldKey));
+    this.kernelMapping.delete(oldKey);
   }
 }
 


### PR DESCRIPTION
Fixes #1532 

> For example the kernel monitor component displays a real filename.

For now, I have it set to `Unsaved Editor ${editor.id}`:
![image](https://user-images.githubusercontent.com/15164633/52368536-acea5500-2a1c-11e9-986b-832571f24a2a.png)

> Also, the store uses a filename as the key for a file-to-kernel map. An unsaved file can eventually be saved, so we need to handle the this also.

When saved, the key is changed from editor ID to file path.