### PR TITLE
isSingeLine -> isSingleLine

### DIFF
--- a/lib/store/output.js
+++ b/lib/store/output.js
@@ -54,7 +54,7 @@ export function reduceOutputs(
   return outputs;
 }
 
-export function isSingeLine(text: ?string, availableSpace: number) {
+export function isSingleLine(text: ?string, availableSpace: number) {
   // If it turns out escapeCarriageReturn is a bottleneck, we should remove it.
   return (
     (!text ||
@@ -98,11 +98,11 @@ export default class OutputStore {
         const bundle = output.data;
         const mimetype = richestMimetype(bundle, displayOrder, transforms);
         return mimetype === "text/plain"
-          ? isSingeLine(bundle[mimetype], availableSpace)
+          ? isSingleLine(bundle[mimetype], availableSpace)
           : false;
       }
       case "stream": {
-        return isSingeLine(output.text, availableSpace);
+        return isSingleLine(output.text, availableSpace);
       }
       default: {
         return false;

--- a/spec/store/output-spec.js
+++ b/spec/store/output-spec.js
@@ -2,7 +2,7 @@
 
 import OutputStore, {
   reduceOutputs,
-  isSingeLine
+  isSingleLine
 } from "../../lib/store/output";
 
 // Adapted from https://github.com/nteract/nteract/blob/master/test/renderer/reducers/document-spec.js#L33
@@ -121,23 +121,23 @@ describe("reduceOutputs", () => {
   });
 });
 
-describe("isSingeLine", () => {
+describe("isSingleLine", () => {
   it("checks for single line output", () => {
     const textSingle = "hello world";
-    expect(isSingeLine(textSingle, textSingle.length + 1)).toEqual(true);
-    expect(isSingeLine(textSingle, textSingle.length)).toEqual(false);
+    expect(isSingleLine(textSingle, textSingle.length + 1)).toEqual(true);
+    expect(isSingleLine(textSingle, textSingle.length)).toEqual(false);
   });
   it("checks for multiple line output", () => {
     const textMultiple = "hello \n world";
-    expect(isSingeLine(textMultiple, textMultiple.length + 1)).toEqual(false);
-    expect(isSingeLine(textMultiple, textMultiple.length)).toEqual(false);
+    expect(isSingleLine(textMultiple, textMultiple.length + 1)).toEqual(false);
+    expect(isSingleLine(textMultiple, textMultiple.length)).toEqual(false);
   });
   it("checks for single line output with line break at the end ", () => {
     const textEndlinebreak = "hello world \n";
-    expect(isSingeLine(textEndlinebreak, textEndlinebreak.length + 1)).toEqual(
+    expect(isSingleLine(textEndlinebreak, textEndlinebreak.length + 1)).toEqual(
       true
     );
-    expect(isSingeLine(textEndlinebreak, textEndlinebreak.length)).toEqual(
+    expect(isSingleLine(textEndlinebreak, textEndlinebreak.length)).toEqual(
       false
     );
   });


### PR DESCRIPTION
This typo bothers me every time I see it! All this does is rename `isSingeLine` to `isSingleLine`.

I did a project-wide search and replace so I think I found all instances.