### PR TITLE
Add a callback for file delete event:

### DIFF
--- a/lib/components/kernel-monitor.js
+++ b/lib/components/kernel-monitor.js
@@ -9,6 +9,7 @@ import tildify from "tildify";
 
 import typeof store from "../store";
 import Kernel from "../kernel";
+import { isUnsavedFilePath } from "../utils";
 
 const showKernelSpec = (kernelSpec: {}) => {
   atom.notifications.addInfo("Hydrogen: Kernel Spec", {
@@ -27,12 +28,8 @@ const restart = (kernel: Kernel) => {
   kernel.restart();
 };
 
-// @TODO If our store holds editor IDs instead of file paths, those messy matching stuff below
-//       can easily be replaced by simple code. This is my workaround so far.
-const isUnsavedEditor = (filePath: string): boolean => {
-  return filePath.match(/Unsaved\sEditor\s\d+/) ? true : false;
-};
-
+// @TODO If our store holds editor IDs instead of file paths, these messy matching stuff below would
+//       easily be replaced by simpler code. See also components/kernel-monitor.js for this problem.
 const openUnsavedEditor = (filePath: string) => {
   const editor = atom.workspace.getTextEditors().find(editor => {
     const match = filePath.match(/\d+/);
@@ -41,19 +38,13 @@ const openUnsavedEditor = (filePath: string) => {
     }
     return String(editor.id) === match[0];
   });
-  // @TODO: We can't restore an unsaved editor once it get destroyed, so it seems better to add a
-  //        disposer to detach the kernel from the unsaved editor when destroyed
-  if (!editor) {
-    atom.notifications.addWarning("hydrogen", {
-      description: "This unsaved editor seems to have been deleted already"
-    });
-    return;
-  }
+  // This path won't happen after https://github.com/nteract/hydrogen/pull/1662 since every deleted
+  // editors would be deleted from `store.kernelMapping`. Just kept here for safety.
+  if (!editor) return;
   atom.workspace.open(editor, {
     searchAllPanes: true
   });
 };
-
 const openEditor = (filePath: string) => {
   atom.workspace
     .open(filePath, {
@@ -183,7 +174,7 @@ const KernelMonitor = observer(({ store }: { store: store }) => {
       Cell: props => {
         return props.value.map((filePath, index) => {
           const separator = index === 0 ? "" : "  |  ";
-          const body = isUnsavedEditor(filePath) ? (
+          const body = isUnsavedFilePath(filePath) ? (
             <a
               onClick={openUnsavedEditor.bind(this, filePath)}
               title="Jump to file"

--- a/lib/store/index.js
+++ b/lib/store/index.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { CompositeDisposable } from "atom";
+import { CompositeDisposable, File } from "atom";
 import {
   observable,
   computed,
@@ -9,7 +9,11 @@ import {
   keys,
   values
 } from "mobx";
-import { isMultilanguageGrammar, getEmbeddedScope } from "./../utils";
+import {
+  isMultilanguageGrammar,
+  getEmbeddedScope,
+  isUnsavedFilePath
+} from "./../utils";
 import _ from "lodash";
 
 import Config from "./../config";
@@ -49,7 +53,6 @@ export class Store {
       );
     }
 
-    const grammar = this.getEmbeddedGrammar(this.editor);
     const kernelOrMap = this.kernelMapping.get(this.filePath);
     if (!kernelOrMap) return null;
     if (kernelOrMap instanceof Kernel) return kernelOrMap;
@@ -124,6 +127,35 @@ export class Store {
     this.startingKernels.set(kernelDisplayName, true);
   }
 
+  addFileDisposer(editor: atom$TextEditor, filePath: string) {
+    const fileDisposer = new CompositeDisposable();
+
+    if (isUnsavedFilePath(filePath)) {
+      fileDisposer.add(
+        editor.onDidSave(event => {
+          fileDisposer.dispose();
+          this.addFileDisposer(editor, event.path); // Add another `fileDisposer` once it's saved
+        })
+      );
+      fileDisposer.add(
+        editor.onDidDestroy(() => {
+          this.kernelMapping.delete(filePath);
+          fileDisposer.dispose();
+        })
+      );
+    } else {
+      const file: atom$File = new File(filePath);
+      fileDisposer.add(
+        file.onDidDelete(() => {
+          this.kernelMapping.delete(filePath);
+          fileDisposer.dispose();
+        })
+      );
+    }
+
+    this.subscriptions.add(fileDisposer);
+  }
+
   @action
   newKernel(
     kernel: Kernel,
@@ -140,6 +172,7 @@ export class Store {
     } else {
       this.kernelMapping.set(filePath, kernel);
     }
+    this.addFileDisposer(editor, filePath);
     const index = this.runningKernels.findIndex(k => k === kernel);
     if (index === -1) {
       this.runningKernels.push(kernel);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -127,6 +127,10 @@ export function isMultilanguageGrammar(grammar: atom$Grammar) {
   return markupGrammars.has(grammar.scopeName);
 }
 
+export const isUnsavedFilePath = (filePath: string): boolean => {
+  return filePath.match(/Unsaved\sEditor\s\d+/) ? true : false;
+};
+
 export function kernelSpecProvidesGrammar(
   kernelSpec: Kernelspec,
   grammar: ?atom$Grammar


### PR DESCRIPTION
## The purpose of this PR:

Plz refer to #1618.

## Approach

If an unsaved editor to which a kernel is already attached is destroyed(deleted), we no longer restore the editor and of course use _jump to file_ functionality within kernel-monitor neither.

I addresses this issue by adding a callback to unsaved editors that called when it destroyed (& saved) and changes the file name and disables _jump to file_ functionality.

## Discussion ?

In the current implementation, the kernel itself wouldn't be shutdown. This is because by doing so, we can reconnect to the kernel after deleting files attached to it.

But that case might be very advanced and it might be more friendly if we just shutdown the kernel when any other editor isn't connected to the kernel. (Jupyter kernel can eat some memory in general)

Thus I'm very welcome to discussion.

## Note

Actually the same thing does happen for saved files. Thus I included the fix for them as well in this PR.


***

Closes #1618 