### PR TITLE
Remove force update hack

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -197,7 +197,10 @@ const Hydrogen = {
         );
 
         editorSubscriptions.add(
-          editor.onDidChangeTitle(newTitle => store.forceEditorUpdate())
+          editor.onDidChangeTitle(newTitle => {
+            const editor = atom.workspace.getActiveTextEditor();
+            store.updateEditor(editor);
+          })
         );
 
         store.subscriptions.add(editorSubscriptions);

--- a/lib/store/index.js
+++ b/lib/store/index.js
@@ -37,6 +37,9 @@ export class Store {
   configMapping: Map<string, ?mixed> = new Map();
   globalMode: boolean = Boolean(atom.config.get("Hydrogen.globalMode"));
 
+  @observable
+  filePath = this.editor ? this.editor.getPath() : null;
+
   @computed
   get kernel(): ?Kernel {
     if (this.globalMode) {
@@ -51,11 +54,6 @@ export class Store {
     const kernelOrMap = this.kernelMapping.get(this.filePath);
     if (!kernelOrMap || kernelOrMap instanceof Kernel) return kernelOrMap;
     if (this.grammar) return kernelOrMap.get(this.grammar.name);
-  }
-
-  @computed
-  get filePath(): ?string {
-    return this.editor ? this.editor.getPath() : null;
   }
 
   @computed
@@ -166,11 +164,10 @@ export class Store {
   updateEditor(editor: ?atom$TextEditor) {
     this.editor = editor;
     this.setGrammar(editor);
+    this.filePath = editor ? editor.getPath() : null;
 
-    if (this.globalMode && this.kernel && editor) {
-      const fileName = editor.getPath();
-      if (!fileName) return;
-      this.kernelMapping.set(fileName, this.kernel);
+    if (this.globalMode && this.kernel && this.filePath) {
+      this.kernelMapping.set(this.filePath, this.kernel);
     }
   }
 
@@ -204,14 +201,6 @@ export class Store {
       newValue = atom.config.get(keyPath);
     }
     this.configMapping.set(keyPath, newValue);
-  }
-
-  forceEditorUpdate() {
-    // Force mobx to recalculate filePath (which depends on editor observable)
-
-    const currentEditor = this.editor;
-    this.updateEditor(null);
-    this.updateEditor(currentEditor);
   }
 }
 

--- a/spec/components/status-bar-spec.js
+++ b/spec/components/status-bar-spec.js
@@ -6,7 +6,7 @@ import Adapter from "enzyme-adapter-react-16";
 
 Enzyme.configure({ adapter: new Adapter() });
 
-import store from "../../lib/store";
+import { Store } from "../../lib/store";
 import KernelTransport from "../../lib/kernel-transport";
 import Kernel from "../../lib/kernel";
 import StatusBar from "../../lib/components/status-bar";
@@ -36,82 +36,35 @@ describe("Status Bar", () => {
     expect(component.text()).toBe("");
   });
 
-  it("should update status correctly", () => {
-    spyOn(StatusBar.prototype, "render").and.callThrough();
-    const component = shallow(<StatusBar store={store} onClick={() => {}} />);
+  describe("Status bar config", () => {
+    let editor, kernel, store;
+    beforeEach(() => {
+      store = new Store();
+      editor = atom.workspace.buildTextEditor();
+      spyOn(editor, "getPath").and.returnValue("foo.py");
+      spyOn(editor, "getGrammar").and.returnValue("python");
+      store.updateEditor(editor);
+      kernel = new Kernel(
+        new KernelTransport({
+          display_name: "Kernel Language Display Name",
+          language: "python"
+        })
+      );
+      store.newKernel(kernel, store.filePath, store.editor, store.grammar);
+      kernel.setExecutionState("idle");
+    });
+    it("hides the component based on config setting", () => {
+      // disable the status bar
+      store.setConfigValue("Hydrogen.statusBarDisable", true);
 
-    // empty
-    expect(StatusBar.prototype.render).toHaveBeenCalledTimes(1);
-    expect(component.type()).toBeNull();
-    expect(component.text()).toBe("");
+      expect(store.kernel).toBeDefined();
+      const component = shallow(<StatusBar store={store} onClick={() => {}} />);
 
-    const kernel = new Kernel(
-      new KernelTransport({
-        display_name: "Python 3",
-        language: "python"
-      })
-    );
-    kernel.setExecutionState("starting");
+      expect(component.text()).toBe("");
 
-    const kernel2 = new Kernel(
-      new KernelTransport({
-        display_name: "Javascript",
-        language: "Javascript"
-      })
-    );
-    kernel2.setExecutionState("idle");
-
-    store.kernelMapping = new Map([
-      ["foo.py", kernel],
-      ["bar.py", kernel],
-      ["foo.js", kernel2]
-    ]);
-
-    store.editor = { getPath: () => "foo.py" };
-
-    // FixMe: Enzyme https://github.com/airbnb/enzyme/issues/1184
-    component.setState();
-    expect(store.kernel.displayName).toBe(kernel.displayName);
-    expect(store.kernel.executionState).toBe(kernel.executionState);
-    // expect(StatusBar.prototype.render).toHaveBeenCalledTimes(2);
-    expect(component.text()).toBe("Python 3 | starting");
-
-    // update execution state
-    store.kernel.setExecutionState("idle");
-
-    // FixMe: Enzyme https://github.com/airbnb/enzyme/issues/1184
-    component.setState();
-    // expect(StatusBar.prototype.render).toHaveBeenCalledTimes(3);
-    expect(component.text()).toBe("Python 3 | idle");
-
-    // doesn't update if switched to editor with same grammar
-    store.editor = { getPath: () => "bar.py" };
-    // expect(StatusBar.prototype.render).toHaveBeenCalledTimes(3);
-
-    // update kernel
-    store.editor = { getPath: () => "foo.js" };
-
-    // FixMe: Enzyme https://github.com/airbnb/enzyme/issues/1184
-    component.setState();
-    expect(store.kernel.displayName).toBe(kernel2.displayName);
-    expect(store.kernel.executionState).toBe(kernel2.executionState);
-    // expect(StatusBar.prototype.render).toHaveBeenCalledTimes(4);
-    expect(component.text()).toBe("Javascript | idle");
-  });
-
-  it("hides the component based on config setting", () => {
-    // disable the status bar
-    store.setConfigValue("Hydrogen.statusBarDisable", true);
-    expect(store.kernel).toBeDefined();
-    const component = shallow(<StatusBar store={store} onClick={() => {}} />);
-
-    expect(component.text()).toBe("");
-
-    // re-enable the status bar
-    store.setConfigValue("Hydrogen.statusBarDisable", false);
-    expect(component.text()).toBe("Javascript | idle");
+      // re-enable the status bar
+      store.setConfigValue("Hydrogen.statusBarDisable", false);
+      expect(component.text()).toBe("Kernel Language Display Name | idle");
+    });
   });
 });
-
-// reset store
-store.kernelMapping = new Map();

--- a/spec/store/index-spec.js
+++ b/spec/store/index-spec.js
@@ -289,6 +289,15 @@ describe("Store", () => {
       store.editor = { getPath: () => "foo.py" };
       expect(store.filePath).toBe("foo.py");
     });
+
+    it("should update filepath when the editor is saved or renamed", () => {
+      const editor = atom.workspace.buildTextEditor();
+      expect(store.filePath).toBeFalsy();
+      spyOn(editor, "getPath").and.returnValue("fake.py");
+
+      store.updateEditor(editor);
+      expect(store.filePath).toEqual("fake.py");
+    });
   });
 
   describe("get notebook", () => {

--- a/spec/store/index-spec.js
+++ b/spec/store/index-spec.js
@@ -2,7 +2,7 @@
 
 import { CompositeDisposable } from "atom";
 import { isObservableMap, isObservableProp, isComputedProp } from "mobx";
-import store, { Store } from "./../../lib/store";
+import globalStore, { Store } from "./../../lib/store";
 import KernelTransport from "./../../lib/kernel-transport";
 import Kernel from "./../../lib/kernel";
 import MarkerStore from "./../../lib/store/markers";
@@ -11,25 +11,24 @@ import { waitAsync } from "../helpers/test-utils";
 
 describe("Store initialize", () => {
   it("should correctly initialize store", () => {
-    expect(store.subscriptions instanceof CompositeDisposable).toBeTruthy();
-    expect(store.markers instanceof MarkerStore).toBeTruthy();
-    expect(store.runningKernels).toEqual([]);
-    expect(isObservableMap(store.startingKernels)).toBeTruthy();
-    expect(isObservableMap(store.kernelMapping)).toBeTruthy();
-    expect(isObservableProp(store, "editor")).toBeTruthy();
-    expect(isObservableProp(store, "grammar")).toBeTruthy();
-    expect(isComputedProp(store, "kernel")).toBeTruthy();
-    expect(isComputedProp(store, "notebook")).toBeTruthy();
+    expect(
+      globalStore.subscriptions instanceof CompositeDisposable
+    ).toBeTruthy();
+    expect(globalStore.markers instanceof MarkerStore).toBeTruthy();
+    expect(globalStore.runningKernels).toEqual([]);
+    expect(isObservableMap(globalStore.startingKernels)).toBeTruthy();
+    expect(isObservableMap(globalStore.kernelMapping)).toBeTruthy();
+    expect(isObservableProp(globalStore, "editor")).toBeTruthy();
+    expect(isObservableProp(globalStore, "grammar")).toBeTruthy();
+    expect(isComputedProp(globalStore, "kernel")).toBeTruthy();
+    expect(isComputedProp(globalStore, "notebook")).toBeTruthy();
   });
 });
 
 describe("Store", () => {
+  let store;
   beforeEach(() => {
-    store.subscriptions = new CompositeDisposable();
-    store.startingKernels = store.kernelMapping = new Map();
-    store.runningKernels = [];
-    store.editor = null;
-    store.grammar = null;
+    store = new Store();
   });
 
   describe("setGrammar", () => {
@@ -37,7 +36,7 @@ describe("Store", () => {
       const editor = atom.workspace.buildTextEditor();
       const grammar = editor.getGrammar();
       expect(grammar.name).toBe("Null Grammar");
-      expect(store.editor).toBeNull();
+
       store.setGrammar(editor);
       expect(store.grammar).toEqual(grammar);
     });
@@ -119,13 +118,11 @@ describe("Store", () => {
     it("should store kernel", () => {
       const editor = { getGrammar: () => ({ scopeName: "source.python" }) };
       const kernel = { kernelSpec: { display_name: "Python 3" } };
-      spyOn(store.startingKernels, "delete");
 
       store.newKernel(kernel, "foo.py", editor);
       expect(store.kernelMapping.size).toBe(1);
       expect(store.kernelMapping.get("foo.py")).toEqual(kernel);
       expect(store.runningKernels).toEqual([kernel]);
-      expect(store.startingKernels.delete).toHaveBeenCalledWith("Python 3");
     });
 
     it("should store kernel for multilanguage file", () => {
@@ -253,7 +250,7 @@ describe("Store", () => {
   describe("updateEditor", () => {
     it("should update editor", () => {
       spyOn(store, "setGrammar").and.callThrough();
-      expect(store.editor).toBeNull();
+      expect(store.editor).not.toBeDefined();
       const editor = atom.workspace.buildTextEditor();
       store.updateEditor(editor);
       expect(store.editor).toBe(editor);
@@ -286,7 +283,9 @@ describe("Store", () => {
     });
 
     it("should return file path", () => {
-      store.editor = { getPath: () => "foo.py" };
+      const editor = atom.workspace.buildTextEditor();
+      spyOn(editor, "getPath").and.returnValue("foo.py");
+      store.updateEditor(editor);
       expect(store.filePath).toBe("foo.py");
     });
 
@@ -357,51 +356,53 @@ describe("Store", () => {
   });
 
   describe("get kernel", () => {
+    let editor, kernel;
+    beforeEach(() => {
+      editor = atom.workspace.buildTextEditor();
+      spyOn(editor, "getPath").and.returnValue("foo.py");
+      spyOn(editor, "getGrammar").and.returnValue("python");
+      store.updateEditor(editor);
+      kernel = new Kernel(
+        new KernelTransport({
+          display_name: "Python 3",
+          language: "python"
+        })
+      );
+      store.newKernel(kernel, store.filePath, store.editor, store.grammar);
+    });
     it("should return null if no editor", () => {
+      store.updateEditor();
       expect(store.kernel).toBeNull();
     });
 
     it("should return null if editor isn't saved", () => {
-      store.editor = { getPath: () => {} };
+      store.updateEditor(atom.workspace.buildTextEditor());
       expect(store.kernel).toBeNull();
     });
 
     it("should return kernel", () => {
-      store.editor = { getPath: () => "foo.py" };
-      const kernel = new Kernel(
-        new KernelTransport({
-          display_name: "Python 3",
-          language: "python"
-        })
-      );
-      store.kernelMapping = new Map([["foo.py", kernel]]);
       expect(store.kernel).toEqual(kernel);
     });
 
     it("should return null if no kernel for file", () => {
-      store.editor = { getPath: () => "foo.py" };
-      const kernel = new Kernel(
-        new KernelTransport({
-          display_name: "Python 3",
-          language: "python"
-        })
-      );
-      store.kernelMapping = new Map([["bar.py", kernel]]);
-      expect(store.kernel).toBeUndefined();
+      const editorWithoutKernel = atom.workspace.buildTextEditor();
+      spyOn(editorWithoutKernel, "getPath").and.returnValue("no-kernel-yet.py");
+      spyOn(editorWithoutKernel, "getGrammar").and.returnValue("python");
+      store.updateEditor(editorWithoutKernel);
+      expect(store.kernel).not.toBeDefined();
     });
-
     it("should return the correct kernel for multilanguage files", () => {
-      store.editor = { getPath: () => "foo.md" };
+      const editor = atom.workspace.buildTextEditor();
+      spyOn(editor, "getPath").and.returnValue("foo.md");
+      spyOn(editor, "getGrammar").and.returnValue("python");
+      store.updateEditor(editor);
       const kernel = new Kernel(
         new KernelTransport({
           display_name: "Python 3",
           language: "python"
         })
       );
-      store.kernelMapping = new Map([
-        ["foo.md", new Map([["python", kernel]])]
-      ]);
-      store.grammar = { name: "python" };
+      store.newKernel(kernel, store.filePath, store.editor, store.grammar);
       expect(store.kernel).toEqual(kernel);
     });
   });


### PR DESCRIPTION
I wrote this hack a while back because the mobx calculated value for `store.filePath` would only update if the editor changed completely. This is because `store.filePath` relied on `editor.getPath()`, but this is not tracked by mobx. Changing `store.filePath` to an observable like below is much simpler.

WIP until #1534