### PR TITLE
Drop Support For Re-evaluating Bubbles

### DIFF
--- a/docs/Usage/GettingStarted.md
+++ b/docs/Usage/GettingStarted.md
@@ -42,25 +42,9 @@ The output can be displayed either in a scrolling view or a sliding history.
 
 <img width=560 src=https://user-images.githubusercontent.com/13436188/31737963-799d2ad2-b449-11e7-9b4c-78e51851e204.gif>
 
-## "Hydrogen: Restart Kernel And Re Evaluate Bubbles"
+## "Hydrogen: Clear Bubble"
 
-Restart running kernel and re-evaluate all bubbles on editor.
-This command works in following way.
-
-1. Restart kernel to cleanup evaluation environment.
-2. Run all code and update all existing bubbles.
-
-## "Hydrogen: Toggle Bubble"
-
-Toggle(add or remove) bubble at current cursor line.
-You can **preset** bubble before executing code.
-If executed with selection, toggle bubble on each selected line.
-
-Typical workflow with this command is
-
-1. Add bubble at line you want manually by **"Hydrogen: Toggle-Bubble"**
-2. Execute code cleanly by **"Hydrogen: Restart-Kernel-And-Re-Evaluate-Bubbles"**
-3. Modify code, then repeat 1-3 until you fully understand/investigated code.
+Remove bubble at current cursor line or current lines within a selection.
 
 ## "Hydrogen: Toggle Watches"
 
@@ -107,7 +91,7 @@ If you are working in a markup file that supports highlighted code blocks, we ca
 
 <img src="https://cloud.githubusercontent.com/assets/13285808/24365090/0af6a91c-1315-11e7-92c6-849031bf9f6a.gif" height=350>
 
-We support 
+We support
 [markdown](https://github.com/burodepeper/language-markdown),
 [gfm](https://github.com/atom/language-gfm),
 [asciidoc](https://github.com/asciidoctor/atom-language-asciidoc),

--- a/docs/Usage/GettingStarted.md
+++ b/docs/Usage/GettingStarted.md
@@ -42,9 +42,9 @@ The output can be displayed either in a scrolling view or a sliding history.
 
 <img width=560 src=https://user-images.githubusercontent.com/13436188/31737963-799d2ad2-b449-11e7-9b4c-78e51851e204.gif>
 
-## "Hydrogen: Clear Bubble"
+## "Hydrogen: Clear Result"
 
-Remove bubble at current cursor line or current lines within a selection.
+Remove results at current cursor line or current lines within a selection.
 
 ## "Hydrogen: Toggle Watches"
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -137,7 +137,7 @@ const Hydrogen = {
           this.handleKernelCommand({ command: "restart-kernel" }),
         "hydrogen:shutdown-kernel": () =>
           this.handleKernelCommand({ command: "shutdown-kernel" }),
-        "hydrogen:toggle-bubble": () => this.toggleBubble(),
+        "hydrogen:clear-bubble": () => this.clearBubble(),
         "hydrogen:export-notebook": () => exportNotebook(),
         "hydrogen:fold-current-cell": () => this.foldCurrentCell(),
         "hydrogen:fold-all-but-current-cell": () => this.foldAllButCurrentCell()
@@ -418,24 +418,13 @@ const Hydrogen = {
     }
   },
 
-  toggleBubble() {
+  clearBubble() {
     const { editor, kernel, markers } = store;
     if (!editor || !markers) return;
     const [startRow, endRow] = editor.getLastSelection().getBufferRowRange();
 
     for (let row = startRow; row <= endRow; row++) {
-      const destroyed = markers.clearOnRow(row);
-
-      if (!destroyed) {
-        const { outputStore } = new ResultView(
-          markers,
-          kernel,
-          editor,
-          row,
-          true
-        );
-        outputStore.status = "empty";
-      }
+      markers.clearOnRow(row);
     }
   },
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -137,7 +137,7 @@ const Hydrogen = {
           this.handleKernelCommand({ command: "restart-kernel" }),
         "hydrogen:shutdown-kernel": () =>
           this.handleKernelCommand({ command: "shutdown-kernel" }),
-        "hydrogen:clear-bubble": () => this.clearBubble(),
+        "hydrogen:clear-result": () => this.clearResult(),
         "hydrogen:export-notebook": () => exportNotebook(),
         "hydrogen:fold-current-cell": () => this.foldCurrentCell(),
         "hydrogen:fold-all-but-current-cell": () => this.foldAllButCurrentCell()
@@ -418,7 +418,7 @@ const Hydrogen = {
     }
   },
 
-  clearBubble() {
+  clearResult() {
     const { editor, kernel, markers } = store;
     if (!editor || !markers) return;
     const [startRow, endRow] = editor.getLastSelection().getBufferRowRange();

--- a/lib/main.js
+++ b/lib/main.js
@@ -135,8 +135,6 @@ const Hydrogen = {
           this.handleKernelCommand({ command: "interrupt-kernel" }),
         "hydrogen:restart-kernel": () =>
           this.handleKernelCommand({ command: "restart-kernel" }),
-        "hydrogen:restart-kernel-and-re-evaluate-bubbles": () =>
-          this.restartKernelAndReEvaluateBubbles(),
         "hydrogen:shutdown-kernel": () =>
           this.handleKernelCommand({ command: "shutdown-kernel" }),
         "hydrogen:toggle-bubble": () => this.toggleBubble(),
@@ -417,23 +415,6 @@ const Hydrogen = {
       }
     } else {
       outputStore.appendOutput({ data: "ok", stream: "status" });
-    }
-  },
-
-  restartKernelAndReEvaluateBubbles() {
-    const { editor, kernel, markers } = store;
-    if (!editor || !kernel || !markers) return;
-
-    let breakpoints = [];
-    markers.markers.forEach((bubble: ResultView) => {
-      breakpoints.push(bubble.marker.getBufferRange().start);
-    });
-    markers.clear();
-
-    if (!editor || !kernel) {
-      this.runAll(breakpoints);
-    } else {
-      kernel.restart(() => this.runAll(breakpoints));
     }
   },
 

--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
       "hydrogen:run-all",
       "hydrogen:run-all-above",
       "hydrogen:run-cell",
-      "hydrogen:run-cell-and-move-down",
-      "hydrogen:clear-result"
+      "hydrogen:run-cell-and-move-down"
     ],
     "atom-workspace": [
       "hydrogen:import-notebook"

--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
       "hydrogen:run-all-above",
       "hydrogen:run-cell",
       "hydrogen:run-cell-and-move-down",
-      "hydrogen:restart-kernel-and-re-evaluate-bubbles",
-      "hydrogen:toggle-bubble"
+      "hydrogen:clear-bubble"
     ],
     "atom-workspace": [
       "hydrogen:import-notebook"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
       "hydrogen:run-all-above",
       "hydrogen:run-cell",
       "hydrogen:run-cell-and-move-down",
-      "hydrogen:clear-bubble"
+      "hydrogen:clear-result"
     ],
     "atom-workspace": [
       "hydrogen:import-notebook"


### PR DESCRIPTION
# Why:
The feature seems to not work very friendly with cells, and has had a long standing bug because of this.
The feature itself would be difficult to implement properly with very little benefit.
We currently support watches which accomplish most of the need for this feature.
IMO: If you wanted to re-evaluate bubbles, you should do so on a bubble by bubble basis since you should want to avoid re-evaluating long or unrelated tasks.

See #861 to understand why the feature was creating originally

---

- Closes #1516
- Closes #1474