### PR TITLE
Add right-click context menu for import-notebook

### DIFF
--- a/lib/import-notebook.js
+++ b/lib/import-notebook.js
@@ -24,7 +24,13 @@ export function ipynbOpener(uri: string) {
   }
 }
 
-export function importNotebook() {
+export function importNotebook(event?: atom$CustomEvent) {
+  // Use selected filepath if called from tree-view context menu
+  const filenameFromTreeView = _.get(event, "target.dataset.path");
+  if (filenameFromTreeView && path.extname(filenameFromTreeView) === ".ipynb") {
+    return _loadNotebook(filenameFromTreeView);
+  }
+
   dialog.showOpenDialog(
     {
       properties: ["openFile"],

--- a/lib/main.js
+++ b/lib/main.js
@@ -154,7 +154,7 @@ const Hydrogen = {
           if (!kernel) return;
           kernel.outputStore.clear();
         },
-        "hydrogen:import-notebook": () => importNotebook()
+        "hydrogen:import-notebook": importNotebook
       })
     );
 

--- a/menus/hydrogen.cson
+++ b/menus/hydrogen.cson
@@ -1,11 +1,6 @@
-# See https://atom.io/docs/latest/hacking-atom-package-word-count#menus for more details
-# 'context-menu':
-#   'atom-text-editor': [
-#     {
-#       'label': 'Toggle atom-repl'
-#       'command': 'atom-repl:toggle'
-#     }
-#   ]
+'context-menu':
+  '.tree-view .file .name[data-name$=\\.ipynb]':
+    [{label: 'Import Notebook', command: 'hydrogen:import-notebook'}]
 'menu': [
   {
     'label': 'Packages'

--- a/package.json
+++ b/package.json
@@ -92,6 +92,11 @@
       "versions": {
         "^1.0.0": "consumeStatusBar"
       }
+    },
+    "tree-view": {
+      "versions": {
+        "^1.0.0": "consumeTreeView"
+      }
     }
   },
   "providedServices": {


### PR DESCRIPTION
When called as an atom-command from the tree-view context menu, we are passed
back an event containing, among other things, the selected filepath

This is useful when hydrogen isn't activated yet,
but you want to import-notebook from tree-view instead of a dialog