### PR TITLE
Fix #1603

### DIFF
--- a/lib/components/kernel-monitor.js
+++ b/lib/components/kernel-monitor.js
@@ -7,8 +7,6 @@ import { observer } from "mobx-react";
 import _ from "lodash";
 import tildify from "tildify";
 
-import { KERNEL_MONITOR_URI } from "./../utils";
-
 import typeof store from "../store";
 import Kernel from "../kernel";
 
@@ -68,6 +66,26 @@ const openEditor = (filePath: string) => {
     });
 };
 
+type KernelInfo = {
+  value: {
+    displayName: string,
+    kernelSpec: Kernelspec
+  }
+};
+const kernelInfoCell = (props: KernelInfo) => {
+  const { displayName, kernelSpec } = props.value;
+  return (
+    <a
+      className="icon"
+      onClick={showKernelSpec.bind(this, kernelSpec)}
+      title="Show kernel spec"
+      key={displayName + "kernelInfo"}
+    >
+      {displayName}
+    </a>
+  );
+};
+
 // Set default properties of React-Table
 Object.assign(ReactTableDefaults, {
   className: "kernel-monitor",
@@ -111,19 +129,7 @@ const KernelMonitor = observer(({ store }: { store: store }) => {
     {
       Header: "Kernel",
       accessor: "kernelInfo",
-      Cell: props => {
-        const { displayName, kernelSpec } = props.value;
-        return (
-          <a
-            className="icon"
-            onClick={showKernelSpec.bind(this, kernelSpec)}
-            title="Show kernel spec"
-            key={displayName + "kernelInfo"}
-          >
-            {displayName}
-          </a>
-        );
-      },
+      Cell: kernelInfoCell,
       maxWidth: 125
     },
     {

--- a/lib/store/index.js
+++ b/lib/store/index.js
@@ -233,13 +233,17 @@ export class Store {
     this.configMapping.set(keyPath, newValue);
   }
 
+  /**
+   * Force mobx to recalculate filePath (which depends on editor observable)
+   */
   forceEditorUpdate() {
-    // Force mobx to recalculate filePath (which depends on editor observable)
-
     const currentEditor = this.editor;
     if (!currentEditor) return;
 
     const oldKey = this.filePath;
+    // Return back if the kernel for this editor is already disposed.
+    if (!this.kernelMapping.has(oldKey)) return;
+
     this.updateEditor(null);
     this.updateEditor(currentEditor);
     const newKey = this.filePath;

--- a/types/atom.js.flow
+++ b/types/atom.js.flow
@@ -1,3 +1,5 @@
+/* @flow */
+
 /**
  * Adapted from https://github.com/facebook/nuclide/tree/master/flow-libs
  * Copyright (c) 2015-present, Facebook, Inc.
@@ -5,8 +7,6 @@
  *
  * This source code is licensed under the license found in the LICENSE file in
  * the root directory of this source tree.
- *
- * @flow
  */
 
 /**
@@ -47,10 +47,10 @@ type atom$Octicon = 'alert' | 'alignment-align' | 'alignment-aligned-to' | 'alig
   'shield' | 'sign-in' | 'sign-out' | 'smiley' | 'split' | 'squirrel' | 'star' | 'star-add' |
   'star-delete' | 'steps' | 'stop' | 'sync' | 'tag' | 'tag-add' | 'tag-remove' | 'tasklist' |
   'telescope' | 'terminal' | 'text-size' | 'three-bars' | 'thumbsdown' | 'thumbsup' | 'tools' |
-  'trashcan' | 'triangle-down' | 'triangle-left' | 'triangle-right' | 'triangle-up' | 'type-array'|
-  'type-boolean'| 'type-class'| 'type-constant'| 'type-constructor'| 'type-enum'| 'type-field'|
-  'type-file'| 'type-function'| 'type-interface'| 'type-method'| 'type-module'| 'type-namespace'|
-  'type-number'| 'type-package'| 'type-property'| 'type-string'| 'type-variable' | 'unfold' |
+  'trashcan' | 'triangle-down' | 'triangle-left' | 'triangle-right' | 'triangle-up' | 'type-array' |
+  'type-boolean' | 'type-class' | 'type-constant' | 'type-constructor' | 'type-enum' | 'type-field' |
+  'type-file' | 'type-function' | 'type-interface' | 'type-method' | 'type-module' | 'type-namespace' |
+  'type-number' | 'type-package' | 'type-property' | 'type-string' | 'type-variable' | 'unfold' |
   'unmute' | 'unverified' | 'verified' | 'versions' | 'watch' | 'x' | 'zap';
 
 type atom$PaneLocation = 'left' | 'right' | 'bottom' | 'center';

--- a/types/electron.js.flow
+++ b/types/electron.js.flow
@@ -1,3 +1,5 @@
+// @flow //
+
 declare module "electron" {
   declare module.exports: any;
 }

--- a/types/electron.js.flow
+++ b/types/electron.js.flow
@@ -1,4 +1,4 @@
-// @flow //
+/* @flow */
 
 declare module "electron" {
   declare module.exports: any;

--- a/types/hydrogen.js.flow
+++ b/types/hydrogen.js.flow
@@ -1,3 +1,5 @@
+/* @flow */
+
 export type HydrogenCellType = 'codecell' | 'markdown';
 
 export type Kernelspec = {

--- a/types/need-to-upstream-to-flow-lib.js.flow
+++ b/types/need-to-upstream-to-flow-lib.js.flow
@@ -1,3 +1,5 @@
+// @flow //
+
 /**
  * Adapted from https://github.com/facebook/nuclide/tree/master/flow-libs
  * Copyright (c) 2015-present, Facebook, Inc.
@@ -5,8 +7,6 @@
  *
  * This source code is licensed under the license found in the LICENSE file in
  * the root directory of this source tree.
- *
- * @flow
  */
 
 /*

--- a/types/need-to-upstream-to-flow-lib.js.flow
+++ b/types/need-to-upstream-to-flow-lib.js.flow
@@ -1,4 +1,4 @@
-// @flow //
+/* @flow */
 
 /**
  * Adapted from https://github.com/facebook/nuclide/tree/master/flow-libs


### PR DESCRIPTION
## Purpose of this PR:

Fixes #1603

## Desc

I found this issue is basically caused by this part: https://github.com/nteract/hydrogen/blob/2d53a2554b37ad02e09981a77e36131e1cd46ed8/lib/main.js#L199

In short, if a file within which a kernel got already destroyed gets renamed, this part in `forceEditorUpdate` change `kernelMapping` into funny state:
https://github.com/aviatesk/hydrogen/blob/432850814ae573e6da95ca75e8a75c6ad4e68840/lib/store/index.js#L248

Addressed by making a part within `forceEditorUpdate` to check whether the map has the file or not and return if not.

## Misc

This PR also contains some modifications for kernel-monitor.js and .js.flow files:
- Name stateless anonymous function to show kernelspec button (kernel-monitor.js)
- Add flow annotations for .js.flow files (eslint-flow-plugin complains otherwise)