### PR TITLE
Make `Display` observer

### DIFF
--- a/lib/components/result-view/display.js
+++ b/lib/components/result-view/display.js
@@ -2,6 +2,7 @@
 
 import React from "react";
 import { toJS } from "mobx";
+import { observer } from "mobx-react";
 import {
   DisplayData,
   ExecuteResult,
@@ -15,8 +16,6 @@ import PlotlyTransform from "@nteract/transform-plotly";
 import { VegaLite1, VegaLite2, Vega2, Vega3 } from "@nteract/transform-vega";
 
 import Markdown from "./markdown";
-
-type Props = { output: any };
 
 // All supported media types for output go here
 export const supportedMediaTypes = (
@@ -53,13 +52,18 @@ export function isTextOutputOnly(data: Object) {
     : false;
 }
 
-export default function Display(props: Props) {
-  return (
-    <Output output={toJS(props.output)}>
-      <ExecuteResult expanded>{supportedMediaTypes}</ExecuteResult>
-      <DisplayData expanded>{supportedMediaTypes}</DisplayData>
-      <StreamText expanded />
-      <KernelOutputError expanded />
-    </Output>
-  );
+@observer
+class Display extends React.Component<{ output: any }> {
+  render() {
+    return (
+      <Output output={toJS(this.props.output)}>
+        <ExecuteResult expanded>{supportedMediaTypes}</ExecuteResult>
+        <DisplayData expanded>{supportedMediaTypes}</DisplayData>
+        <StreamText expanded />
+        <KernelOutputError expanded />
+      </Output>
+    );
+  }
 }
+
+export default Display;


### PR DESCRIPTION
## Purpose

This PR just does what @BenRussert proposed here: https://github.com/nteract/hydrogen/issues/1678#issuecomment-505910843
Please see https://github.com/mobxjs/mobx-react#faq for why I took the `observer` class way.

## Misc

I confirmed this still works if we updated to mobx-react v6 as I'm doing in #1631 

- Fixes #1678
- Fixes #1681 