### PR TITLE
1527: Fix typo in style customization doc

### DIFF
--- a/docs/StyleCustomization.md
+++ b/docs/StyleCustomization.md
@@ -26,7 +26,7 @@ In your styles.less:
 ```less
 .hydrogen {
   .multiline-container {
-    .cell_display {
+    .hydrogen_cell_display {
       background-color: @background-color-highlight;
     }
   }

--- a/lib/import-notebook.js
+++ b/lib/import-notebook.js
@@ -24,7 +24,13 @@ export function ipynbOpener(uri: string) {
   }
 }
 
-export function importNotebook() {
+export function importNotebook(event?: atom$CustomEvent) {
+  // Use selected filepath if called from tree-view context menu
+  const filenameFromTreeView = _.get(event, "target.dataset.path");
+  if (filenameFromTreeView && path.extname(filenameFromTreeView) === ".ipynb") {
+    return _loadNotebook(filenameFromTreeView);
+  }
+
   dialog.showOpenDialog(
     {
       properties: ["openFile"],

--- a/lib/main.js
+++ b/lib/main.js
@@ -154,7 +154,7 @@ const Hydrogen = {
           if (!kernel) return;
           kernel.outputStore.clear();
         },
-        "hydrogen:import-notebook": () => importNotebook()
+        "hydrogen:import-notebook": importNotebook
       })
     );
 

--- a/menus/hydrogen.cson
+++ b/menus/hydrogen.cson
@@ -1,11 +1,6 @@
-# See https://atom.io/docs/latest/hacking-atom-package-word-count#menus for more details
-# 'context-menu':
-#   'atom-text-editor': [
-#     {
-#       'label': 'Toggle atom-repl'
-#       'command': 'atom-repl:toggle'
-#     }
-#   ]
+'context-menu':
+  '.tree-view .file .name[data-name$=\\.ipynb]':
+    [{label: 'Import Notebook', command: 'hydrogen:import-notebook'}]
 'menu': [
   {
     'label': 'Packages'

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "atom-jasmine3-test-runner": "^4.0.0",
     "enzyme": "^3.1.1",
     "enzyme-adapter-react-16": "^1.0.4",
-    "flow-bin": "^0.96.0",
+    "flow-bin": "^0.97.0",
     "husky": "^1.1.0",
     "lint-staged": "^8.0.0",
     "markdox": "^0.1.10",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,11 @@
       "versions": {
         "^1.0.0": "consumeStatusBar"
       }
+    },
+    "tree-view": {
+      "versions": {
+        "^1.0.0": "consumeTreeView"
+      }
     }
   },
   "providedServices": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Hydrogen",
   "main": "./lib/main",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "description": "Run code interactively, inspect data, and plot. All the power of Jupyter kernels, inside your favorite text editor.",
   "author": "nteract contributors",
   "keywords": [


### PR DESCRIPTION
This PR is to fix a small typo in [the style customization doc](docs/StyleCustomization.md#multiline-result-view), about which I created #1527.
To be more specific, the class name of cells in multiline results is now defined as `.multiline-container .hydrogen_cell_display`, but the doc example still shows `.multiline-container .cell_display`.

(I found 1 package spec error and 5 flow type-check errors, but they are difinitely unrelated to this commit)