### PR TITLE
Add Soft Wrapping To Config

### DIFF
--- a/lib/components/result-view/history.js
+++ b/lib/components/result-view/history.js
@@ -47,9 +47,9 @@ const History = observer(({ store }: { store: OutputStore }) => {
         style={{
           fontSize: atom.config.get(`Hydrogen.outputAreaFontSize`) || "inherit"
         }}
-        hydrogen-wrapOutput={(atom.config.get(
+        hydrogen-wrapOutput={((atom.config.get(
           `Hydrogen.wrapOutput`
-        ): boolean).toString()}
+        ): any): boolean).toString()}
       >
         <Display output={output} />
       </div>

--- a/lib/components/result-view/history.js
+++ b/lib/components/result-view/history.js
@@ -47,7 +47,9 @@ const History = observer(({ store }: { store: OutputStore }) => {
         style={{
           fontSize: atom.config.get(`Hydrogen.outputAreaFontSize`) || "inherit"
         }}
-        hydrogen-wrapOutput={atom.config.get(`Hydrogen.wrapOutput`).toString()}
+        hydrogen-wrapOutput={(atom.config.get(
+          `Hydrogen.wrapOutput`
+        ): boolean).toString()}
       >
         <Display output={output} />
       </div>

--- a/lib/components/result-view/history.js
+++ b/lib/components/result-view/history.js
@@ -47,9 +47,9 @@ const History = observer(({ store }: { store: OutputStore }) => {
         style={{
           fontSize: atom.config.get(`Hydrogen.outputAreaFontSize`) || "inherit"
         }}
-        hydrogen-wrapOutput={((atom.config.get(
-          `Hydrogen.wrapOutput`
-        ): any): boolean).toString()}
+        hydrogen-wrapOutput={Boolean(
+          atom.config.get(`Hydrogen.wrapOutput`)
+        ).toString()}
       >
         <Display output={output} />
       </div>

--- a/lib/components/result-view/history.js
+++ b/lib/components/result-view/history.js
@@ -47,9 +47,7 @@ const History = observer(({ store }: { store: OutputStore }) => {
         style={{
           fontSize: atom.config.get(`Hydrogen.outputAreaFontSize`) || "inherit"
         }}
-        hydrogen-wrapOutput={Boolean(
-          atom.config.get(`Hydrogen.wrapOutput`)
-        ).toString()}
+        hydrogen-wrapOutput={atom.config.get(`Hydrogen.wrapOutput`).toString()}
       >
         <Display output={output} />
       </div>

--- a/lib/components/result-view/history.js
+++ b/lib/components/result-view/history.js
@@ -47,6 +47,7 @@ const History = observer(({ store }: { store: OutputStore }) => {
         style={{
           fontSize: atom.config.get(`Hydrogen.outputAreaFontSize`) || "inherit"
         }}
+        hydrogen-wrapOutput={atom.config.get(`Hydrogen.wrapOutput`).toString()}
       >
         <Display output={output} />
       </div>

--- a/lib/components/result-view/list.js
+++ b/lib/components/result-view/list.js
@@ -38,7 +38,9 @@ class ScrollList extends React.Component<Props> {
         ref={el => {
           this.el = el;
         }}
-        hydrogen-wrapOutput={atom.config.get(`Hydrogen.wrapOutput`).toString()}
+        hydrogen-wrapOutput={(atom.config.get(
+          `Hydrogen.wrapOutput`
+        ): boolean).toString()}
       >
         {this.props.outputs.map((output, index) => (
           <Display output={output} key={index} />

--- a/lib/components/result-view/list.js
+++ b/lib/components/result-view/list.js
@@ -38,9 +38,9 @@ class ScrollList extends React.Component<Props> {
         ref={el => {
           this.el = el;
         }}
-        hydrogen-wrapOutput={(atom.config.get(
+        hydrogen-wrapOutput={((atom.config.get(
           `Hydrogen.wrapOutput`
-        ): boolean).toString()}
+        ): any): boolean).toString()}
       >
         {this.props.outputs.map((output, index) => (
           <Display output={output} key={index} />

--- a/lib/components/result-view/list.js
+++ b/lib/components/result-view/list.js
@@ -38,6 +38,7 @@ class ScrollList extends React.Component<Props> {
         ref={el => {
           this.el = el;
         }}
+        hydrogen-wrapOutput={atom.config.get(`Hydrogen.wrapOutput`).toString()}
       >
         {this.props.outputs.map((output, index) => (
           <Display output={output} key={index} />

--- a/lib/components/result-view/list.js
+++ b/lib/components/result-view/list.js
@@ -38,9 +38,7 @@ class ScrollList extends React.Component<Props> {
         ref={el => {
           this.el = el;
         }}
-        hydrogen-wrapOutput={Boolean(
-          atom.config.get(`Hydrogen.wrapOutput`)
-        ).toString()}
+        hydrogen-wrapOutput={atom.config.get(`Hydrogen.wrapOutput`).toString()}
       >
         {this.props.outputs.map((output, index) => (
           <Display output={output} key={index} />

--- a/lib/components/result-view/list.js
+++ b/lib/components/result-view/list.js
@@ -38,9 +38,9 @@ class ScrollList extends React.Component<Props> {
         ref={el => {
           this.el = el;
         }}
-        hydrogen-wrapOutput={((atom.config.get(
-          `Hydrogen.wrapOutput`
-        ): any): boolean).toString()}
+        hydrogen-wrapOutput={Boolean(
+          atom.config.get(`Hydrogen.wrapOutput`)
+        ).toString()}
       >
         {this.props.outputs.map((output, index) => (
           <Display output={output} key={index} />

--- a/lib/components/result-view/result-view.js
+++ b/lib/components/result-view/result-view.js
@@ -157,9 +157,9 @@ class ResultViewComponent extends React.Component<Props> {
                 userSelect: "text"
               }
         }
-        hydrogen-wrapOutput={((atom.config.get(
-          `Hydrogen.wrapOutput`
-        ): any): boolean).toString()}
+        hydrogen-wrapOutput={Boolean(
+          atom.config.get(`Hydrogen.wrapOutput`)
+        ).toString()}
       >
         <div
           className="hydrogen_cell_display"

--- a/lib/components/result-view/result-view.js
+++ b/lib/components/result-view/result-view.js
@@ -157,9 +157,7 @@ class ResultViewComponent extends React.Component<Props> {
                 userSelect: "text"
               }
         }
-        hydrogen-wrapOutput={Boolean(
-          atom.config.get(`Hydrogen.wrapOutput`)
-        ).toString()}
+        hydrogen-wrapOutput={atom.config.get(`Hydrogen.wrapOutput`).toString()}
       >
         <div
           className="hydrogen_cell_display"

--- a/lib/components/result-view/result-view.js
+++ b/lib/components/result-view/result-view.js
@@ -157,7 +157,9 @@ class ResultViewComponent extends React.Component<Props> {
                 userSelect: "text"
               }
         }
-        hydrogen-wrapOutput={atom.config.get(`Hydrogen.wrapOutput`).toString()}
+        hydrogen-wrapOutput={(atom.config.get(
+          `Hydrogen.wrapOutput`
+        ): boolean).toString()}
       >
         <div
           className="hydrogen_cell_display"

--- a/lib/components/result-view/result-view.js
+++ b/lib/components/result-view/result-view.js
@@ -157,6 +157,7 @@ class ResultViewComponent extends React.Component<Props> {
                 userSelect: "text"
               }
         }
+        hydrogen-wrapOutput={atom.config.get(`Hydrogen.wrapOutput`).toString()}
       >
         <div
           className="hydrogen_cell_display"

--- a/lib/components/result-view/result-view.js
+++ b/lib/components/result-view/result-view.js
@@ -157,9 +157,9 @@ class ResultViewComponent extends React.Component<Props> {
                 userSelect: "text"
               }
         }
-        hydrogen-wrapOutput={(atom.config.get(
+        hydrogen-wrapOutput={((atom.config.get(
           `Hydrogen.wrapOutput`
-        ): boolean).toString()}
+        ): any): boolean).toString()}
       >
         <div
           className="hydrogen_cell_display"

--- a/lib/config.js
+++ b/lib/config.js
@@ -65,6 +65,15 @@ const Config = {
       default: true,
       order: 4
     },
+    wrapOutput: {
+      title: "Enable Soft Wrap for Output",
+      includeTitle: false,
+      description:
+        "If enabled, your output code from hydrogen will break long text and items.",
+      type: "boolean",
+      default: false,
+      order: 4.5
+    },
     outputAreaDefault: {
       title: "View output in the dock by default",
       description:

--- a/lib/config.js
+++ b/lib/config.js
@@ -69,7 +69,7 @@ const Config = {
       title: "Enable Soft Wrap for Output",
       includeTitle: false,
       description:
-        "If enabled, your output code from hydrogen will break long text and items.",
+        "If enabled, your output code from Hydrogen will break long text and items.",
       type: "boolean",
       default: false,
       order: 4.5

--- a/spec/components/result-view/history-spec.js
+++ b/spec/components/result-view/history-spec.js
@@ -6,6 +6,10 @@ import Enzyme, { shallow } from "enzyme";
 import History from "../../../lib/components/result-view/history";
 
 describe("History", () => {
+  beforeEach(() => {
+    atom.config.set(`Hydrogen.wrapOutput`, false);
+  });
+
   it("should render and display the current output", () => {
     const mockStore = {
       index: 0,

--- a/spec/components/result-view/result-view-spec.js
+++ b/spec/components/result-view/result-view-spec.js
@@ -6,6 +6,10 @@ import { shallow } from "enzyme";
 import ResultViewComponent from "../../../lib/components/result-view/result-view";
 
 describe("ResultViewComponent", () => {
+  beforeEach(() => {
+    atom.config.set(`Hydrogen.wrapOutput`, false);
+  });
+
   it("should render", () => {
     const mockStore = {
       index: 0,

--- a/styles/hydrogen.less
+++ b/styles/hydrogen.less
@@ -29,7 +29,7 @@ code, pre {
   font-size: inherit;
   font-family: inherit;
   padding: 0;
-  white-space: pre-wrap;
+  white-space: pre;
 }
 
 img {
@@ -111,6 +111,12 @@ svg:first-child {
 .multiline-container {
   display: flex;
   border: solid 1px @base-border-color;
+  &[hydrogen-wrapoutput="true"] {
+    code, pre {
+      white-space: pre-wrap;
+      word-wrap: break-word;
+    }
+  }
 }
 
 .multiline-container .hydrogen_cell_display {

--- a/types/atom.js.flow
+++ b/types/atom.js.flow
@@ -155,6 +155,9 @@ type atom$ConfigSchema = {
   ): IDisposable,
 
   // Managing Settings
+  // get method for special cases (@NOTE: This should be listed ABOVE the general case one)
+  get("Hydrogen.wrapOutput"): boolean,
+  // get method for general cases
   get(
     keyPath?: string,
     options?: {


### PR DESCRIPTION
Using html attributes and css, I enabled a way for us to configure css styles, while still having their rules be inside the stylesheet and be able to override.

The purpose of the added css is to revert behavior of #1594, and make word-breaking/wrapping a configurable option since #1569 was not actually a bug but a feature request.

Closes #1679 