### PR TITLE
Fix wrapping result issue #1569

### DIFF
--- a/styles/hydrogen.less
+++ b/styles/hydrogen.less
@@ -27,7 +27,7 @@ code, pre {
   font-size: inherit;
   font-family: inherit;
   padding: 0;
-  white-space: pre;
+  white-space: pre-wrap;
 }
 
 img {


### PR DESCRIPTION
This PR fixes [hydrogen.less](styles/hydrogen.less) so that results will be wrapped correctly.

Why `pre-wrap` ?:
- The values that wrap texts other than `pre-wrap` *don't* preserve a sequence of whitespaces/tabs, which seems inappropriate in code results. See https://developer.mozilla.org/en-US/docs/Web/CSS/white-space#Values.