### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: generic
-dist: trusty
-sudo: false
+
 notifications:
   email:
     on_success: never
@@ -14,3 +13,16 @@ env:
   matrix:
     - ATOM_CHANNEL=stable
     - ATOM_CHANNEL=beta
+
+dist: xenial
+
+addons:
+  apt:
+    packages:
+    - build-essential
+    - fakeroot
+    - git
+    - libsecret-1-dev
+    - libgconf2-4 # TODO: Remove once Atom v1.39 is stable
+
+sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: generic
 
-notifications:
-  email:
-    on_success: never
-    on_failure: change
+env:
+  matrix:
+    - ATOM_CHANNEL=stable
+    - ATOM_CHANNEL=beta
 
 script:
   - curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
@@ -11,13 +11,8 @@ script:
   - ./build-package.sh
   - npm run flow
 
-env:
-  matrix:
-    - ATOM_CHANNEL=stable
-    - ATOM_CHANNEL=beta
-
+sudo: false
 dist: xenial
-
 addons:
   apt:
     packages:
@@ -25,6 +20,12 @@ addons:
     - fakeroot
     - git
     - libsecret-1-dev
-    - libgconf2-4 # TODO: Remove once Atom v1.39 is stable
+    - libgconf2-4 # @TODO: Remove once Atom v1.39 is stable
 
-sudo: false
+git:
+  depth: 10
+
+notifications:
+  email:
+    on_success: never
+    on_failure: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@ notifications:
     on_failure: change
 
 script:
-  - curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh
+  - curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
+  - chmod u+x build-package.sh
+  - ./build-package.sh
   - npm run flow
 
 env:


### PR DESCRIPTION
### Purpose

Fixes the failure of builds in CI.

- [x] Add `addons` and use the `xenial` image

### Misc

- [x] Split `script` to prevent it from being streamed from the remote server
- ~~[ ] Run only on `master` branch to prevent double builds on PRs~~ We basically only use `master` branch thus never mind
- ~~[ ] Split project-specific config vs. general setups~~ Out travis config is so simple and no need to do this

### References

- https://github.com/atom/ci/issues/90
- https://github.com/atom/wrap-guide/pull/84
