### PR TITLE
Don't focus on kernel monitor after toggling

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -115,7 +115,7 @@ const Hydrogen = {
           const lastItem = atom.workspace.getActivePaneItem();
           const lastPane = atom.workspace.paneForItem(lastItem);
           await atom.workspace.toggle(KERNEL_MONITOR_URI);
-          lastPane.activate();
+          if (lastPane) lastPane.activate();
         },
         "hydrogen:start-local-kernel": () => this.startZMQKernel(),
         "hydrogen:connect-to-remote-kernel": () => this.connectToWSKernel(),

--- a/lib/main.js
+++ b/lib/main.js
@@ -111,8 +111,12 @@ const Hydrogen = {
         "hydrogen:run-cell-and-move-down": () => this.runCell(true),
         "hydrogen:toggle-watches": () => atom.workspace.toggle(WATCHES_URI),
         "hydrogen:toggle-output-area": () => toggleOutputMode(),
-        "hydrogen:toggle-kernel-monitor": () =>
-          atom.workspace.toggle(KERNEL_MONITOR_URI),
+        "hydrogen:toggle-kernel-monitor": async () => {
+          const lastItem = atom.workspace.getActivePaneItem();
+          const lastPane = atom.workspace.paneForItem(lastItem);
+          await atom.workspace.toggle(KERNEL_MONITOR_URI);
+          lastPane.activate();
+        },
         "hydrogen:start-local-kernel": () => this.startZMQKernel(),
         "hydrogen:connect-to-remote-kernel": () => this.connectToWSKernel(),
         "hydrogen:connect-to-existing-kernel": () =>


### PR DESCRIPTION
## Rationale

Currently `toggle-kernel-monitor` uses just `atom.workspace.toggle` API and after invoking the command our focus will be on the kernel-monitor pane and IMO most of the time we have to manually switch back to the previous editor (or pane in general).

This is because, within kernel monitor, we just _monitor_ it or click to do some action, and there is nothing to do with keybindings, thus there is no need to stay focus on it after toggling it.

## Approach

This PR includes the workaround for `atom.workspace.toggle` using `prevPane` stuff, cause there seems no option for `toggle` API unlike `open`...