### PR TITLE
Fix Editor Focus/Cursor Freezing

### DIFF
--- a/lib/components/result-view/index.js
+++ b/lib/components/result-view/index.js
@@ -19,7 +19,10 @@ export default class ResultView {
   outputStore: OutputStore;
 
   destroy = () => {
-    atom.workspace.getActiveTextEditor().element.focus();
+    const editor = atom.workspace.getActiveTextEditor();
+    if (editor != null) {
+      editor.element.focus();
+    }
     this.disposer.dispose();
     this.marker.destroy();
   };

--- a/lib/components/result-view/index.js
+++ b/lib/components/result-view/index.js
@@ -19,6 +19,7 @@ export default class ResultView {
   outputStore: OutputStore;
 
   destroy = () => {
+    atom.workspace.getActiveTextEditor().element.focus();
     this.disposer.dispose();
     this.marker.destroy();
   };


### PR DESCRIPTION
When implementing #1652, I introduced a focusing bug. When destroying a Multiline Markdown display via the close button, the editor was not refocusing onto the cursor. This PR defaults to always focusing on the editor after destroying a `ResultView`. I am unsure of whether or not I should check whats being focused first, but this is one solution.

Closes #1680