### PR TITLE
Fix Horizontal Scrolling of Result Views

### DIFF
--- a/lib/components/result-view/result-view.js
+++ b/lib/components/result-view/result-view.js
@@ -85,12 +85,20 @@ class ResultViewComponent extends React.Component<Props> {
     return (event: WheelEvent) => {
       const clientHeight = element.clientHeight;
       const scrollHeight = element.scrollHeight;
+      const clientWidth = element.clientWidth;
+      const scrollWidth = element.scrollWidth;
       const scrollTop = element.scrollTop;
+      const scrollLeft = element.scrollLeft;
       const atTop = scrollTop !== 0 && event.deltaY < 0;
+      const atLeft = scrollLeft !== 0 && event.deltaX < 0;
       const atBottom =
         scrollTop !== scrollHeight - clientHeight && event.deltaY > 0;
+      const atRight =
+        scrollLeft !== scrollWidth - clientWidth && event.deltaX > 0;
 
       if (clientHeight < scrollHeight && (atTop || atBottom)) {
+        event.stopPropagation();
+      } else if (clientWi < scrollWidth && (atLeft || atRight)) {
         event.stopPropagation();
       }
     };

--- a/lib/components/result-view/result-view.js
+++ b/lib/components/result-view/result-view.js
@@ -98,7 +98,7 @@ class ResultViewComponent extends React.Component<Props> {
 
       if (clientHeight < scrollHeight && (atTop || atBottom)) {
         event.stopPropagation();
-      } else if (clientWi < scrollWidth && (atLeft || atRight)) {
+      } else if (clientWidth < scrollWidth && (atLeft || atRight)) {
         event.stopPropagation();
       }
     };


### PR DESCRIPTION
## The Issue
Unlike vertical scrolling, horizontal scrolling inside a `ResultView` scrolled both the `ResultView` and the `Atom Editor Pane`.

The expected behavior is to stop `Atom Editor Pane` scrolling while scrolling inside a `ResultView`.

This behavior was already implemented for vertical scrolling, but had not been implemented for horizontal scrolling.

This PR fixes that issue.

## Notes
- For reproduction, see #1644 
- Upon merge, closes #1644.

**This PR is ready for review**