### PR TITLE
Implement markdown preview

### DIFF
--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -242,10 +242,10 @@ export function getCell(
   editor: atom$TextEditor,
   start: atom$Point,
   end: atom$Point
-) {
+): { range: atom$Range, cellType: HydrogenCellType } {
   const buffer = editor.getBuffer();
   const regexString = getRegexString(editor);
-  let cellType = "code";
+  let cellType: HydrogenCellType = "codecell";
 
   if (!regexString) {
     return {

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -287,10 +287,11 @@ export function getCell(
       }
     );
   }
-
+  end = buffer.getEndPosition();
+  end.row++;
   buffer.scanInRange(
     regex,
-    new Range(new Point(start.row + 1, 0), buffer.getEndPosition()),
+    new Range(new Point(start.row + 1, 0), end),
     ({ range }) => {
       end = new Point(range.end.row, 0);
     }

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -263,7 +263,15 @@ export function getCell(
       ({ match, range }) => {
         for (let i = 1; i < match.length; i++) {
           if (match[i]) {
-            cellType = match[i];
+            switch (match[i]) {
+              case "md":
+              case "markdown":
+                cellType = "markdown";
+                break;
+              case "codecell":
+              default:
+                cellType = "codecell";
+            }
           }
         }
         start = new Point(range.start.row, 0);

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -349,7 +349,7 @@ export function findPrecedingBlock(
       row = previousRow;
     }
     if (sameIndent && !blank && !isEnd) {
-      return [getRows(editor, previousRow, row), row];
+      return { code: getRows(editor, previousRow, row), row };
     }
     previousRow -= 1;
   }
@@ -357,16 +357,44 @@ export function findPrecedingBlock(
 }
 
 export function findCodeBlock(editor: atom$TextEditor) {
+  const currentCell = getCurrentCell(editor);
   const selectedText = getSelectedText(editor);
 
   if (selectedText) {
     const selectedRange = editor.getSelectedBufferRange();
+    let startRow = selectedRange.start.row;
+    let startColumn = selectedRange.start.column;
     let endRow = selectedRange.end.row;
-    if (selectedRange.end.column === 0) {
+    let endColumn = selectedRange.end.column;
+    if (endColumn === 0) {
       endRow -= 1;
+      endColumn = editor.getBuffer().rangeForRow(endRow, false).end.column;
     }
-    endRow = escapeBlankRows(editor, selectedRange.start.row, endRow);
-    return [selectedText, endRow];
+    console.log(startRow);
+    console.log(endRow);
+    endRow = escapeBlankRows(editor, startRow, endRow);
+    if (startRow == currentCell.range.start.row) {
+      startRow++;
+      startColumn = 0;
+    }
+    const code =
+      currentCell.cellType == "md" || currentCell.cellType == "markdown"
+        ? parseCodeToMarkdown(
+            editor,
+            new Point(startRow, startColumn),
+            new Point(endRow, endColumn)
+          )
+        : getTextInRange(
+            editor,
+            new Point(startRow, startColumn),
+            new Point(endRow, endColumn)
+          );
+    console.log(code);
+    return {
+      code: startRow <= endRow ? code : "",
+      row: endRow,
+      cellType: currentCell.cellType
+    };
   }
 
   const cursor = editor.getLastCursor();

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -272,7 +272,7 @@ function getCurrentFencedCodeBlock(editor: atom$TextEditor) {
     end += 1;
   }
 
-  return { range: new Range([start, 0], [end, 9999999]), cellType };
+  return { range: new Range([start, 0], [end, 9999999]), cellType: "codecell" };
 }
 
 export function getCurrentCell(editor: atom$TextEditor) {

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -130,7 +130,7 @@ export function getFoldRange(editor: atom$TextEditor, row: number) {
 export function getFoldContents(editor: atom$TextEditor, row: number) {
   const range = getFoldRange(editor, row);
   if (!range) return;
-  return [getRows(editor, range[0], range[1]), range[1]];
+  return { code: getRows(editor, range[0], range[1]), row: range[1] };
 }
 
 export function getCodeToInspect(editor: atom$TextEditor) {

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -206,40 +206,8 @@ export function getBreakpoints(editor: atom$TextEditor) {
 function getCurrentCodeCell(editor: atom$TextEditor) {
   const buffer = editor.getBuffer();
   let start = new Point(0, 0);
-  let end = buffer.getEndPosition();
-  const regexString = getRegexString(editor);
-  let cellType = "code";
-
-  if (!regexString) {
-    return { range: new Range(start, end), cellType };
-  }
-
-  const regex = new RegExp(regexString);
-  const cursor = editor.getCursorBufferPosition();
-  cursor.column = buffer.rangeForRow(cursor.row, false).end.column;
-
-  if (cursor.row >= 0) {
-    buffer.backwardsScanInRange(
-      regex,
-      new Range(start, cursor),
-      ({ match, range }) => {
-        for (let i = 1; i < match.length; i++) {
-          if (match[i]) {
-            cellType = match[i];
-          }
-        }
-        start = new Point(range.start.row, 0);
-      }
-    );
-  }
-
-  buffer.scanInRange(regex, new Range(cursor, end), ({ range }) => {
-    end = range.start;
-  });
-
-  log("CellManager: Cell [start, end]:", [start, end], "cursor:", cursor);
-
-  return { range: new Range(start, end), cellType };
+  let end = buffer.rangeForRow(editor.getCursorBufferPosition().row, true).end;
+  return getCell(editor, start, end);
 }
 
 function isEmbeddedCode(
@@ -278,6 +246,52 @@ export function getCurrentCell(editor: atom$TextEditor) {
     return getCurrentFencedCodeBlock(editor);
   }
   return getCurrentCodeCell(editor);
+}
+
+export function getCell(
+  editor: atom$TextEditor,
+  start: atom$Point,
+  end: atom$Point
+) {
+  const buffer = editor.getBuffer();
+  const regexString = getRegexString(editor);
+  let cellType = "code";
+
+  if (!regexString) {
+    return {
+      range: new Range(new Point(0, 0), buffer.getEndPosition()),
+      cellType
+    };
+  }
+
+  const regex = new RegExp(regexString);
+
+  if (end.row >= 0) {
+    buffer.backwardsScanInRange(
+      regex,
+      new Range(start, end),
+      ({ match, range }) => {
+        for (let i = 1; i < match.length; i++) {
+          if (match[i]) {
+            cellType = match[i];
+          }
+        }
+        start = new Point(range.start.row, 0);
+      }
+    );
+  }
+
+  buffer.scanInRange(
+    regex,
+    new Range(new Point(start.row + 1, 0), buffer.getEndPosition()),
+    ({ range }) => {
+      end = new Point(range.end.row, 0);
+    }
+  );
+
+  log("CellManager: Cell [start, end]:", [start, end]);
+
+  return { range: new Range(start, end), cellType };
 }
 
 export function getCells(

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -212,9 +212,8 @@ export function getBreakpoints(editor: atom$TextEditor) {
 }
 
 function getCurrentCodeCell(editor: atom$TextEditor) {
-  const buffer = editor.getBuffer();
   let start = new Point(0, 0);
-  let end = buffer.rangeForRow(editor.getCursorBufferPosition().row, true).end;
+  let end = new Point(editor.getCursorBufferPosition().row + 1, 0);
   return getCell(editor, start, end);
 }
 

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -425,9 +425,15 @@ export function parseCodeToMarkdown(
   if (commentStartString) trimLength = commentStartString.length + 1;
 
   let markdown = "";
-  for (let i = start.row + 1; i <= end.row; i++) {
-    const text = getRow(editor, i);
-    text != null ? (markdown += text.substring(trimLength) + "\n\n") : null;
+  for (let i = start.row; i <= end.row; i++) {
+    const text = getTextInRange(
+      editor,
+      i == start.row ? start : new Point(i, 0),
+      i == end.row ? end : new Point(i + 1, 0)
+    );
+    text != null
+      ? (markdown += normalizeString(text.substring(trimLength)) + "\n")
+      : null;
   }
   return markdown;
 }

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -133,7 +133,11 @@ export function getFoldContents(editor: atom$TextEditor, row: number) {
   return {
     code: getRows(editor, range[0], range[1]),
     row: range[1],
-    cellType: getCell(editor, range[0], range[1]).cellType
+    cellType: getCell(
+      editor,
+      new Point(range[0], 0),
+      new Point(range[1] + 1, 0)
+    ).cellType
   };
 }
 

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -425,7 +425,7 @@ export function parseCodeToMarkdown(
 
   let markdown = "";
   for (let i = start.row + 1; i <= end.row; i++) {
-    text = getRow(editor, i);
+    const text = getRow(editor, i);
     text != null ? (markdown += text.substring(2) + "\n\n") : null;
   }
   return markdown;

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -38,7 +38,7 @@ export function getRows(
   startRow: number,
   endRow: number
 ) {
-  const code = editor.getTextInBufferRange({
+  const text = editor.getTextInBufferRange({
     start: {
       row: startRow,
       column: 0
@@ -48,7 +48,7 @@ export function getRows(
       column: 9999999
     }
   });
-  return normalizeString(code);
+  return normalizeString(text);
 }
 
 export function getMetadataForRow(

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -29,8 +29,8 @@ export function getTextInRange(
   start: atom$Point,
   end: atom$Point
 ) {
-  const code = editor.getTextInBufferRange([start, end]);
-  return normalizeString(code);
+  const text = editor.getTextInBufferRange([start, end]);
+  return normalizeString(text);
 }
 
 export function getRows(

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -487,13 +487,14 @@ export function parseCodeToMarkdown(
 
   let markdown = "";
   for (let i = start.row; i <= end.row; i++) {
-    const text = getTextInRange(
-      editor,
-      i == start.row ? start : new Point(i, 0),
-      i == end.row ? end : new Point(i + 1, 0)
+    const text = normalizeString(
+      getTextInRange(
+        editor,
+        i == start.row ? start : new Point(i, 0),
+        i == end.row ? end : new Point(i + 1, 0)
+      )
     );
-    const parsedText = normalizeString(text.substring(trimLength));
-    text != null && parsedText != null ? (markdown += parsedText + "\n") : null;
+    text != null ? (markdown += text.substring(trimLength) + "\n") : null;
   }
   return markdown;
 }

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -216,10 +216,9 @@ function getCurrentCodeCell(editor: atom$TextEditor) {
 
   const regex = new RegExp(regexString);
   const cursor = editor.getCursorBufferPosition();
+  cursor.column = buffer.rangeForRow(cursor.row, false).end.column;
 
-  cursor.column = 0;
-
-  if (cursor.row > 0) {
+  if (cursor.row >= 0) {
     buffer.backwardsScanInRange(
       regex,
       new Range(start, cursor),

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -130,7 +130,11 @@ export function getFoldRange(editor: atom$TextEditor, row: number) {
 export function getFoldContents(editor: atom$TextEditor, row: number) {
   const range = getFoldRange(editor, row);
   if (!range) return;
-  return { code: getRows(editor, range[0], range[1]), row: range[1] };
+  return {
+    code: getRows(editor, range[0], range[1]),
+    row: range[1],
+    cellType: getCell(editor, range[0], range[1]).cellType
+  };
 }
 
 export function getCodeToInspect(editor: atom$TextEditor) {

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -353,14 +353,14 @@ export function findPrecedingBlock(
   let previousRow = row - 1;
   while (previousRow >= 0) {
     const previousIndentLevel = editor.indentationForBufferRow(previousRow);
-    const sameIndent = previousIndentLevel <= indentLevel;
+    const sameScope = previousIndentLevel <= indentLevel;
     const blank = isBlank(editor, previousRow);
     const isEnd = getRow(editor, previousRow) === "end";
 
     if (isBlank(editor, row)) {
       row = previousRow;
     }
-    if (sameIndent && !blank && !isEnd) {
+    if (sameScope && !blank && !isEnd) {
       return { code: getRows(editor, previousRow, row), row };
     }
     previousRow -= 1;

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -236,7 +236,6 @@ function getCurrentCodeCell(editor: atom$TextEditor) {
 
   buffer.scanInRange(regex, new Range(cursor, end), ({ range }) => {
     end = range.start;
-    end.row--;
   });
 
   log("CellManager: Cell [start, end]:", [start, end], "cursor:", cursor);

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -389,7 +389,7 @@ export function findCodeBlock(editor: atom$TextEditor) {
           );
     console.log(code);
     return {
-      code: startRow <= endRow ? code : "",
+      code: startRow <= endRow ? code : true,
       row: endRow,
       cellType: currentCell.cellType
     };

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -239,7 +239,6 @@ function getCurrentCodeCell(editor: atom$TextEditor) {
     end.row--;
   });
 
-  //log("CellManager: Cell [start, end]:", [start, end], "cursor:", cursor);
   log("CellManager: Cell [start, end]:", [start, end], "cursor:", cursor);
 
   return { range: new Range(start, end), cellType };
@@ -373,7 +372,6 @@ export function findCodeBlock(editor: atom$TextEditor) {
   const cursor = editor.getLastCursor();
 
   const row = cursor.getBufferRow();
-
   log("findCodeBlock:", row);
 
   const indentLevel = cursor.getIndentLevel();

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -384,19 +384,23 @@ export function findCodeBlock(editor: atom$TextEditor) {
       startRow++;
       startColumn = 0;
     }
-    const code =
-      currentCell.cellType == "md" || currentCell.cellType == "markdown"
-        ? parseCodeToMarkdown(
-            editor,
-            new Point(startRow, startColumn),
-            new Point(endRow, endColumn)
-          )
-        : getTextInRange(
-            editor,
-            new Point(startRow, startColumn),
-            new Point(endRow, endColumn)
-          );
-    console.log(code);
+    let code;
+    switch (currentCell.cellType) {
+      case "markdown":
+        code = parseCodeToMarkdown(
+          editor,
+          new Point(startRow, startColumn),
+          new Point(endRow, endColumn)
+        );
+        break;
+      case "codecell":
+        code = getTextInRange(
+          editor,
+          new Point(startRow, startColumn),
+          new Point(endRow, endColumn)
+        );
+        break;
+    }
     return {
       code: startRow <= endRow ? code : true,
       row: endRow,

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -51,26 +51,6 @@ export function getRows(
   return normalizeString(text);
 }
 
-export function removeCommentsMarkdownCell(
-  editor: atom$TextEditor,
-  text: string
-): string {
-  const commentStartString = getCommentStartString(editor);
-  if (!commentStartString) return text;
-
-  const lines = text.split("\n");
-  const editedLines = [];
-  _.forEach(lines, line => {
-    if (line.startsWith(commentStartString)) {
-      // Remove comment from start of line
-      editedLines.push(line.slice(commentStartString.length));
-    } else {
-      editedLines.push(line);
-    }
-  });
-  return stripIndent(editedLines.join("\n"));
-}
-
 export function getSelectedText(editor: atom$TextEditor) {
   return normalizeString(editor.getSelectedText());
 }

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -51,23 +51,6 @@ export function getRows(
   return normalizeString(text);
 }
 
-export function getMetadataForRow(
-  editor: atom$TextEditor,
-  start: atom$Point
-): string {
-  // `start` is a Point on the first line of the cell. The cell marker is on the
-  // previous line
-  if (start.row === 0) {
-    return "code";
-  }
-  var rowText = getRow(editor, start.row - 1);
-  if (_.includes(rowText, "md") || _.includes(rowText, "markdown")) {
-    return "markdown";
-  } else {
-    return "code";
-  }
-}
-
 export function removeCommentsMarkdownCell(
   editor: atom$TextEditor,
   text: string

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -13,9 +13,9 @@ import {
   rowRangeForCodeFoldAtBufferRow
 } from "./utils";
 
-export function normalizeString(code: ?string) {
-  if (code) {
-    return code.replace(/\r\n|\r/g, "\n");
+export function normalizeString(text: ?string) {
+  if (text) {
+    return text.replace(/\r\n|\r/g, "\n");
   }
   return null;
 }

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -387,7 +387,18 @@ export function findCodeBlock(editor: atom$TextEditor) {
   if (isBlank(editor, row) || getRow(editor, row) === "end") {
     return findPrecedingBlock(editor, row, indentLevel);
   }
-  return [getRow(editor, row), row];
+  let code = true;
+  if (currentCell.range.start.row != row) {
+    code =
+      currentCell.cellType == "md" || currentCell.cellType == "markdown"
+        ? parseCodeToMarkdown(editor, new Point(row, 0), new Point(row + 1, 0))
+        : getTextInRange(editor, new Point(row, 0), new Point(row + 1, 0));
+  }
+  return {
+    code,
+    row,
+    cellType: currentCell.cellType
+  };
 }
 
 export function foldCurrentCell(editor: atom$TextEditor) {

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -369,7 +369,11 @@ export function findPrecedingBlock(
       row = previousRow;
     }
     if (sameScope && !blank && !isEnd) {
-      return { code: getRows(editor, previousRow, row), row };
+      return {
+        code: getRows(editor, previousRow, row),
+        row,
+        cellType: getCell(editor, new Point(0, 0), new Point(row + 1, 0))
+      };
     }
     previousRow -= 1;
   }

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -427,7 +427,8 @@ export function parseCodeToMarkdown(
 
   let markdown = "";
   for (let i = start.row + 1; i <= end.row; i++) {
-    markdown += getRow(editor, i).substring(2) + "\n\n";
+    text = getRow(editor, i);
+    text != null ? (markdown += text.substring(2) + "\n\n") : null;
   }
   return markdown;
 }

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -492,9 +492,8 @@ export function parseCodeToMarkdown(
       i == start.row ? start : new Point(i, 0),
       i == end.row ? end : new Point(i + 1, 0)
     );
-    text != null && normalizeString(text.substring(trimLength)) != null
-      ? (markdown += normalizeString(text.substring(trimLength)) + "\n")
-      : null;
+    const parsedText = normalizeString(text.substring(trimLength));
+    text != null && parsedText != null ? (markdown += parsedText + "\n") : null;
   }
   return markdown;
 }

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -455,8 +455,12 @@ export function findCodeBlock(editor: atom$TextEditor) {
 
 export function foldCurrentCell(editor: atom$TextEditor) {
   const { range: cellRange } = getCurrentCell(editor);
-  const newRange = adjustCellFoldRange(editor, cellRange);
-  editor.setSelectedBufferRange(newRange);
+  foldCell(editor, cellRange);
+}
+
+export function foldCell(editor: atom$TextEditor, range: atom$Range) {
+  const foldRange = adjustCellFoldRange(editor, range);
+  editor.setSelectedBufferRange(foldRange);
   editor.getSelections()[0].fold();
 }
 
@@ -465,14 +469,17 @@ export function foldAllButCurrentCell(editor: atom$TextEditor) {
 
   // I take .slice(1) because there's always an empty cell range from [0,0] to
   // [0,0]
-  const allCellRanges = getCells(editor).slice(1);
-  const currentCellRange = getCurrentCell(editor)["range"];
-  const newRanges = allCellRanges
-    .filter(cellRange => !cellRange.isEqual(currentCellRange))
-    .map(cellRange => adjustCellFoldRange(editor, cellRange));
-
-  editor.setSelectedBufferRanges(newRanges);
-  editor.getSelections().forEach(selection => selection.fold());
+  const allCellRanges = getCells(editor);
+  const currentCellRange = getCurrentCell(editor).range;
+  _.forEach(allCellRanges, range => {
+    log("cell", range);
+    if (
+      range.start.row != currentCellRange.start.row &&
+      range.end.row != currentCellRange.end.row
+    ) {
+      foldCell(editor, range);
+    }
+  });
 
   // Restore selections
   editor.setSelectedBufferRanges(initialSelections);
@@ -504,15 +511,16 @@ export function parseCodeToMarkdown(
 }
 
 function adjustCellFoldRange(editor: atom$TextEditor, range: atom$Range) {
-  const startRow = range.start.row > 0 ? range.start.row - 1 : 0;
+  const startRow = range.start.row > 0 ? range.start.row : 0;
   const startWidth = editor.lineTextForBufferRow(startRow).length;
   const endRow =
     range.end.row == editor.getLastBufferRow()
       ? range.end.row
       : range.end.row - 1;
+  const endWidth = editor.lineTextForBufferRow(endRow).length;
 
   return new Range(
     new Point(startRow, startWidth),
-    new Point(endRow, range.end.column)
+    new Point(endRow, endWidth)
   );
 }

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -211,7 +211,7 @@ function getCurrentCodeCell(editor: atom$TextEditor) {
   let cellType = "code";
 
   if (!regexString) {
-    return new Range(start, end);
+    return { range: new Range(start, end), cellType };
   }
 
   const regex = new RegExp(regexString);
@@ -272,7 +272,7 @@ function getCurrentFencedCodeBlock(editor: atom$TextEditor) {
     end += 1;
   }
 
-  return new Range([start, 0], [end, 9999999]);
+  return { range: new Range([start, 0], [end, 9999999]), cellType };
 }
 
 export function getCurrentCell(editor: atom$TextEditor) {

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -453,7 +453,7 @@ export function findCodeBlock(editor: atom$TextEditor) {
 }
 
 export function foldCurrentCell(editor: atom$TextEditor) {
-  const cellRange = getCurrentCell(editor)["range"];
+  const { range: cellRange } = getCurrentCell(editor);
   const newRange = adjustCellFoldRange(editor, cellRange);
   editor.setSelectedBufferRange(newRange);
   editor.getSelections()[0].fold();

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -214,7 +214,7 @@ function isEmbeddedCode(
 function getCurrentFencedCodeBlock(editor: atom$TextEditor) {
   const buffer = editor.getBuffer();
   const { row: bufferEndRow } = buffer.getEndPosition();
-
+  const cellType: HydrogenCellType = "codecell";
   const cursor = editor.getCursorBufferPosition();
   let start = cursor.row;
   let end = cursor.row;
@@ -228,7 +228,7 @@ function getCurrentFencedCodeBlock(editor: atom$TextEditor) {
     end += 1;
   }
 
-  return { range: new Range([start, 0], [end + 1, 0]), cellType: "codecell" };
+  return { range: new Range([start, 0], [end + 1, 0]), cellType: cellType };
 }
 
 export function getCurrentCell(editor: atom$TextEditor) {

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -212,8 +212,8 @@ export function getBreakpoints(editor: atom$TextEditor) {
 }
 
 function getCurrentCodeCell(editor: atom$TextEditor) {
-  let start = new Point(0, 0);
-  let end = new Point(editor.getCursorBufferPosition().row + 1, 0);
+  const start = new Point(0, 0);
+  const end = new Point(editor.getCursorBufferPosition().row + 1, 0);
   return getCell(editor, start, end);
 }
 

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -420,13 +420,14 @@ export function parseCodeToMarkdown(
   start: atom$Point,
   end: atom$Point
 ): string {
+  let trimLength = 0;
   const commentStartString = getCommentStartString(editor);
-  if (!commentStartString) return getTextInRange(editor, start, end);
+  if (commentStartString) trimLength = commentStartString.length + 1;
 
   let markdown = "";
   for (let i = start.row + 1; i <= end.row; i++) {
     const text = getRow(editor, i);
-    text != null ? (markdown += text.substring(2) + "\n\n") : null;
+    text != null ? (markdown += text.substring(trimLength) + "\n\n") : null;
   }
   return markdown;
 }

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -475,9 +475,11 @@ export function parseCodeToMarkdown(
   start: atom$Point,
   end: atom$Point
 ): string {
-  let trimLength = 0;
   const commentStartString = getCommentStartString(editor);
-  if (commentStartString) trimLength = commentStartString.length + 1;
+  const trimLength =
+    commentStartString && commentStartString.length
+      ? commentStartString.length + 1
+      : 0;
 
   let markdown = "";
   for (let i = start.row; i <= end.row; i++) {

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -13,11 +13,11 @@ import {
   rowRangeForCodeFoldAtBufferRow
 } from "./utils";
 
-export function normalizeString(text: ?string) {
+export function normalizeString(text: string) {
   if (text) {
     return text.replace(/\r\n|\r/g, "\n");
   }
-  return null;
+  return text;
 }
 
 export function getRow(editor: atom$TextEditor, row: number) {

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -356,6 +356,7 @@ export function findPrecedingBlock(
         code: getRows(editor, previousRow, row),
         row,
         cellType: getCell(editor, new Point(0, 0), new Point(row + 1, 0))
+          .cellType
       };
     }
     previousRow -= 1;

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -270,7 +270,7 @@ function getCurrentFencedCodeBlock(editor: atom$TextEditor) {
     end += 1;
   }
 
-  return { range: new Range([start, 0], [end, 9999999]), cellType: "codecell" };
+  return { range: new Range([start, 0], [end + 1, 0]), cellType: "codecell" };
 }
 
 export function getCurrentCell(editor: atom$TextEditor) {
@@ -305,7 +305,7 @@ export function getCellsForBreakPoints(
   return _.compact(
     _.map(breakpoints, end => {
       const cell = end.isEqual(start) ? null : new Range(start, end);
-      start = new Point(end.row + 1, 0);
+      start = end;
       return cell;
     })
   );

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -488,7 +488,7 @@ export function parseCodeToMarkdown(
       i == start.row ? start : new Point(i, 0),
       i == end.row ? end : new Point(i + 1, 0)
     );
-    text != null
+    text != null && normalizeString(text.substring(trimLength)) != null
       ? (markdown += normalizeString(text.substring(trimLength)) + "\n")
       : null;
   }

--- a/lib/components/result-view/history.js
+++ b/lib/components/result-view/history.js
@@ -52,14 +52,16 @@ const History = observer(({ store }: { store: OutputStore }) => {
           fontSize: atom.config.get(`Hydrogen.outputAreaFontSize`) || "inherit"
         }}
       >
-        <Output
-          output={toJS(output)}
-          displayOrder={displayOrder}
-          transforms={transforms}
-          theme="light"
-          models={{}}
-          expanded
-        />
+        <div comment="This div is used to keep the output as display:block for markdown cells.">
+          <Output
+            output={toJS(output)}
+            displayOrder={displayOrder}
+            transforms={transforms}
+            theme="light"
+            models={{}}
+            expanded
+          />
+        </div>
       </div>
     </div>
   ) : null;

--- a/lib/components/result-view/result-view.js
+++ b/lib/components/result-view/result-view.js
@@ -5,7 +5,6 @@ import React from "react";
 import { observer } from "mobx-react";
 import { action, observable, toJS } from "mobx";
 import { Display } from "@nteract/display-area";
-import MarkdownRender from "@nteract/markdown";
 import { transforms, displayOrder } from "./transforms";
 import Status from "./status";
 
@@ -159,20 +158,14 @@ class ResultViewComponent extends React.Component<Props> {
             overflowY: "auto"
           }}
         >
-          {toJS(outputs)[0]["media_type"] == "text/markdown" ? (
-            <MarkdownRender className="markdown">
-              {toJS(outputs)[0]["text"]}
-            </MarkdownRender>
-          ) : (
-            <Display
-              outputs={toJS(outputs)}
-              displayOrder={displayOrder}
-              transforms={transforms}
-              theme="light"
-              models={{}}
-              expanded
-            />
-          )}
+          <Display
+            outputs={toJS(outputs)}
+            displayOrder={displayOrder}
+            transforms={transforms}
+            theme="light"
+            models={{}}
+            expanded
+          />
         </div>
         {isPlain ? null : (
           <div className="toolbar">

--- a/lib/components/result-view/result-view.js
+++ b/lib/components/result-view/result-view.js
@@ -5,6 +5,7 @@ import React from "react";
 import { observer } from "mobx-react";
 import { action, observable, toJS } from "mobx";
 import { Display } from "@nteract/display-area";
+import MarkdownRender from "@nteract/markdown";
 import { transforms, displayOrder } from "./transforms";
 import Status from "./status";
 
@@ -103,7 +104,6 @@ class ResultViewComponent extends React.Component<Props> {
 
   render() {
     const { outputs, status, isPlain, position } = this.props.store;
-
     const inlineStyle = {
       marginLeft: `${position.lineLength + position.charWidth}px`,
       marginTop: `-${position.lineHeight}px`
@@ -159,14 +159,20 @@ class ResultViewComponent extends React.Component<Props> {
             overflowY: "auto"
           }}
         >
-          <Display
-            outputs={toJS(outputs)}
-            displayOrder={displayOrder}
-            transforms={transforms}
-            theme="light"
-            models={{}}
-            expanded
-          />
+          {toJS(outputs)[0]["media_type"] == "text/markdown" ? (
+            <MarkdownRender className="markdown">
+              {toJS(outputs)[0]["text"]}
+            </MarkdownRender>
+          ) : (
+            <Display
+              outputs={toJS(outputs)}
+              displayOrder={displayOrder}
+              transforms={transforms}
+              theme="light"
+              models={{}}
+              expanded
+            />
+          )}
         </div>
         {isPlain ? null : (
           <div className="toolbar">

--- a/lib/components/result-view/result-view.js
+++ b/lib/components/result-view/result-view.js
@@ -103,6 +103,7 @@ class ResultViewComponent extends React.Component<Props> {
 
   render() {
     const { outputs, status, isPlain, position } = this.props.store;
+
     const inlineStyle = {
       marginLeft: `${position.lineLength + position.charWidth}px`,
       marginTop: `-${position.lineHeight}px`

--- a/lib/main.js
+++ b/lib/main.js
@@ -569,8 +569,7 @@ const Hydrogen = {
               end
             )
           : codeManager.getTextInRange(editor, start, end);
-      lineToRun =
-        codeManager.escapeBlankRows(editor, start.row, end.row);
+      lineToRun = codeManager.escapeBlankRows(editor, start.row, end.row);
       if (code) {
         this.createResultBubble(editor, code, lineToRun - 1, cellType);
       }
@@ -586,14 +585,26 @@ const Hydrogen = {
       }
 
       if (foldable) {
-        codeBlock = codeManager.getFoldContents(editor, lineToRun);
-        code += codeBlock.code;
-        lineToRun = codeBlock.row - 1;
-      } else if (codeManager.getRow(editor, lineToRun) !== "end" && cell.range.start.row != lineToRun) {
-        code +=
+        let codeBlock = codeManager.getFoldContents(editor, lineToRun);
+        if (codeBlock && codeBlock.code) code += codeBlock.code;
+        lineToRun = codeBlock ? codeBlock.row - 1 : lineToRun;
+      } else if (
+        codeManager.getRow(editor, lineToRun) !== "end" &&
+        cell.range.start.row != lineToRun
+      ) {
+        let cellCode =
           cell.cellType == "md" || cell.cellType == "markdown"
-            ? codeManager.parseCodeToMarkdown(editor, new Point(lineToRun, 0), new Point(lineToRun + 1, 0))
-            : codeManager.getTextInRange(editor, new Point(lineToRun, 0), new Point(lineToRun + 1, 0));
+            ? codeManager.parseCodeToMarkdown(
+                editor,
+                new Point(lineToRun, 0),
+                new Point(lineToRun + 1, 0)
+              )
+            : codeManager.getTextInRange(
+                editor,
+                new Point(lineToRun, 0),
+                new Point(lineToRun + 1, 0)
+              );
+        if (cellCode) code += cellCode;
       }
       lineToRun++;
       if (lineToRun >= cell.range.end.row) {
@@ -604,7 +615,7 @@ const Hydrogen = {
       }
     }
     if (code != "") {
-      this.createResultBubble(editor, code, lineToRun - 1,  cell.cellType);
+      this.createResultBubble(editor, code, lineToRun - 1, cell.cellType);
     }
   },
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -343,23 +343,6 @@ const Hydrogen = {
     }
   },
 
-  createMarkdownResultBubble(
-    editor: atom$TextEditor,
-    code: string,
-    row: number
-  ) {
-    const { markers } = store;
-
-    const { outputStore } = new ResultView(markers, null, editor, row, true);
-
-    outputStore.appendOutput({
-      name: "stdout",
-      text: code,
-      output_type: "stream",
-      media_type: "text/markdown"
-    });
-  },
-
   createResultBubble(
     editor: atom$TextEditor,
     code: string,

--- a/lib/main.js
+++ b/lib/main.js
@@ -573,13 +573,17 @@ const Hydrogen = {
             )
           : codeManager.getTextInRange(editor, start, end);
       lineToRun = end.row;
-      displayRow = codeManager.escapeBlankRows(editor, start.row, end.row - 1);
+      const displayRow = codeManager.escapeBlankRows(
+        editor,
+        start.row,
+        end.row - 1
+      );
       if (code) {
         this.createResultBubble(editor, code, displayRow, cellType);
       }
     }
     if (i < cells.length) {
-      cell = codeManager.getCell(editor, cells[i].start, cells[i].end);
+      let cell = codeManager.getCell(editor, cells[i].start, cells[i].end);
       let code = "";
       while (lineToRun <= cursorRow) {
         const indentLevel = cursor.getIndentLevel();

--- a/lib/main.js
+++ b/lib/main.js
@@ -519,13 +519,28 @@ const Hydrogen = {
     kernel: Kernel,
     breakpoints?: Array<atom$Point>
   ) {
-    let cells = codeManager.getCells(editor, breakpoints);
+    const cells = codeManager.getCells(editor, breakpoints);
     _.forEach(
       cells,
       ({ start, end }: { start: atom$Point, end: atom$Point }) => {
-        const code = codeManager.getTextInRange(editor, start, end);
-        const endRow = codeManager.escapeBlankRows(editor, start.row, end.row);
-        this._createResultBubble(editor, kernel, code, endRow);
+        const cell = codeManager.getCell(editor, start, end);
+        start = cell.range.start;
+        end = cell.range.end;
+        const cellType = cell.cellType;
+        const code =
+          cellType == "md" || cellType == "markdown"
+            ? codeManager.parseCodeToMarkdown(
+                editor,
+                new Point(start.row + 1, start.column),
+                end
+              )
+            : codeManager.getTextInRange(editor, start, end);
+        const endRow =
+          codeManager.escapeBlankRows(editor, start.row, end.row) - 1;
+
+        if (code) {
+          this.createResultBubble(editor, code, endRow, cellType);
+        }
       }
     );
   },

--- a/lib/main.js
+++ b/lib/main.js
@@ -559,9 +559,13 @@ const Hydrogen = {
     const cellType = currentCell["cellType"];
     const code =
       cellType == "md" || cellType == "markdown"
-        ? codeManager.parseCodeToMarkdown(editor, start, end)
+        ? codeManager.parseCodeToMarkdown(
+            editor,
+            new Point(start.row + 1, start.column),
+            end
+          )
         : codeManager.getTextInRange(editor, start, end);
-    const endRow = codeManager.escapeBlankRows(editor, start.row, end.row);
+    const endRow = codeManager.escapeBlankRows(editor, start.row, end.row) - 1;
 
     if (code) {
       if (moveDown === true) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -526,8 +526,11 @@ const Hydrogen = {
                 end
               )
             : codeManager.getTextInRange(editor, start, end);
-        const endRow =
-          codeManager.escapeBlankRows(editor, start.row, end.row) - 1;
+        const endRow = codeManager.escapeBlankRows(
+          editor,
+          start.row,
+          end.row - 1
+        );
 
         if (code) {
           this.createResultBubble(editor, code, endRow, cellType);
@@ -569,9 +572,10 @@ const Hydrogen = {
               end
             )
           : codeManager.getTextInRange(editor, start, end);
-      lineToRun = codeManager.escapeBlankRows(editor, start.row, end.row);
+      lineToRun = end.row;
+      displayRow = codeManager.escapeBlankRows(editor, start.row, end.row - 1);
       if (code) {
-        this.createResultBubble(editor, code, lineToRun - 1, cellType);
+        this.createResultBubble(editor, code, displayRow, cellType);
       }
     }
     if (i < cells.length) {
@@ -609,14 +613,24 @@ const Hydrogen = {
         }
         lineToRun++;
         if (lineToRun >= cell.range.end.row) {
-          this.createResultBubble(editor, code, lineToRun - 1, cell.cellType);
+          const displayRow = codeManager.escapeBlankRows(
+            editor,
+            cell.range.start.row,
+            lineToRun - 1
+          );
+          this.createResultBubble(editor, code, displayRow, cell.cellType);
           i++;
           cell = codeManager.getCell(editor, cells[i].start, cells[i].end);
           code = "";
         }
       }
       if (code != "") {
-        this.createResultBubble(editor, code, lineToRun - 1, cell.cellType);
+        const displayRow = codeManager.escapeBlankRows(
+          editor,
+          cell.range.start.row,
+          lineToRun - 1
+        );
+        this.createResultBubble(editor, code, displayRow, cell.cellType);
       }
     }
   },
@@ -637,7 +651,7 @@ const Hydrogen = {
             end
           )
         : codeManager.getTextInRange(editor, start, end);
-    const endRow = codeManager.escapeBlankRows(editor, start.row, end.row) - 1;
+    const endRow = codeManager.escapeBlankRows(editor, start.row, end.row - 1);
 
     if (code) {
       if (moveDown === true) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -360,7 +360,12 @@ const Hydrogen = {
     });
   },
 
-  createResultBubble(editor: atom$TextEditor, code: string, row: number) {
+  createResultBubble(
+    editor: atom$TextEditor,
+    code: string,
+    row: number,
+    cellType: string
+  ) {
     const { grammar, filePath, kernel } = store;
 
     if (!filePath || !grammar) {
@@ -370,7 +375,7 @@ const Hydrogen = {
     }
 
     if (kernel) {
-      this._createResultBubble(editor, kernel, code, row);
+      this._createResultBubble(editor, kernel, code, row, cellType);
       return;
     }
 
@@ -379,7 +384,7 @@ const Hydrogen = {
       editor,
       filePath,
       (kernel: ZMQKernel) => {
-        this._createResultBubble(editor, kernel, code, row);
+        this._createResultBubble(editor, kernel, code, row, cellType);
       }
     );
   },
@@ -388,7 +393,8 @@ const Hydrogen = {
     editor: atom$TextEditor,
     kernel: Kernel,
     code: string,
-    row: number
+    row: number,
+    cellType: string
   ) {
     if (atom.workspace.getActivePaneItem() instanceof WatchesPane) {
       kernel.watchesStore.run();
@@ -413,10 +419,31 @@ const Hydrogen = {
       !globalOutputStore
     );
 
-    kernel.execute(code, result => {
-      outputStore.appendOutput(result);
-      if (globalOutputStore) globalOutputStore.appendOutput(result);
-    });
+    if (cellType == "md" || cellType == "markdown") {
+      outputStore.appendOutput({
+        output_type: "display_data",
+        data: {
+          "text/markdown": code
+        },
+        metadata: {}
+      });
+      if (globalOutputStore)
+        globalOutputStore.appendOutput({
+          output_type: "display_data",
+          data: {
+            "text/markdown": code
+          },
+          metadata: {}
+        });
+      outputStore.appendOutput({ data: "ok", stream: "status" });
+      if (globalOutputStore)
+        globalOutputStore.appendOutput({ data: "ok", stream: "status" });
+    } else {
+      kernel.execute(code, result => {
+        outputStore.appendOutput(result);
+        if (globalOutputStore) globalOutputStore.appendOutput(result);
+      });
+    }
   },
 
   restartKernelAndReEvaluateBubbles() {
@@ -554,11 +581,7 @@ const Hydrogen = {
       if (moveDown === true) {
         codeManager.moveDown(editor, endRow);
       }
-      if (cellType == "md" || cellType == "markdown") {
-        this.createMarkdownResultBubble(editor, code, endRow);
-      } else {
-        this.createResultBubble(editor, code, endRow);
-      }
+      this.createResultBubble(editor, code, endRow, cellType);
     }
   },
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -353,7 +353,8 @@ const Hydrogen = {
 
     if (!filePath || !grammar) {
       return atom.notifications.addError(
-        "The language grammar must be set in order to start a kernel. The easiest way to do this is to save the file."
+        "The language grammar must be set in order to start a kernel. " +
+          "The easiest way to do this is to save the file."
       );
     }
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -550,14 +550,14 @@ const Hydrogen = {
     const cursorRow = cursor.getBufferRow();
     let lineToRun = -1;
     const cells = codeManager.getCells(editor, breakpoints);
-    let i;
+    let i = 0;
     for (i = 0; i < cells.length; i++) {
       let start = cells[i].start;
       let end = cells[i].end;
       if (end.row > cursorRow) {
         break;
       }
-      const cell = codeManager.getCell(editor, start, end);
+      let cell = codeManager.getCell(editor, start, end);
       start = cell.range.start;
       end = cell.range.end;
       const cellType = cell.cellType;
@@ -574,48 +574,50 @@ const Hydrogen = {
         this.createResultBubble(editor, code, lineToRun - 1, cellType);
       }
     }
-    let cell = codeManager.getCell(editor, cells[i].start, cells[i].end);
-    let code = "";
-    while (lineToRun <= cursorRow) {
-      const indentLevel = cursor.getIndentLevel();
-      let foldable = editor.isFoldableAtBufferRow(lineToRun);
-      const foldRange = rowRangeForCodeFoldAtBufferRow(editor, lineToRun);
-      if (!foldRange || foldRange[0] == null || foldRange[1] == null) {
-        foldable = false;
-      }
+    if (i < cells.length) {
+      cell = codeManager.getCell(editor, cells[i].start, cells[i].end);
+      let code = "";
+      while (lineToRun <= cursorRow) {
+        const indentLevel = cursor.getIndentLevel();
+        let foldable = editor.isFoldableAtBufferRow(lineToRun);
+        const foldRange = rowRangeForCodeFoldAtBufferRow(editor, lineToRun);
+        if (!foldRange || foldRange[0] == null || foldRange[1] == null) {
+          foldable = false;
+        }
 
-      if (foldable) {
-        let codeBlock = codeManager.getFoldContents(editor, lineToRun);
-        if (codeBlock && codeBlock.code) code += codeBlock.code;
-        lineToRun = codeBlock ? codeBlock.row - 1 : lineToRun;
-      } else if (
-        codeManager.getRow(editor, lineToRun) !== "end" &&
-        cell.range.start.row != lineToRun
-      ) {
-        let cellCode =
-          cell.cellType == "md" || cell.cellType == "markdown"
-            ? codeManager.parseCodeToMarkdown(
-                editor,
-                new Point(lineToRun, 0),
-                new Point(lineToRun + 1, 0)
-              )
-            : codeManager.getTextInRange(
-                editor,
-                new Point(lineToRun, 0),
-                new Point(lineToRun + 1, 0)
-              );
-        if (cellCode) code += cellCode;
+        if (foldable) {
+          let codeBlock = codeManager.getFoldContents(editor, lineToRun);
+          if (codeBlock && codeBlock.code) code += codeBlock.code;
+          lineToRun = codeBlock ? codeBlock.row - 1 : lineToRun;
+        } else if (
+          codeManager.getRow(editor, lineToRun) !== "end" &&
+          cell.range.start.row != lineToRun
+        ) {
+          let cellCode =
+            cell.cellType == "md" || cell.cellType == "markdown"
+              ? codeManager.parseCodeToMarkdown(
+                  editor,
+                  new Point(lineToRun, 0),
+                  new Point(lineToRun + 1, 0)
+                )
+              : codeManager.getTextInRange(
+                  editor,
+                  new Point(lineToRun, 0),
+                  new Point(lineToRun + 1, 0)
+                );
+          if (cellCode) code += cellCode;
+        }
+        lineToRun++;
+        if (lineToRun >= cell.range.end.row) {
+          this.createResultBubble(editor, code, lineToRun - 1, cell.cellType);
+          i++;
+          cell = codeManager.getCell(editor, cells[i].start, cells[i].end);
+          code = "";
+        }
       }
-      lineToRun++;
-      if (lineToRun >= cell.range.end.row) {
+      if (code != "") {
         this.createResultBubble(editor, code, lineToRun - 1, cell.cellType);
-        i++;
-        cell = codeManager.getCell(editor, cells[i].start, cells[i].end);
-        code = "";
       }
-    }
-    if (code != "") {
-      this.createResultBubble(editor, code, lineToRun - 1, cell.cellType);
     }
   },
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -477,13 +477,15 @@ const Hydrogen = {
     if (!codeBlock) {
       return;
     }
-
-    const [code, row] = codeBlock;
+    const { code, row, cellType } = codeBlock;
     if (code) {
       if (moveDown === true) {
         codeManager.moveDown(editor, row);
       }
-      this.createResultBubble(editor, code, row);
+      //if the line is a heading we don't want a result we just want to move down
+      if (code !== true) {
+        this.createResultBubble(editor, code, row, cellType);
+      }
     }
   },
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -348,7 +348,7 @@ const Hydrogen = {
     editor: atom$TextEditor,
     code: string,
     row: number,
-    cellType: string
+    cellType: HydrogenCellType
   ) {
     const { grammar, filePath, kernel } = store;
 
@@ -379,7 +379,7 @@ const Hydrogen = {
     kernel: Kernel,
     code: string,
     row: number,
-    cellType: string
+    cellType: HydrogenCellType
   ) {
     if (atom.workspace.getActivePaneItem() instanceof WatchesPane) {
       kernel.watchesStore.run();
@@ -401,23 +401,26 @@ const Hydrogen = {
       kernel,
       editor,
       row,
-      !globalOutputStore || cellType == "md" || cellType == "markdown"
+      !globalOutputStore || cellType === "markdown"
     );
 
-    if (cellType == "md" || cellType == "markdown") {
-      outputStore.appendOutput({
-        output_type: "display_data",
-        data: {
-          "text/markdown": code
-        },
-        metadata: {}
-      });
-      outputStore.appendOutput({ data: "ok", stream: "status" });
-    } else {
-      kernel.execute(code, result => {
-        outputStore.appendOutput(result);
-        if (globalOutputStore) globalOutputStore.appendOutput(result);
-      });
+    switch (cellType) {
+      case "markdown":
+        outputStore.appendOutput({
+          output_type: "display_data",
+          data: {
+            "text/markdown": code
+          },
+          metadata: {}
+        });
+        outputStore.appendOutput({ data: "ok", stream: "status" });
+        break;
+      case "codecell":
+        kernel.execute(code, result => {
+          outputStore.appendOutput(result);
+          if (globalOutputStore) globalOutputStore.appendOutput(result);
+        });
+        break;
     }
   },
 
@@ -518,14 +521,19 @@ const Hydrogen = {
         start = cell.range.start;
         end = cell.range.end;
         const cellType = cell.cellType;
-        const code =
-          cellType == "md" || cellType == "markdown"
-            ? codeManager.parseCodeToMarkdown(
-                editor,
-                new Point(start.row + 1, start.column),
-                end
-              )
-            : codeManager.getTextInRange(editor, start, end);
+        let code;
+        switch (cellType) {
+          case "markdown":
+            code = codeManager.parseCodeToMarkdown(
+              editor,
+              new Point(start.row + 1, start.column),
+              end
+            );
+            break;
+          case "codecell":
+            code = codeManager.getTextInRange(editor, start, end);
+            break;
+        }
         const endRow = codeManager.escapeBlankRows(
           editor,
           start.row,
@@ -564,14 +572,19 @@ const Hydrogen = {
       start = cell.range.start;
       end = cell.range.end;
       const cellType = cell.cellType;
-      const code =
-        cellType == "md" || cellType == "markdown"
-          ? codeManager.parseCodeToMarkdown(
-              editor,
-              new Point(start.row + 1, start.column),
-              end
-            )
-          : codeManager.getTextInRange(editor, start, end);
+      let code;
+      switch (cellType) {
+        case "markdown":
+          code = codeManager.parseCodeToMarkdown(
+            editor,
+            new Point(start.row + 1, start.column),
+            end
+          );
+          break;
+        case "codecell":
+          code = codeManager.getTextInRange(editor, start, end);
+          break;
+      }
       lineToRun = end.row;
       const displayRow = codeManager.escapeBlankRows(
         editor,
@@ -601,18 +614,23 @@ const Hydrogen = {
           codeManager.getRow(editor, lineToRun) !== "end" &&
           cell.range.start.row != lineToRun
         ) {
-          let cellCode =
-            cell.cellType == "md" || cell.cellType == "markdown"
-              ? codeManager.parseCodeToMarkdown(
-                  editor,
-                  new Point(lineToRun, 0),
-                  new Point(lineToRun + 1, 0)
-                )
-              : codeManager.getTextInRange(
-                  editor,
-                  new Point(lineToRun, 0),
-                  new Point(lineToRun + 1, 0)
-                );
+          let cellCode;
+          switch (cell.cellType) {
+            case "markdown":
+              cellCode = codeManager.parseCodeToMarkdown(
+                editor,
+                new Point(lineToRun, 0),
+                new Point(lineToRun + 1, 0)
+              );
+              break;
+            case "codecell":
+              cellCode = codeManager.getTextInRange(
+                editor,
+                new Point(lineToRun, 0),
+                new Point(lineToRun + 1, 0)
+              );
+              break;
+          }
           if (cellCode) code += cellCode;
         }
         lineToRun++;
@@ -645,16 +663,21 @@ const Hydrogen = {
     // https://github.com/nteract/hydrogen/issues/1452
     atom.commands.dispatch(editor.element, "autocomplete-plus:cancel");
     const currentCell = codeManager.getCurrentCell(editor);
-    const { start, end } = currentCell["range"];
-    const cellType = currentCell["cellType"];
-    const code =
-      cellType == "md" || cellType == "markdown"
-        ? codeManager.parseCodeToMarkdown(
-            editor,
-            new Point(start.row + 1, start.column),
-            end
-          )
-        : codeManager.getTextInRange(editor, start, end);
+    const { start, end } = currentCell.range;
+    const cellType = currentCell.cellType;
+    let code;
+    switch (cellType) {
+      case "markdown":
+        code = codeManager.parseCodeToMarkdown(
+          editor,
+          new Point(start.row + 1, start.column),
+          end
+        );
+        break;
+      case "codecell":
+        code = codeManager.getTextInRange(editor, start, end);
+        break;
+    }
     const endRow = codeManager.escapeBlankRows(editor, start.row, end.row - 1);
 
     if (code) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -346,9 +346,11 @@ const Hydrogen = {
 
   createResultBubble(
     editor: atom$TextEditor,
-    code: string,
     row: number,
-    cellType: HydrogenCellType
+    codeBlock: {
+      cellType: HydrogenCellType,
+      code: string
+    }
   ) {
     const { grammar, filePath, kernel } = store;
 
@@ -360,7 +362,7 @@ const Hydrogen = {
     }
 
     if (kernel) {
-      this._createResultBubble(editor, kernel, code, row, cellType);
+      this._createResultBubble(editor, kernel, row, codeBlock);
       return;
     }
 
@@ -369,7 +371,7 @@ const Hydrogen = {
       editor,
       filePath,
       (kernel: ZMQKernel) => {
-        this._createResultBubble(editor, kernel, code, row, cellType);
+        this._createResultBubble(editor, kernel, row, codeBlock);
       }
     );
   },
@@ -377,9 +379,11 @@ const Hydrogen = {
   _createResultBubble(
     editor: atom$TextEditor,
     kernel: Kernel,
-    code: string,
     row: number,
-    cellType: HydrogenCellType
+    codeBlock: {
+      cellType: HydrogenCellType,
+      code: string
+    }
   ) {
     if (atom.workspace.getActivePaneItem() instanceof WatchesPane) {
       kernel.watchesStore.run();
@@ -401,22 +405,22 @@ const Hydrogen = {
       kernel,
       editor,
       row,
-      !globalOutputStore || cellType === "markdown"
+      !globalOutputStore || codeBlock.cellType === "markdown"
     );
 
-    switch (cellType) {
+    switch (codeBlock.cellType) {
       case "markdown":
         outputStore.appendOutput({
           output_type: "display_data",
           data: {
-            "text/markdown": code
+            "text/markdown": codeBlock.code
           },
           metadata: {}
         });
         outputStore.appendOutput({ data: "ok", stream: "status" });
         break;
       case "codecell":
-        kernel.execute(code, result => {
+        kernel.execute(codeBlock.code, result => {
           outputStore.appendOutput(result);
           if (globalOutputStore) globalOutputStore.appendOutput(result);
         });

--- a/lib/main.js
+++ b/lib/main.js
@@ -400,7 +400,7 @@ const Hydrogen = {
       kernel,
       editor,
       row,
-      !globalOutputStore
+      !globalOutputStore || cellType == "md" || cellType == "markdown"
     );
 
     if (cellType == "md" || cellType == "markdown") {
@@ -411,17 +411,7 @@ const Hydrogen = {
         },
         metadata: {}
       });
-      if (globalOutputStore)
-        globalOutputStore.appendOutput({
-          output_type: "display_data",
-          data: {
-            "text/markdown": code
-          },
-          metadata: {}
-        });
       outputStore.appendOutput({ data: "ok", stream: "status" });
-      if (globalOutputStore)
-        globalOutputStore.appendOutput({ data: "ok", stream: "status" });
     } else {
       kernel.execute(code, result => {
         outputStore.appendOutput(result);

--- a/lib/main.js
+++ b/lib/main.js
@@ -475,14 +475,13 @@ const Hydrogen = {
     if (!codeBlock) {
       return;
     }
-    const { code, row, cellType } = codeBlock;
-    if (code) {
+    if (codeBlock.code) {
       if (moveDown === true) {
-        codeManager.moveDown(editor, row);
+        codeManager.moveDown(editor, codeBlock.row);
       }
       //if the line is a heading we don't want a result we just want to move down
-      if (code !== true) {
-        this.createResultBubble(editor, code, row, cellType);
+      if (codeBlock.code !== true) {
+        this.createResultBubble(editor, codeBlock.row, codeBlock);
       }
     }
   },
@@ -545,7 +544,7 @@ const Hydrogen = {
         );
 
         if (code) {
-          this.createResultBubble(editor, code, endRow, cellType);
+          this.createResultBubble(editor, endRow, { code, cellType });
         }
       }
     );
@@ -596,7 +595,7 @@ const Hydrogen = {
         end.row - 1
       );
       if (code) {
-        this.createResultBubble(editor, code, displayRow, cellType);
+        this.createResultBubble(editor, displayRow, { code, cellType });
       }
     }
     if (i < cells.length) {
@@ -644,7 +643,10 @@ const Hydrogen = {
             cell.range.start.row,
             lineToRun - 1
           );
-          this.createResultBubble(editor, code, displayRow, cell.cellType);
+          this.createResultBubble(editor, displayRow, {
+            code,
+            cellType: cell.cellType
+          });
           i++;
           cell = codeManager.getCell(editor, cells[i].start, cells[i].end);
           code = "";
@@ -656,7 +658,10 @@ const Hydrogen = {
           cell.range.start.row,
           lineToRun - 1
         );
-        this.createResultBubble(editor, code, displayRow, cell.cellType);
+        this.createResultBubble(editor, displayRow, {
+          code,
+          cellType: cell.cellType
+        });
       }
     }
   },
@@ -688,7 +693,7 @@ const Hydrogen = {
       if (moveDown === true) {
         codeManager.moveDown(editor, endRow);
       }
-      this.createResultBubble(editor, code, endRow, cellType);
+      this.createResultBubble(editor, endRow, { code, cellType });
     }
   },
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -51,6 +51,7 @@ import {
   KERNEL_MONITOR_URI,
   hotReloadPackage,
   openOrShowDock,
+  rowRangeForCodeFoldAtBufferRow,
   kernelSpecProvidesGrammar
 } from "./utils";
 
@@ -544,13 +545,66 @@ const Hydrogen = {
       );
       return;
     }
-
+    const breakpoints = codeManager.getBreakpoints(editor);
     const cursor = editor.getLastCursor();
-    const row = codeManager.escapeBlankRows(editor, 0, cursor.getBufferRow());
-    const code = codeManager.getRows(editor, 0, row);
+    const cursorRow = cursor.getBufferRow();
+    let lineToRun = -1;
+    const cells = codeManager.getCells(editor, breakpoints);
+    let i;
+    for (i = 0; i < cells.length; i++) {
+      let start = cells[i].start;
+      let end = cells[i].end;
+      if (end.row > cursorRow) {
+        break;
+      }
+      const cell = codeManager.getCell(editor, start, end);
+      start = cell.range.start;
+      end = cell.range.end;
+      const cellType = cell.cellType;
+      const code =
+        cellType == "md" || cellType == "markdown"
+          ? codeManager.parseCodeToMarkdown(
+              editor,
+              new Point(start.row + 1, start.column),
+              end
+            )
+          : codeManager.getTextInRange(editor, start, end);
+      lineToRun =
+        codeManager.escapeBlankRows(editor, start.row, end.row);
+      if (code) {
+        this.createResultBubble(editor, code, lineToRun - 1, cellType);
+      }
+    }
+    let cell = codeManager.getCell(editor, cells[i].start, cells[i].end);
+    let code = "";
+    while (lineToRun <= cursorRow) {
+      const indentLevel = cursor.getIndentLevel();
+      let foldable = editor.isFoldableAtBufferRow(lineToRun);
+      const foldRange = rowRangeForCodeFoldAtBufferRow(editor, lineToRun);
+      if (!foldRange || foldRange[0] == null || foldRange[1] == null) {
+        foldable = false;
+      }
 
-    if (code) {
-      this.createResultBubble(editor, code, row);
+      if (foldable) {
+        codeBlock = codeManager.getFoldContents(editor, lineToRun);
+        code += codeBlock.code;
+        lineToRun = codeBlock.row - 1;
+      } else if (codeManager.getRow(editor, lineToRun) !== "end" && cell.range.start.row != lineToRun) {
+        code +=
+          cell.cellType == "md" || cell.cellType == "markdown"
+            ? codeManager.parseCodeToMarkdown(editor, new Point(lineToRun, 0), new Point(lineToRun + 1, 0))
+            : codeManager.getTextInRange(editor, new Point(lineToRun, 0), new Point(lineToRun + 1, 0));
+      }
+      lineToRun++;
+      if (lineToRun >= cell.range.end.row) {
+        this.createResultBubble(editor, code, lineToRun - 1, cell.cellType);
+        i++;
+        cell = codeManager.getCell(editor, cells[i].start, cells[i].end);
+        code = "";
+      }
+    }
+    if (code != "") {
+      this.createResultBubble(editor, code, lineToRun - 1,  cell.cellType);
     }
   },
 

--- a/lib/store/index.js
+++ b/lib/store/index.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { CompositeDisposable } from "atom";
+import { CompositeDisposable, Point } from "atom";
 import {
   observable,
   computed,
@@ -83,20 +83,31 @@ export class Store {
       );
     }
     const cellRanges = codeManager.getCells(editor);
-    _.forEach(cellRanges, cell => {
-      const { start, end } = cell;
-      let source = codeManager.getTextInRange(editor, start, end);
+    _.forEach(cellRanges, range => {
+      const cell = codeManager.getCell(editor, range.start, range.end);
+      const { start, end } = cell.range;
+      let source =
+        cellType == "md" || cellType == "markdown"
+          ? codeManager.parseCodeToMarkdown(
+              editor,
+              new Point(start.row + 1, start.column),
+              end
+            )
+          : codeManager.getTextInRange(
+              editor,
+              new Point(start.row + 1, start.column),
+              end
+            );
       source = source ? source : "";
       // When the cell marker following a given cell range is on its own line,
       // the newline immediately preceding that cell marker is included in
       // `source`. We remove that here. See #1512 for more details.
       if (source.slice(-1) === "\n") source = source.slice(0, -1);
-      const cellType = codeManager.getMetadataForRow(editor, start);
+      const cellType = cell.cellType;
       let newCell;
-      if (cellType === "code") {
+      if (cellType === "code" || cellType === "codecell") {
         newCell = commutable.emptyCodeCell.set("source", source);
-      } else if (cellType === "markdown") {
-        source = codeManager.removeCommentsMarkdownCell(editor, source);
+      } else if (cellType === "md" || cellType === "markdown") {
         newCell = commutable.emptyMarkdownCell.set("source", source);
       }
       notebook = commutable.appendCellToNotebook(notebook, newCell);

--- a/lib/store/index.js
+++ b/lib/store/index.js
@@ -85,6 +85,7 @@ export class Store {
     const cellRanges = codeManager.getCells(editor);
     _.forEach(cellRanges, range => {
       const cell = codeManager.getCell(editor, range.start, range.end);
+      const cellType = cell.cellType;
       const { start, end } = cell.range;
       let source =
         cellType == "md" || cellType == "markdown"
@@ -103,7 +104,6 @@ export class Store {
       // the newline immediately preceding that cell marker is included in
       // `source`. We remove that here. See #1512 for more details.
       if (source.slice(-1) === "\n") source = source.slice(0, -1);
-      const cellType = cell.cellType;
       let newCell;
       if (cellType === "code" || cellType === "codecell") {
         newCell = commutable.emptyCodeCell.set("source", source);

--- a/lib/store/index.js
+++ b/lib/store/index.js
@@ -87,28 +87,36 @@ export class Store {
       const cell = codeManager.getCell(editor, range.start, range.end);
       const cellType = cell.cellType;
       const { start, end } = cell.range;
-      let source =
-        cellType == "md" || cellType == "markdown"
-          ? codeManager.parseCodeToMarkdown(
-              editor,
-              new Point(start.row + 1, start.column),
-              end
-            )
-          : codeManager.getTextInRange(
-              editor,
-              new Point(start.row + 1, start.column),
-              end
-            );
+      let source;
+      switch (cellType) {
+        case "markdown":
+          source = codeManager.parseCodeToMarkdown(
+            editor,
+            new Point(start.row + 1, start.column),
+            end
+          );
+          break;
+        case "codecell":
+          source = codeManager.getTextInRange(
+            editor,
+            new Point(start.row + 1, start.column),
+            end
+          );
+          break;
+      }
       source = source ? source : "";
       // When the cell marker following a given cell range is on its own line,
       // the newline immediately preceding that cell marker is included in
       // `source`. We remove that here. See #1512 for more details.
       while (source.slice(-1) === "\n") source = source.slice(0, -1);
       let newCell;
-      if (cellType === "code" || cellType === "codecell") {
-        newCell = commutable.emptyCodeCell.set("source", source);
-      } else if (cellType === "md" || cellType === "markdown") {
-        newCell = commutable.emptyMarkdownCell.set("source", source);
+      switch (cellType) {
+        case "markdown":
+          newCell = commutable.emptyMarkdownCell.set("source", source);
+          break;
+        case "codecell":
+          newCell = commutable.emptyCodeCell.set("source", source);
+          break;
       }
       notebook = commutable.appendCellToNotebook(notebook, newCell);
     });

--- a/lib/store/index.js
+++ b/lib/store/index.js
@@ -103,7 +103,7 @@ export class Store {
       // When the cell marker following a given cell range is on its own line,
       // the newline immediately preceding that cell marker is included in
       // `source`. We remove that here. See #1512 for more details.
-      if (source.slice(-1) === "\n") source = source.slice(0, -1);
+      while (source.slice(-1) === "\n") source = source.slice(0, -1);
       let newCell;
       if (cellType === "code" || cellType === "codecell") {
         newCell = commutable.emptyCodeCell.set("source", source);

--- a/spec/code-manager-spec.js
+++ b/spec/code-manager-spec.js
@@ -67,9 +67,9 @@ describe("CodeManager", () => {
         const points = [[1, 2], [3, 4], [5, 6], [10, 5]].map(toPoint); // bp1 // bp2 // bp3 // bp4
         const cellsExpected = [
           [[0, 0], [1, 2]],
-          [[2, 0], [3, 4]],
-          [[4, 0], [5, 6]],
-          [[6, 0], [10, 5]]
+          [[1, 2], [3, 4]],
+          [[3, 4], [5, 6]],
+          [[5, 6], [10, 5]]
         ].map(toRange); // zero-to-bp1 // nextRow of bp1 to bp2 // nextRow of bp2 to bp3 // nextRow of bp3 to bp4
 
         expect(CM.getCellsForBreakPoints(editor, points)).toEqual(
@@ -91,8 +91,8 @@ describe("CodeManager", () => {
           // EOF is always treated as implicit breakpoints
           const cellsExpected = [
             [[0, 0], [0, 7]],
-            [[1, 0], [2, 7]],
-            [[3, 0], [4, 0]]
+            [[0, 7], [2, 7]],
+            [[2, 7], [4, 0]]
           ].map(toRange); // zero-to-row0:bp // nextRow of row0:bp to row2:bp // nextRow of row2:bp to EOF(= implicit bp)
           expect(CM.getCells(editor)).toEqual(cellsExpected);
         });
@@ -105,7 +105,7 @@ describe("CodeManager", () => {
             "print('foo bar')"
           ];
           editor.setText(code.join("\n") + "\n");
-          const cellsExpected = [[[2, 0], [3, 0]], [[4, 0], [5, 0]]].map(
+          const cellsExpected = [[[2, 0], [3, 0]], [[3, 0], [5, 0]]].map(
             toRange
           );
           expect(CM.getCells(editor)).toEqual(cellsExpected);
@@ -119,7 +119,7 @@ describe("CodeManager", () => {
             "print('foo bar')"
           ];
           editor.setText(code.join("\n") + "\n");
-          const cellsExpected = [[[2, 0], [3, 0]], [[4, 0], [5, 0]]].map(
+          const cellsExpected = [[[1, 0], [3, 0]], [[3, 0], [5, 0]]].map(
             toRange
           );
           expect(CM.getCells(editor)).toEqual(cellsExpected);
@@ -127,7 +127,7 @@ describe("CodeManager", () => {
         it("doesn't create initial empty cell with no whitespace", () => {
           const code = ["print('hello world')", "# %%", "print('foo bar')"];
           editor.setText(code.join("\n") + "\n");
-          const cellsExpected = [[[0, 0], [1, 0]], [[2, 0], [3, 0]]].map(
+          const cellsExpected = [[[0, 0], [1, 0]], [[1, 0], [3, 0]]].map(
             toRange
           );
           expect(CM.getCells(editor)).toEqual(cellsExpected);
@@ -135,7 +135,7 @@ describe("CodeManager", () => {
         it("doesn't start a cell outside of a line comment scope", () => {
           const code = ["# %%", "print('# %%')"];
           editor.setText(code.join("\n") + "\n");
-          const cellsExpected = [[[1, 0], [2, 0]]].map(toRange);
+          const cellsExpected = [[[0, 0], [2, 0]]].map(toRange);
           expect(CM.getCells(editor)).toEqual(cellsExpected);
         });
       });
@@ -144,8 +144,8 @@ describe("CodeManager", () => {
           breakpoints = [[0, 11], [2, 11], [1, 6]].map(toPoint); // row0:bp // row2:bp // row1:bp
           const cellsExpected = [
             [[0, 0], [0, 11]],
-            [[1, 0], [1, 6]],
-            [[2, 0], [2, 11]]
+            [[0, 11], [1, 6]],
+            [[1, 6], [2, 11]]
           ].map(toRange); // zero to row0:bp // nextRow of row0:bp to row1:bp // nextRow of row1:bp to row2:bp
 
           expect(CM.getCells(editor, breakpoints)).toEqual(cellsExpected);

--- a/spec/store/index-spec.js
+++ b/spec/store/index-spec.js
@@ -370,7 +370,7 @@ describe("Store", () => {
     it("should export markdown to markdown cells", () => {
       const source1 = 'print("Hola World! I <3 ZMQ!")';
       const source2 = "2 + 2";
-      editor.setText(`# %%\n${source1}\n# %% markdown\n${source2}\n`);
+      editor.setText(`# %%\n${source1}\n# %% markdown\n# ${source2}`);
       store.updateEditor(editor);
       const codeCell = commutable.emptyCodeCell.set("source", source1);
       const markdownCell = commutable.emptyMarkdownCell.set("source", source2);

--- a/spec/store/index-spec.js
+++ b/spec/store/index-spec.js
@@ -353,7 +353,7 @@ describe("Store", () => {
     it("should return a fully-fledged notebook when the file isn't empty", () => {
       const source1 = 'print("Hola World! I <3 ZMQ!")';
       const source2 = "2 + 2";
-      editor.setText(`# %%\n${source1}\n# %%\n${source2}\n`);
+      editor.setText(`# %%\n${source1}\n# %%\n${source2}\n\n\n`);
       store.updateEditor(editor);
       const codeCell1 = commutable.emptyCodeCell.set("source", source1);
       const codeCell2 = commutable.emptyCodeCell.set("source", source2);

--- a/styles/hydrogen.less
+++ b/styles/hydrogen.less
@@ -87,10 +87,6 @@ svg:first-child {
   padding: 0 0.25em 0 0.25em;
 }
 
-.inline-container .hydrogen_cell_display .markdown * {
-  margin: 0px;
-}
-
 .inline-container.icon::before {
   font-size: 80%;
   width: 1.2em;
@@ -117,10 +113,6 @@ svg:first-child {
   .modebar-group {
     display: flex;
   }
-}
-
-.multiline-container .hydrogen_cell_display .markdown * {
-  margin: 0px;
 }
 
 .multiline-container .toolbar {

--- a/styles/hydrogen.less
+++ b/styles/hydrogen.less
@@ -87,6 +87,10 @@ svg:first-child {
   padding: 0 0.25em 0 0.25em;
 }
 
+.inline-container .hydrogen_cell_display .markdown * {
+  margin: 0px;
+}
+
 .inline-container.icon::before {
   font-size: 80%;
   width: 1.2em;
@@ -113,6 +117,10 @@ svg:first-child {
   .modebar-group {
     display: flex;
   }
+}
+
+.multiline-container .hydrogen_cell_display .markdown * {
+  margin: 0px;
 }
 
 .multiline-container .toolbar {

--- a/styles/hydrogen.less
+++ b/styles/hydrogen.less
@@ -87,10 +87,6 @@ svg:first-child {
   padding: 0 0.25em 0 0.25em;
 }
 
-.inline-container .hydrogen_cell_display .markdown * {
-  margin: 0px;
-}
-
 .inline-container.icon::before {
   font-size: 80%;
   width: 1.2em;

--- a/types/hydrogen.js.flow
+++ b/types/hydrogen.js.flow
@@ -1,3 +1,13 @@
+export type HydrogenCellType = 'markdown' | 'codecell';
+
+export type HydrogenCell = {
+  start: atom$Point,
+  end: atom$Point,
+  range: atom$Range,
+  cellType: HydrogenCellType,
+  code: string
+}
+
 export type Kernelspec = {
   env: Object,
   argv: Array<string>,


### PR DESCRIPTION
This is my first ever pull request, so apologies ahead of time if I am doing this wrong.

I would like to implement an idea I thought of. I recently just started using hydrogen since I had previously been using jupyter notebooks. However when using hydrogen, markdown just looks like comments, which are ignored by the code block finder. I find this frustrating as notebooks I am using are just full of long areas of comments, which can be hard to distinguish from normal code comments.

My strategy for implementing this would be to use atom's core package called markdown-preview to parse the md into html/css, and then to stick it in a result bubble with a close button.

If you have any suggestions, changes, or advice, I would love to hear it.

If you believe this would be a nice feature with or without changes, I would love to take it on.