### PR TITLE
Enable jump click on slider range

### DIFF
--- a/styles/hydrogen.less
+++ b/styles/hydrogen.less
@@ -184,6 +184,7 @@ svg:first-child {
   padding: @pad @btn-size + 1;
   height: @btn-size + 2 * @pad;
   position: relative;
+  display: flex;
   .rangeslider {
     position: relative;
     width: 100%;


### PR DESCRIPTION
This is very small tweak on styles.less sheet: Enable click on anywhere on slider range.

Currently we have to click on the side icons or drag the slider, but if we add `display: flux` to the original class we can click wherever on slider range and can jump to that point:
![image](https://user-images.githubusercontent.com/40514306/57573921-b8f61080-746a-11e9-8e62-2e5be686d8b3.png)

The change seems to have no effect other than that.