### PR TITLE
New Error For Import Notebook

### DIFF
--- a/lib/import-notebook.js
+++ b/lib/import-notebook.js
@@ -54,15 +54,22 @@ export function importNotebook(event?: atom$CustomEvent) {
 
 export async function _loadNotebook(filename: string) {
   let data;
+  let nb;
   try {
     data = await readFileP(filename);
+    nb = parseNotebook(data);
   } catch (err) {
-    atom.notifications.addError("Error reading file", {
-      detail: err.message
-    });
+    if (err.name === "SyntaxError") {
+      atom.notifications.addError("Error not a valid notebook", {
+        detail: err.stack
+      });
+    } else {
+      atom.notifications.addError("Error reading file", {
+        detail: err.message
+      });
+    }
     return;
   }
-  const nb = parseNotebook(data);
   if (nb.nbformat < 4) {
     atom.notifications.addError("Only notebook version 4 currently supported");
     return;


### PR DESCRIPTION
## The Issue
When supplying `parseNotebook` with a bad JSON format (this includes empty files), we didn't tell the user that an error occurred. Nothing would happen visually, but an experienced user could see an error in the console. This PR now catches this error and throws an atom error with the stack trace, so that users know they don't had a valid file.

## Notes
- `Import Notebook` also has always thrown an error immediately after creating a `.ipynb` in atom, since it is not a valid notebook and atom tries to open it immediately.

---

- Closes #1648 