### PR TITLE
Update regexString

### DIFF
--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -177,7 +177,7 @@ export function getRegexString(editor: atom$TextEditor) {
 
   const escapedCommentStartString = escapeStringRegexp(commentStartString);
 
-  const regexString = `${escapedCommentStartString}(%%| %%| <(?:codecell|md|markdown)>| In\[[0-9 ]*\]:?)`;
+  const regexString = `${escapedCommentStartString} *%% *(md|markdown)?| *<(codecell|md|markdown)>| *(In\[[0-9 ]*\])`;
 
   return regexString;
 }

--- a/spec/code-manager-spec.js
+++ b/spec/code-manager-spec.js
@@ -82,7 +82,7 @@ describe("CodeManager", () => {
         waitAsync(async () => {
           await atom.packages.activatePackage("language-python");
           editor.setGrammar(atom.grammars.grammarForScopeName("source.python"));
-          const code = ["v0 = 0 # %%", "v1 = 1", "v2 = 2 # %%", "v3 = 3"]; // row0:bp // row1 // row2:bp // row3
+          const code = ["v0 = 0 #   %%", "v1 = 1", "v2 = 2 #%%", "v3 = 3"]; // row0:bp // row1 // row2:bp // row3
           editor.setText(code.join("\n") + "\n");
         })
       );


### PR DESCRIPTION
This is a small but hopefully quality of life update.

Current Effects:
The change to the regex string allows for any amounts of spaces rather than one or zero between the comment characters and any of the characters that indicate the start of a cell heading. It also removed an unnecessary duplicate search with a space for the `%%` and ` %%` headings.

Future Effects:
Their is also a second change to the regex in which before their were no capturing groups for different cell types. The new regex adds those capturing groups allowing for easy determination of cell types, which currently are only code and markdown. This means it will make it easier to make hydrogen behave differently for multiple cell types in the future.

This change should not affect any current or legacy code. Unless another branch is using the current regexString for capturing the heading line without the comment in front.