### PR TITLE
Activate the existing items in a dock in addition to showing the dock

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -45,7 +45,12 @@ export async function openOrShowDock(URI: string): Promise<?void> {
   // this function is basically workspace.open, except it
   // will not focus the newly opened pane
   let dock = atom.workspace.paneContainerForURI(URI);
-  if (dock) return dock.show();
+  if (dock) {
+    // If the target item already exist, activate it and show dock
+    const pane = atom.workspace.paneForURI(URI);
+    if (pane) pane.activateItemForURI(URI);
+    return dock.show();
+  }
 
   await atom.workspace.open(URI, {
     searchAllPanes: true,

--- a/types/atom.js.flow
+++ b/types/atom.js.flow
@@ -428,6 +428,7 @@ declare class atom$Pane {
   getActiveItemIndex(): number,
   activateItem(item: Object): ?Object,
   activateItemAtIndex(index: number): void,
+  activateItemForURI(uri: string): boolean,
   moveItemToPane(item: Object, pane: atom$Pane, index: number): void,
   destroyItem(item: Object, force?: boolean): boolean | Promise<boolean>,
   itemForURI(uri: string): Object,


### PR DESCRIPTION
`openOrShowDock` is called after every execution when output view is toggled and when `Hydrogen:Add-Watch` or `Hydrogen:Remove-Watch` is called.

Currently it only shows the dock and the target items are not activated if they are not already activated (here to _activate_ means to make the item visible in a pane).

This PR is a workaround for this using [`atom$Pane.activateItemForURI`](https://atom.io/docs/api/v1.0.2/Pane#instance-activateItemForURI) API which doesn't focus the item but only activate the item.