### PR TITLE
Require Atom >= 1.28.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "repository": "https://github.com/nteract/hydrogen",
   "license": "MIT",
   "engines": {
-    "atom": ">=1.20.0 <2.0.0"
+    "atom": ">=1.28.0 <2.0.0"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Fixes #1551

Atom 1.28.0 was released in June 2018 I believe. That's probably old enough to not inconvenience ourselves to support it. Thoughts?