### PR TITLE
Fix `npm run prettier` command's script

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "scripts": {
     "flow": "flow",
-    "prettier": "prettier --write 'lib/**/*.js' 'spec/**/*.js'",
+    "prettier": "prettier --write lib/**/*.js spec/**/*.js",
     "build:docs": "markdox lib/plugin-api/hydrogen-provider.js lib/plugin-api/hydrogen-kernel.js -o docs/PluginAPI.md"
   },
   "atomTestRunner": "atom-jasmine3-test-runner",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "scripts": {
     "flow": "flow",
-    "prettier": "prettier --write lib/**/*.js spec/**/*.js",
+    "prettier": "prettier --write \"lib/**/*.js\" \"spec/**/*.js\"",
     "build:docs": "markdox lib/plugin-api/hydrogen-provider.js lib/plugin-api/hydrogen-kernel.js -o docs/PluginAPI.md"
   },
   "atomTestRunner": "atom-jasmine3-test-runner",


### PR DESCRIPTION
The prettier command seems to be broken:
```
$ npm run prettier

> Hydrogen@2.9.0 prettier C:\Users\aviat\GitHub\Hydrogen
> prettier --write 'lib/**/*.js' 'spec/**/*.js'

[error] No matching files. Patterns tried: 'lib/**/*.js' 'spec/**/*.js' !**/node_modules/** !./node_modules/** !**/.{git,svn,hg
}/** !./.{git,svn,hg}/**
npm ERR! code ELIFECYCLE
npm ERR! errno 2
npm ERR! Hydrogen@2.9.0 prettier: `prettier --write 'lib/**/*.js' 'spec/**/*.js'`
npm ERR! Exit status 2
npm ERR!
npm ERR! Failed at the Hydrogen@2.9.0 prettier script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\aviat\AppData\Roaming\npm-cache\_logs\2019-05-09T11_08_03_665Z-debug.log
```

I stripped single quotes and then it works fine

```
$ npm run prettier

> Hydrogen@2.9.0 prettier C:\Users\aviat\GitHub\Hydrogen
> prettier --write lib/**/*.js spec/**/*.js

lib\autocomplete-provider.js 125ms
lib\code-manager.js 189ms
lib\commands.js 36ms
lib\components\inspector.js 40ms
lib\components\kernel-monitor.js 34ms
lib\components\output-area.js 56ms
lib\components\result-view\history.js 42ms
lib\components\result-view\index.js 40ms
lib\components\result-view\list.js 21ms
lib\components\result-view\result-view.js 62ms
lib\components\result-view\status.js 22ms
lib\components\result-view\transforms.js 20ms
lib\components\status-bar.js 12ms
lib\components\watch-sidebar\index.js 18ms
lib\components\watch-sidebar\watch.js 22ms
lib\config.js 33ms
lib\existing-kernel-picker.js 29ms
lib\export-notebook.js 18ms
lib\import-notebook.js 43ms
lib\input-view.js 40ms
lib\kernel-manager.js 75ms
lib\kernel-picker.js 20ms
lib\kernel-transport.js 19ms
lib\kernel.js 64ms
lib\main.js 115ms
lib\panes\inspector.js 19ms
lib\panes\kernel-monitor.js 14ms
lib\panes\output-area.js 23ms
lib\panes\watches.js 12ms
lib\plugin-api\hydrogen-kernel.js 21ms
lib\plugin-api\hydrogen-provider.js 15ms
lib\plugin-api\hydrogen-types.js 22ms
lib\signal-list-view.js 33ms
lib\store\index.js 57ms
lib\store\markers.js 18ms
lib\store\output.js 27ms
lib\store\watch.js 15ms
lib\store\watches.js 44ms
lib\utils.js 26ms
lib\ws-kernel-picker.js 55ms
lib\ws-kernel.js 16ms
lib\zmq-kernel.js 50ms
spec\code-manager-spec.js 48ms
spec\commands-spec.js 19ms
spec\components\output-area-spec.js 22ms
spec\components\result-view\history-spec.js 13ms
spec\components\result-view\result-view-spec.js 10ms
spec\components\status-bar-spec.js 17ms
spec\config-spec.js 8ms
spec\helpers\test-utils.js 8ms
spec\import-notebook-spec.js 13ms
spec\kernel-manager-spec.js 30ms
spec\panes-spec.js 23ms
spec\store\index-spec.js 95ms
spec\store\markers-spec.js 14ms
spec\store\output-spec.js 44ms
spec\store\watch-spec.js 23ms
spec\utils-spec.js 25ms
```