### PR TITLE
Implement Markdown Results

### DIFF
--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -203,7 +203,10 @@ export function getBreakpoints(editor: atom$TextEditor) {
   return breakpoints;
 }
 
-function getCurrentCodeCell(editor: atom$TextEditor) {
+function getCell(editor: atom$TextEditor, anyPointInCell: atom$Point) {
+  if (!anyPointInCell) {
+    anyPointInCell = editor.getCursorBufferPosition();
+  }
   const buffer = editor.getBuffer();
   let start = new Point(0, 0);
   let end = buffer.getEndPosition();
@@ -214,28 +217,32 @@ function getCurrentCodeCell(editor: atom$TextEditor) {
   }
 
   const regex = new RegExp(regexString);
-  const cursor = editor.getCursorBufferPosition();
 
-  while (cursor.row < end.row) {
-    cursor.row += 1;
-    cursor.column = 0;
+  while (anyPointInCell.row < end.row) {
+    anyPointInCell.row += 1;
+    anyPointInCell.column = 0;
   }
 
-  if (cursor.row > 0) {
+  if (anyPointInCell.row > 0) {
     buffer.backwardsScanInRange(
       regex,
-      new Range(start, cursor),
+      new Range(start, anyPointInCell),
       ({ range }) => {
         start = new Point(range.start.row + 1, 0);
       }
     );
   }
 
-  buffer.scanInRange(regex, new Range(cursor, end), ({ range }) => {
+  buffer.scanInRange(regex, new Range(anyPointInCell, end), ({ range }) => {
     end = range.start;
   });
 
-  log("CellManager: Cell [start, end]:", [start, end], "cursor:", cursor);
+  log(
+    "CellManager: Cell [start, end]:",
+    [start, end],
+    "anyPointInCell:",
+    anyPointInCell
+  );
 
   return new Range(start, end);
 }
@@ -259,7 +266,7 @@ function getCurrentFencedCodeBlock(editor: atom$TextEditor) {
   let start = cursor.row;
   let end = cursor.row;
   const scope = getEmbeddedScope(editor, cursor);
-  if (!scope) return getCurrentCodeCell(editor);
+  if (!scope) return getCell(editor);
   while (start > 0 && isEmbeddedCode(editor, scope, start - 1)) {
     start -= 1;
   }
@@ -275,7 +282,7 @@ export function getCurrentCell(editor: atom$TextEditor) {
   if (isMultilanguageGrammar(editor.getGrammar())) {
     return getCurrentFencedCodeBlock(editor);
   }
-  return getCurrentCodeCell(editor);
+  return getCell(editor);
 }
 
 export function getCells(

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -53,19 +53,39 @@ export function getRows(
 
 export function getMetadataForRow(
   editor: atom$TextEditor,
-  start: atom$Point
+  anyPointInCell: atom$Point
 ): string {
-  // `start` is a Point on the first line of the cell. The cell marker is on the
-  // previous line
-  if (start.row === 0) {
-    return "code";
+  let cellType = "codecell";
+  const buffer = editor.getBuffer();
+  anyPointInCell = new Point(
+    anyPointInCell.row,
+    buffer.lineLengthForRow(anyPointInCell.row)
+  );
+  const regexString = getRegexString(editor);
+  if (regexString) {
+    const regex = new RegExp(regexString, "g");
+    buffer.backwardsScanInRange(
+      regex,
+      new Range(new Point(0, 0), anyPointInCell),
+      ({ match }) => {
+        for (let i = 1; i < match.length; i++) {
+          if (match[i]) {
+            switch (match[i]) {
+              case "md":
+              case "markdown":
+                cellType = "markdown";
+                break;
+              case "codecell":
+              default:
+                cellType = "codecell";
+                break;
+            }
+          }
+        }
+      }
+    );
   }
-  var rowText = getRow(editor, start.row - 1);
-  if (_.includes(rowText, "md") || _.includes(rowText, "markdown")) {
-    return "markdown";
-  } else {
-    return "code";
-  }
+  return cellType;
 }
 
 export function removeCommentsMarkdownCell(
@@ -222,7 +242,7 @@ function getCell(editor: atom$TextEditor, anyPointInCell?: atom$Point) {
 
   const regex = new RegExp(regexString);
 
-  if (anyPointInCell.row > 0) {
+  if (anyPointInCell.row >= 0) {
     buffer.backwardsScanInRange(
       regex,
       new Range(start, anyPointInCell),

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -216,7 +216,7 @@ function getCurrentCodeCell(editor: atom$TextEditor) {
   const regex = new RegExp(regexString);
   const cursor = editor.getCursorBufferPosition();
 
-  while (cursor.row < end.row && isComment(editor, cursor)) {
+  while (cursor.row < end.row) {
     cursor.row += 1;
     cursor.column = 0;
   }

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -203,7 +203,7 @@ export function getBreakpoints(editor: atom$TextEditor) {
   return breakpoints;
 }
 
-function getCell(editor: atom$TextEditor, anyPointInCell: atom$Point) {
+function getCell(editor: atom$TextEditor, anyPointInCell?: atom$Point) {
   if (!anyPointInCell) {
     anyPointInCell = editor.getCursorBufferPosition();
   }

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -54,7 +54,7 @@ export function getRows(
 export function getMetadataForRow(
   editor: atom$TextEditor,
   anyPointInCell: atom$Point
-): string {
+): HydrogenCellType {
   let cellType = "codecell";
   const buffer = editor.getBuffer();
   anyPointInCell = new Point(

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -218,11 +218,6 @@ function getCell(editor: atom$TextEditor, anyPointInCell: atom$Point) {
 
   const regex = new RegExp(regexString);
 
-  while (anyPointInCell.row < end.row) {
-    anyPointInCell.row += 1;
-    anyPointInCell.column = 0;
-  }
-
   if (anyPointInCell.row > 0) {
     buffer.backwardsScanInRange(
       regex,

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -99,7 +99,7 @@ export function isComment(editor: atom$TextEditor, position: atom$Point) {
 }
 
 export function isBlank(editor: atom$TextEditor, row: number) {
-  return editor.getBuffer().isRowBlank(row) || editor.isBufferRowCommented(row);
+  return editor.getBuffer().isRowBlank(row);
 }
 
 export function escapeBlankRows(

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -130,7 +130,7 @@ export function getFoldRange(editor: atom$TextEditor, row: number) {
 export function getFoldContents(editor: atom$TextEditor, row: number) {
   const range = getFoldRange(editor, row);
   if (!range) return;
-  return [getRows(editor, range[0], range[1]), range[1]];
+  return { code: getRows(editor, range[0], range[1]), row: range[1] };
 }
 
 export function getCodeToInspect(editor: atom$TextEditor) {
@@ -351,7 +351,7 @@ export function findPrecedingBlock(
       row = previousRow;
     }
     if (sameIndent && !blank && !isEnd) {
-      return [getRows(editor, previousRow, row), row];
+      return { code: getRows(editor, previousRow, row), row };
     }
     previousRow -= 1;
   }
@@ -368,7 +368,7 @@ export function findCodeBlock(editor: atom$TextEditor) {
       endRow -= 1;
     }
     endRow = escapeBlankRows(editor, selectedRange.start.row, endRow);
-    return [selectedText, endRow];
+    return { code: selectedText, row: endRow };
   }
 
   const cursor = editor.getLastCursor();
@@ -389,7 +389,7 @@ export function findCodeBlock(editor: atom$TextEditor) {
   if (isBlank(editor, row) || getRow(editor, row) === "end") {
     return findPrecedingBlock(editor, row, indentLevel);
   }
-  return [getRow(editor, row), row];
+  return { code: getRow(editor, row), row };
 }
 
 export function foldCurrentCell(editor: atom$TextEditor) {

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -63,7 +63,7 @@ export function getMetadataForRow(
   );
   const regexString = getRegexString(editor);
   if (regexString) {
-    const regex = new RegExp(regexString, "g");
+    const regex = new RegExp(regexString);
     buffer.backwardsScanInRange(
       regex,
       new Range(new Point(0, 0), anyPointInCell),

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -208,6 +208,10 @@ function getCell(editor: atom$TextEditor, anyPointInCell: atom$Point) {
     anyPointInCell = editor.getCursorBufferPosition();
   }
   const buffer = editor.getBuffer();
+  anyPointInCell = new Point(
+    anyPointInCell.row,
+    buffer.lineLengthForRow(anyPointInCell.row)
+  );
   let start = new Point(0, 0);
   let end = buffer.getEndPosition();
   const regexString = getRegexString(editor);

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -371,6 +371,10 @@ export function findPrecedingBlock(
       row = previousRow;
     }
     if (sameIndent && !blank && !isEnd) {
+      const cell = getCell(editor, new Point(row, 0));
+      if (cell.start.row > row) {
+        return { code: "", row };
+      }
       return { code: getRows(editor, previousRow, row), row };
     }
     previousRow -= 1;
@@ -383,12 +387,22 @@ export function findCodeBlock(editor: atom$TextEditor) {
 
   if (selectedText) {
     const selectedRange = editor.getSelectedBufferRange();
+    const cell = getCell(editor, selectedRange.end);
+    const startPoint = cell.start.isGreaterThan(selectedRange.start)
+      ? cell.start
+      : selectedRange.start;
     let endRow = selectedRange.end.row;
     if (selectedRange.end.column === 0) {
       endRow -= 1;
     }
-    endRow = escapeBlankRows(editor, selectedRange.start.row, endRow);
-    return { code: selectedText, row: endRow };
+    endRow = escapeBlankRows(editor, startPoint, endRow);
+    if (startPoint.isGreaterThanOrEqual(selectedRange.end)) {
+      return { code: "", row: endRow };
+    }
+    return {
+      code: getTextInRange(editor, startPoint, selectedRange.end),
+      row: endRow
+    };
   }
 
   const cursor = editor.getLastCursor();
@@ -408,6 +422,10 @@ export function findCodeBlock(editor: atom$TextEditor) {
   }
   if (isBlank(editor, row) || getRow(editor, row) === "end") {
     return findPrecedingBlock(editor, row, indentLevel);
+  }
+  const cell = getCell(editor, new Point(row, 0));
+  if (cell.start.row > row) {
+    return { code: "", row };
   }
   return { code: getRow(editor, row), row };
 }

--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -395,7 +395,7 @@ export function findCodeBlock(editor: atom$TextEditor) {
     if (selectedRange.end.column === 0) {
       endRow -= 1;
     }
-    endRow = escapeBlankRows(editor, startPoint, endRow);
+    endRow = escapeBlankRows(editor, startPoint.row, endRow);
     if (startPoint.isGreaterThanOrEqual(selectedRange.end)) {
       return { code: "", row: endRow };
     }

--- a/lib/components/result-view/history.js
+++ b/lib/components/result-view/history.js
@@ -52,16 +52,14 @@ const History = observer(({ store }: { store: OutputStore }) => {
           fontSize: atom.config.get(`Hydrogen.outputAreaFontSize`) || "inherit"
         }}
       >
-        <div comment="This div is used to keep the output as display:block for markdown cells.">
-          <Output
-            output={toJS(output)}
-            displayOrder={displayOrder}
-            transforms={transforms}
-            theme="light"
-            models={{}}
-            expanded
-          />
-        </div>
+        <Output
+          output={toJS(output)}
+          displayOrder={displayOrder}
+          transforms={transforms}
+          theme="light"
+          models={{}}
+          expanded
+        />
       </div>
     </div>
   ) : null;

--- a/lib/components/result-view/history.js
+++ b/lib/components/result-view/history.js
@@ -52,14 +52,16 @@ const History = observer(({ store }: { store: OutputStore }) => {
           fontSize: atom.config.get(`Hydrogen.outputAreaFontSize`) || "inherit"
         }}
       >
-        <Output
-          output={toJS(output)}
-          displayOrder={displayOrder}
-          transforms={transforms}
-          theme="light"
-          models={{}}
-          expanded
-        />
+        <div comment="This div is used to keep the output as display:block for markdown cells.">
+          <Output
+            output={toJS(output)}
+            displayOrder={displayOrder}
+            transforms={transforms}
+            theme="light"
+            models={{}}
+            expanded
+          />
+        </div>
       </div>
     </div>
   ) : null;

--- a/lib/main.js
+++ b/lib/main.js
@@ -495,8 +495,12 @@ const Hydrogen = {
       cells,
       ({ start, end }: { start: atom$Point, end: atom$Point }) => {
         const code = codeManager.getTextInRange(editor, start, end);
-        const endRow = codeManager.escapeBlankRows(editor, start.row, end.row);
-        this._createResultBubble(editor, kernel, { code, endRow });
+        const row = codeManager.escapeBlankRows(
+          editor,
+          start.row,
+          end.row == editor.getLastBufferRow() ? end.row : end.row - 1
+        );
+        this._createResultBubble(editor, kernel, { code, row });
       }
     );
   },
@@ -527,13 +531,17 @@ const Hydrogen = {
     atom.commands.dispatch(editor.element, "autocomplete-plus:cancel");
     const { start, end } = codeManager.getCurrentCell(editor);
     const code = codeManager.getTextInRange(editor, start, end);
-    const endRow = codeManager.escapeBlankRows(editor, start.row, end.row);
+    const row = codeManager.escapeBlankRows(
+      editor,
+      start.row,
+      end.row == editor.getLastBufferRow() ? end.row : end.row - 1
+    );
 
     if (code) {
       if (moveDown === true) {
-        codeManager.moveDown(editor, endRow);
+        codeManager.moveDown(editor, row);
       }
-      this.createResultBubble(editor, { code, endRow });
+      this.createResultBubble(editor, { code, row });
     }
   },
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -565,9 +565,7 @@ const Hydrogen = {
       const row = codeManager.escapeBlankRows(
         editor,
         start.row,
-        end.row == editor.getLastBufferRow() || cell.containsPoint(cursor)
-          ? end.row
-          : end.row - 1
+        end.row == editor.getLastBufferRow() ? end.row : end.row - 1
       );
       const cellType = codeManager.getMetadataForRow(editor, start);
       if (code) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -468,10 +468,10 @@ const Hydrogen = {
     const { row } = codeBlock;
     let { code } = codeBlock;
     const cellType = codeManager.getMetadataForRow(editor, new Point(row, 0));
-    if (cellType === "markdown") {
-      code = codeManager.removeCommentsMarkdownCell(editor, code);
-    }
     if (code) {
+      if (cellType === "markdown") {
+        code = codeManager.removeCommentsMarkdownCell(editor, code);
+      }
       if (moveDown === true) {
         codeManager.moveDown(editor, row);
       }
@@ -519,10 +519,12 @@ const Hydrogen = {
         end.row == editor.getLastBufferRow() ? end.row : end.row - 1
       );
       const cellType = codeManager.getMetadataForRow(editor, start);
-      if (cellType === "markdown") {
-        code = codeManager.removeCommentsMarkdownCell(editor, code);
+      if (code) {
+        if (cellType === "markdown") {
+          code = codeManager.removeCommentsMarkdownCell(editor, code);
+        }
+        this._createResultBubble(editor, kernel, { code, row, cellType });
       }
-      this._createResultBubble(editor, kernel, { code, row, cellType });
     }
   },
 
@@ -568,10 +570,12 @@ const Hydrogen = {
           : end.row - 1
       );
       const cellType = codeManager.getMetadataForRow(editor, start);
-      if (cellType === "markdown") {
-        code = codeManager.removeCommentsMarkdownCell(editor, code);
+      if (code) {
+        if (cellType === "markdown") {
+          code = codeManager.removeCommentsMarkdownCell(editor, code);
+        }
+        this.createResultBubble(editor, { code, row, cellType });
       }
-      this.createResultBubble(editor, { code, row, cellType });
       if (cell.containsPoint(cursor)) {
         break;
       }

--- a/lib/main.js
+++ b/lib/main.js
@@ -345,7 +345,7 @@ const Hydrogen = {
 
   createResultBubble(
     editor: atom$TextEditor,
-    codeBlock: { code: string, row: number, cellType: string }
+    codeBlock: { code: string, row: number, cellType: HydrogenCellType }
   ) {
     const { grammar, filePath, kernel } = store;
 
@@ -373,7 +373,7 @@ const Hydrogen = {
   _createResultBubble(
     editor: atom$TextEditor,
     kernel: Kernel,
-    codeBlock: { code: string, row: number, cellType: string }
+    codeBlock: { code: string, row: number, cellType: HydrogenCellType }
   ) {
     if (atom.workspace.getActivePaneItem() instanceof WatchesPane) {
       kernel.watchesStore.run();

--- a/lib/main.js
+++ b/lib/main.js
@@ -396,24 +396,27 @@ const Hydrogen = {
       codeBlock.row,
       !globalOutputStore || codeBlock.cellType == "markdown"
     );
-
-    switch (codeBlock.cellType) {
-      case "markdown":
-        outputStore.appendOutput({
-          output_type: "display_data",
-          data: {
-            "text/markdown": codeBlock.code
-          },
-          metadata: {}
-        });
-        outputStore.appendOutput({ data: "ok", stream: "status" });
-        break;
-      case "codecell":
-        kernel.execute(codeBlock.code, result => {
-          outputStore.appendOutput(result);
-          if (globalOutputStore) globalOutputStore.appendOutput(result);
-        });
-        break;
+    if (codeBlock.code.search(/[\S]/) != -1) {
+      switch (codeBlock.cellType) {
+        case "markdown":
+          outputStore.appendOutput({
+            output_type: "display_data",
+            data: {
+              "text/markdown": codeBlock.code
+            },
+            metadata: {}
+          });
+          outputStore.appendOutput({ data: "ok", stream: "status" });
+          break;
+        case "codecell":
+          kernel.execute(codeBlock.code, result => {
+            outputStore.appendOutput(result);
+            if (globalOutputStore) globalOutputStore.appendOutput(result);
+          });
+          break;
+      }
+    } else {
+      outputStore.appendOutput({ data: "ok", stream: "status" });
     }
   },
 
@@ -468,7 +471,7 @@ const Hydrogen = {
     const { row } = codeBlock;
     let { code } = codeBlock;
     const cellType = codeManager.getMetadataForRow(editor, new Point(row, 0));
-    if (code) {
+    if (code || code === "") {
       if (cellType === "markdown") {
         code = codeManager.removeCommentsMarkdownCell(editor, code);
       }
@@ -519,7 +522,7 @@ const Hydrogen = {
         end.row == editor.getLastBufferRow() ? end.row : end.row - 1
       );
       const cellType = codeManager.getMetadataForRow(editor, start);
-      if (code) {
+      if (code || code === "") {
         if (cellType === "markdown") {
           code = codeManager.removeCommentsMarkdownCell(editor, code);
         }
@@ -568,7 +571,7 @@ const Hydrogen = {
         end.row == editor.getLastBufferRow() ? end.row : end.row - 1
       );
       const cellType = codeManager.getMetadataForRow(editor, start);
-      if (code) {
+      if (code || code === "") {
         if (cellType === "markdown") {
           code = codeManager.removeCommentsMarkdownCell(editor, code);
         }
@@ -593,7 +596,7 @@ const Hydrogen = {
       end.row == editor.getLastBufferRow() ? end.row : end.row - 1
     );
     const cellType = codeManager.getMetadataForRow(editor, start);
-    if (code) {
+    if (code || code === "") {
       if (cellType === "markdown") {
         code = codeManager.removeCommentsMarkdownCell(editor, code);
       }

--- a/lib/main.js
+++ b/lib/main.js
@@ -509,19 +509,17 @@ const Hydrogen = {
     breakpoints?: Array<atom$Point>
   ) {
     let cells = codeManager.getCells(editor, breakpoints);
-    _.forEach(
-      cells,
-      ({ start, end }: { start: atom$Point, end: atom$Point }) => {
-        const code = codeManager.getTextInRange(editor, start, end);
-        const row = codeManager.escapeBlankRows(
-          editor,
-          start.row,
-          end.row == editor.getLastBufferRow() ? end.row : end.row - 1
-        );
-        const cellType = codeManager.getMetadataForRow(editor, start);
-        this._createResultBubble(editor, kernel, { code, row, cellType });
-      }
-    );
+    for (const cell of cells) {
+      const { start, end } = cell;
+      const code = codeManager.getTextInRange(editor, start, end);
+      const row = codeManager.escapeBlankRows(
+        editor,
+        start.row,
+        end.row == editor.getLastBufferRow() ? end.row : end.row - 1
+      );
+      const cellType = codeManager.getMetadataForRow(editor, start);
+      this._createResultBubble(editor, kernel, { code, row, cellType });
+    }
   },
 
   runAllAbove() {
@@ -555,21 +553,19 @@ const Hydrogen = {
     const breakpoints = codeManager.getBreakpoints(editor);
     breakpoints.push(cursor);
     const cells = codeManager.getCells(editor, breakpoints);
-    for (let i = 0; i < cells.length; i++) {
-      log("cell", i, cells[i]);
-      const start = cells[i].start;
-      const end = cells[i].end;
+    for (const cell of cells) {
+      const { start, end } = cell;
       const code = codeManager.getTextInRange(editor, start, end);
       const row = codeManager.escapeBlankRows(
         editor,
         start.row,
-        end.row == editor.getLastBufferRow() || cells[i].containsPoint(cursor)
+        end.row == editor.getLastBufferRow() || cell.containsPoint(cursor)
           ? end.row
           : end.row - 1
       );
       const cellType = codeManager.getMetadataForRow(editor, start);
       this.createResultBubble(editor, { code, row, cellType });
-      if (cells[i].containsPoint(cursor)) {
+      if (cell.containsPoint(cursor)) {
         break;
       }
     }

--- a/lib/main.js
+++ b/lib/main.js
@@ -508,8 +508,8 @@ const Hydrogen = {
   },
 
   runAllAbove() {
-    const editor = store.editor; // to make flow happy
-    if (!editor) return;
+    const { editor, kernel, grammar, filePath } = store;
+    if (!editor || !grammar || !filePath) return;
     if (isMultilanguageGrammar(editor.getGrammar())) {
       atom.notifications.addError(
         '"Run All Above" is not supported for this file type!'
@@ -517,12 +517,44 @@ const Hydrogen = {
       return;
     }
 
-    const cursor = editor.getLastCursor();
-    const row = codeManager.escapeBlankRows(editor, 0, cursor.getBufferRow());
-    const code = codeManager.getRows(editor, 0, row);
+    if (editor && kernel) {
+      this._runAllAbove(editor, kernel);
+      return;
+    }
 
-    if (code) {
-      this.createResultBubble(editor, { code, row });
+    kernelManager.startKernelFor(
+      grammar,
+      editor,
+      filePath,
+      (kernel: ZMQKernel) => {
+        this._runAllAbove(editor, kernel);
+      }
+    );
+  },
+
+  _runAllAbove(editor: atom$TextEditor, kernel: Kernel) {
+    const cursor = editor.getCursorBufferPosition();
+    cursor.column = editor.getBuffer().lineLengthForRow(cursor.row);
+    const breakpoints = codeManager.getBreakpoints(editor);
+    breakpoints.push(cursor);
+    const cells = codeManager.getCells(editor, breakpoints);
+    for (let i = 0; i < cells.length; i++) {
+      log("cell", i, cells[i]);
+      const start = cells[i].start;
+      const end = cells[i].end;
+      const code = codeManager.getTextInRange(editor, start, end);
+      const row = codeManager.escapeBlankRows(
+        editor,
+        start.row,
+        end.row == editor.getLastBufferRow() || cells[i].containsPoint(cursor)
+          ? end.row
+          : end.row - 1
+      );
+      const cellType = codeManager.getMetadataForRow(editor, start);
+      this.createResultBubble(editor, { code, row, cellType });
+      if (cells[i].containsPoint(cursor)) {
+        break;
+      }
     }
   },
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -343,7 +343,10 @@ const Hydrogen = {
     }
   },
 
-  createResultBubble(editor: atom$TextEditor, code: string, row: number) {
+  createResultBubble(
+    editor: atom$TextEditor,
+    codeBlock: { code: string, row: number, cellType: string }
+  ) {
     const { grammar, filePath, kernel } = store;
 
     if (!filePath || !grammar) {
@@ -353,7 +356,7 @@ const Hydrogen = {
     }
 
     if (kernel) {
-      this._createResultBubble(editor, kernel, code, row);
+      this._createResultBubble(editor, kernel, codeBlock);
       return;
     }
 
@@ -362,7 +365,7 @@ const Hydrogen = {
       editor,
       filePath,
       (kernel: ZMQKernel) => {
-        this._createResultBubble(editor, kernel, code, row);
+        this._createResultBubble(editor, kernel, codeBlock);
       }
     );
   },
@@ -370,8 +373,7 @@ const Hydrogen = {
   _createResultBubble(
     editor: atom$TextEditor,
     kernel: Kernel,
-    code: string,
-    row: number
+    codeBlock: { code: string, row: number, cellType: string }
   ) {
     if (atom.workspace.getActivePaneItem() instanceof WatchesPane) {
       kernel.watchesStore.run();
@@ -391,11 +393,11 @@ const Hydrogen = {
       markers,
       kernel,
       editor,
-      row,
+      codeBlock.row,
       !globalOutputStore
     );
 
-    kernel.execute(code, result => {
+    kernel.execute(codeBlock.code, result => {
       outputStore.appendOutput(result);
       if (globalOutputStore) globalOutputStore.appendOutput(result);
     });
@@ -454,7 +456,7 @@ const Hydrogen = {
       if (moveDown === true) {
         codeManager.moveDown(editor, row);
       }
-      this.createResultBubble(editor, code, row);
+      this.createResultBubble(editor, { code, row });
     }
   },
 
@@ -494,7 +496,7 @@ const Hydrogen = {
       ({ start, end }: { start: atom$Point, end: atom$Point }) => {
         const code = codeManager.getTextInRange(editor, start, end);
         const endRow = codeManager.escapeBlankRows(editor, start.row, end.row);
-        this._createResultBubble(editor, kernel, code, endRow);
+        this._createResultBubble(editor, kernel, { code, endRow });
       }
     );
   },
@@ -514,7 +516,7 @@ const Hydrogen = {
     const code = codeManager.getRows(editor, 0, row);
 
     if (code) {
-      this.createResultBubble(editor, code, row);
+      this.createResultBubble(editor, { code, row });
     }
   },
 
@@ -531,7 +533,7 @@ const Hydrogen = {
       if (moveDown === true) {
         codeManager.moveDown(editor, endRow);
       }
-      this.createResultBubble(editor, code, endRow);
+      this.createResultBubble(editor, { code, endRow });
     }
   },
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -402,10 +402,7 @@ const Hydrogen = {
         outputStore.appendOutput({
           output_type: "display_data",
           data: {
-            "text/markdown": codeManager.removeCommentsMarkdownCell(
-              editor,
-              codeBlock.code
-            )
+            "text/markdown": codeBlock.code
           },
           metadata: {}
         });
@@ -468,8 +465,12 @@ const Hydrogen = {
       return;
     }
 
-    const { code, row } = codeBlock;
+    const { row } = codeBlock;
+    let { code } = codeBlock;
     const cellType = codeManager.getMetadataForRow(editor, new Point(row, 0));
+    if (cellType === "markdown") {
+      code = codeManager.removeCommentsMarkdownCell(editor, code);
+    }
     if (code) {
       if (moveDown === true) {
         codeManager.moveDown(editor, row);
@@ -511,13 +512,16 @@ const Hydrogen = {
     let cells = codeManager.getCells(editor, breakpoints);
     for (const cell of cells) {
       const { start, end } = cell;
-      const code = codeManager.getTextInRange(editor, start, end);
+      let code = codeManager.getTextInRange(editor, start, end);
       const row = codeManager.escapeBlankRows(
         editor,
         start.row,
         end.row == editor.getLastBufferRow() ? end.row : end.row - 1
       );
       const cellType = codeManager.getMetadataForRow(editor, start);
+      if (cellType === "markdown") {
+        code = codeManager.removeCommentsMarkdownCell(editor, code);
+      }
       this._createResultBubble(editor, kernel, { code, row, cellType });
     }
   },
@@ -555,7 +559,7 @@ const Hydrogen = {
     const cells = codeManager.getCells(editor, breakpoints);
     for (const cell of cells) {
       const { start, end } = cell;
-      const code = codeManager.getTextInRange(editor, start, end);
+      let code = codeManager.getTextInRange(editor, start, end);
       const row = codeManager.escapeBlankRows(
         editor,
         start.row,
@@ -564,6 +568,9 @@ const Hydrogen = {
           : end.row - 1
       );
       const cellType = codeManager.getMetadataForRow(editor, start);
+      if (cellType === "markdown") {
+        code = codeManager.removeCommentsMarkdownCell(editor, code);
+      }
       this.createResultBubble(editor, { code, row, cellType });
       if (cell.containsPoint(cursor)) {
         break;
@@ -577,15 +584,17 @@ const Hydrogen = {
     // https://github.com/nteract/hydrogen/issues/1452
     atom.commands.dispatch(editor.element, "autocomplete-plus:cancel");
     const { start, end } = codeManager.getCurrentCell(editor);
-    const code = codeManager.getTextInRange(editor, start, end);
+    let code = codeManager.getTextInRange(editor, start, end);
     const row = codeManager.escapeBlankRows(
       editor,
       start.row,
       end.row == editor.getLastBufferRow() ? end.row : end.row - 1
     );
     const cellType = codeManager.getMetadataForRow(editor, start);
-
     if (code) {
+      if (cellType === "markdown") {
+        code = codeManager.removeCommentsMarkdownCell(editor, code);
+      }
       if (moveDown === true) {
         codeManager.moveDown(editor, row);
       }

--- a/lib/main.js
+++ b/lib/main.js
@@ -451,7 +451,7 @@ const Hydrogen = {
       return;
     }
 
-    const [code, row] = codeBlock;
+    const { code, row } = codeBlock;
     if (code) {
       if (moveDown === true) {
         codeManager.moveDown(editor, row);

--- a/lib/main.js
+++ b/lib/main.js
@@ -452,11 +452,12 @@ const Hydrogen = {
     }
 
     const { code, row } = codeBlock;
+    const cellType = codeManager.getMetadataForRow(editor, new Point(row, 0));
     if (code) {
       if (moveDown === true) {
         codeManager.moveDown(editor, row);
       }
-      this.createResultBubble(editor, { code, row });
+      this.createResultBubble(editor, { code, row, cellType });
     }
   },
 
@@ -500,7 +501,8 @@ const Hydrogen = {
           start.row,
           end.row == editor.getLastBufferRow() ? end.row : end.row - 1
         );
-        this._createResultBubble(editor, kernel, { code, row });
+        const cellType = codeManager.getMetadataForRow(editor, start);
+        this._createResultBubble(editor, kernel, { code, row, cellType });
       }
     );
   },
@@ -536,12 +538,13 @@ const Hydrogen = {
       start.row,
       end.row == editor.getLastBufferRow() ? end.row : end.row - 1
     );
+    const cellType = codeManager.getMetadataForRow(editor, start);
 
     if (code) {
       if (moveDown === true) {
         codeManager.moveDown(editor, row);
       }
-      this.createResultBubble(editor, { code, row });
+      this.createResultBubble(editor, { code, row, cellType });
     }
   },
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -394,13 +394,30 @@ const Hydrogen = {
       kernel,
       editor,
       codeBlock.row,
-      !globalOutputStore
+      !globalOutputStore || codeBlock.cellType == "markdown"
     );
 
-    kernel.execute(codeBlock.code, result => {
-      outputStore.appendOutput(result);
-      if (globalOutputStore) globalOutputStore.appendOutput(result);
-    });
+    switch (codeBlock.cellType) {
+      case "markdown":
+        outputStore.appendOutput({
+          output_type: "display_data",
+          data: {
+            "text/markdown": codeManager.removeCommentsMarkdownCell(
+              editor,
+              codeBlock.code
+            )
+          },
+          metadata: {}
+        });
+        outputStore.appendOutput({ data: "ok", stream: "status" });
+        break;
+      case "codecell":
+        kernel.execute(codeBlock.code, result => {
+          outputStore.appendOutput(result);
+          if (globalOutputStore) globalOutputStore.appendOutput(result);
+        });
+        break;
+    }
   },
 
   restartKernelAndReEvaluateBubbles() {

--- a/lib/store/index.js
+++ b/lib/store/index.js
@@ -93,7 +93,7 @@ export class Store {
       if (source.slice(-1) === "\n") source = source.slice(0, -1);
       const cellType = codeManager.getMetadataForRow(editor, start);
       let newCell;
-      if (cellType === "code") {
+      if (cellType === "codecell") {
         newCell = commutable.emptyCodeCell.set("source", source);
       } else if (cellType === "markdown") {
         source = codeManager.removeCommentsMarkdownCell(editor, source);

--- a/spec/code-manager-spec.js
+++ b/spec/code-manager-spec.js
@@ -151,6 +151,58 @@ describe("CodeManager", () => {
           expect(CM.getCells(editor, breakpoints)).toEqual(cellsExpected);
         });
       });
+      describe("labeled markdown", () => {
+        beforeEach(() => {
+          const code = [
+            "#%% md Block 1",
+            "##Markdown Header",
+            "Plain Text",
+            "# %%markdown Block 2",
+            "#`code`",
+            "`code`",
+            "# <markdown> Block 3",
+            "#*Italics*"
+          ];
+          editor.setText(code.join("\n") + "\n");
+        });
+        it("returns correct cellType", () => {
+          expect(CM.getMetadataForRow(editor, new Point(1, 0))).toBe(
+            "markdown"
+          );
+          expect(CM.getMetadataForRow(editor, new Point(5, 0))).toBe(
+            "markdown"
+          );
+          expect(CM.getMetadataForRow(editor, new Point(7, 0))).toBe(
+            "markdown"
+          );
+        });
+      });
+      describe("labeled markdown and codecell", () => {
+        beforeEach(() => {
+          const code = [
+            "#%% md Block 1",
+            "##Markdown Header",
+            "Plain Text",
+            "# %% Block 2",
+            "#comment",
+            "print('hi')",
+            "# ln[0] Block 3",
+            "#comment"
+          ];
+          editor.setText(code.join("\n") + "\n");
+        });
+        it("returns correct cellType", () => {
+          expect(CM.getMetadataForRow(editor, new Point(2, 0))).toBe(
+            "markdown"
+          );
+          expect(CM.getMetadataForRow(editor, new Point(5, 0))).toBe(
+            "codecell"
+          );
+          expect(CM.getMetadataForRow(editor, new Point(7, 0))).toBe(
+            "codecell"
+          );
+        });
+      });
     });
 
     describe("foldCells", () => {

--- a/types/hydrogen.js.flow
+++ b/types/hydrogen.js.flow
@@ -1,3 +1,5 @@
+export type HydrogenCellType = 'codecell' | 'markdown';
+
 export type Kernelspec = {
   env: Object,
   argv: Array<string>,


### PR DESCRIPTION
# Markdown Result Bubbles
This is a rewrite of #1620 because it was trying to accomplish too much.

### Effects:
- Adds Markdown Result Bubbles Inline, but never outputs globally
- Alters `runAllAbove`to start a kernel if one does not exist, so that separate cells are not skipped by the async
- Refactors `getCurrentCodeCell` to `getCell,` which accepts any point, but if not given uses last cursor
- Refactors `getMetadataForRow` to also work with any point, but it is required.
   - This is now the birthplace of `cellType`
- `isBlank` no longer returns true for comments
- `findCodeBlock` and its "children"/"return" functions now return an object instead of an array
- `createResultBubble` now uses a `codeBlock` argument instead of a code and row argument
- `_createResultBubble` now outputs "fake" data streams for rendering markdown to `ResultView`'s
- Adds test for `getMetadataForRow`

### Notes:
- This makes over 50% less additions and deletions than #1620 
- This does not edit any previous test cases, which means this passes all original tests.

### Known Bugs:
- [ ]  Code block text from markdown cells gets default hydrogen styling  
   - Example code:
    ```
    #%%md
    # `Shift-Enter`
    #Plain Text
    ```
- [ ]  If markdown cell contains only `'---'` the outputted hr has no width  
   - Example code:
    ```
    #%%md
    # ---
    ```
- [ ]  Nested html tags in markdown cells render in separated sibling spans when text is in front  
   - Example Code:
    ```
    #%%md
    # hi <div class='outside-container'><div class="inside-container"></div></div>
    ```
   - Example Result (Bad Behavior):
    ```
    <div class="cell_display" style="max-height: 100%; overflow-y: auto;">
       <p>
          "hi "
          <span>
             <div class="outside-container"></div>
          </span>
          <span>
             <div class="inside-container"></div>
          </span>
       </p>
    </div>
    ```