### PR TITLE
Improve Plotly Support

### DIFF
--- a/lib/components/result-view/display.js
+++ b/lib/components/result-view/display.js
@@ -22,7 +22,7 @@ export const supportedMediaTypes = (
   <RichMedia>
     <Vega3 />
     <Vega2 />
-    <Plotly />
+    <Plotly data="" />
     <VegaLite2 />
     <VegaLite1 />
     <Media.Json />

--- a/lib/components/result-view/display.js
+++ b/lib/components/result-view/display.js
@@ -12,7 +12,7 @@ import {
   Media,
   RichMedia
 } from "@nteract/outputs";
-import PlotlyTransform from "@nteract/transform-plotly";
+import Plotly from "./plotly";
 import { VegaLite1, VegaLite2, Vega2, Vega3 } from "@nteract/transform-vega";
 
 import Markdown from "./markdown";
@@ -22,7 +22,7 @@ export const supportedMediaTypes = (
   <RichMedia>
     <Vega3 />
     <Vega2 />
-    <PlotlyTransform />
+    <Plotly />
     <VegaLite2 />
     <VegaLite1 />
     <Media.Json />

--- a/lib/components/result-view/display.js
+++ b/lib/components/result-view/display.js
@@ -22,7 +22,7 @@ export const supportedMediaTypes = (
   <RichMedia>
     <Vega3 />
     <Vega2 />
-    <Plotly data="" />
+    <Plotly />
     <VegaLite2 />
     <VegaLite1 />
     <Media.Json />

--- a/lib/components/result-view/plotly.js
+++ b/lib/components/result-view/plotly.js
@@ -38,12 +38,6 @@ declare class PlotlyHTMLElement extends HTMLDivElement {
   redraw: () => void;
 }
 
-/*
- * As part of the init notebook mode, Plotly sneaks a <script> tag in to load
- * the plotlyjs lib. We have already loaded this though, so we "handle" the
- * transform by doing nothing and returning null.
- */
-
 export class PlotlyTransform extends React.Component<Props> {
   static defaultProps = {
     data: "",

--- a/lib/components/result-view/plotly.js
+++ b/lib/components/result-view/plotly.js
@@ -1,0 +1,148 @@
+/* @flow */
+/**
+ * Adapted from https://github.com/nteract/nteract/blob/master/packages/transform-plotly/src/index.tsx
+ * Copyright (c) 2016 - present, nteract contributors
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ *
+ * @NOTE: This `PlotlyTransform` component could be used exactly same as the original `PlotlyTransform` component of @nteract/transform-plotly,
+ *        except that this file adds the ability to download a plot from an electron context.
+ */
+
+import { cloneDeep } from "lodash";
+import React from "react";
+
+interface Props {
+  data: string | object;
+  mediaType: "application/vnd.plotly.v1+json";
+}
+
+type ObjectType = object;
+
+interface FigureLayout extends ObjectType {
+  height?: string;
+  autosize?: boolean;
+}
+
+interface Figure extends ObjectType {
+  data: object;
+  layout: FigureLayout;
+}
+
+class PlotlyHTMLElement extends HTMLDivElement {
+  data: object;
+  layout: object;
+  newPlot: () => void;
+  redraw: () => void;
+}
+
+const NULL_MIMETYPE = "text/vnd.plotly.v1+html";
+const MIMETYPE = "application/vnd.plotly.v1+json";
+
+/*
+ * As part of the init notebook mode, Plotly sneaks a <script> tag in to load
+ * the plotlyjs lib. We have already loaded this though, so we "handle" the
+ * transform by doing nothing and returning null.
+ */
+const PlotlyNullTransform = () => null;
+PlotlyNullTransform.MIMETYPE = NULL_MIMETYPE;
+PlotlyNullTransform.defaultProps = {
+  mediaType: NULL_MIMETYPE
+};
+
+export class PlotlyTransform extends React.Component<Props> {
+  static MIMETYPE = MIMETYPE;
+
+  static defaultProps = {
+    mediaType: MIMETYPE
+  };
+
+  plotDiv: PlotlyHTMLElement | null;
+  Plotly: {
+    newPlot: (
+      div: PlotlyHTMLElement | null | undefined,
+      data: object,
+      layout: FigureLayout
+    ) => void,
+    redraw: (div?: PlotlyHTMLElement) => void
+  };
+
+  constructor(props) {
+    super(props);
+    this.downloadImage = this.downloadImage.bind(this);
+  }
+
+  componentDidMount(): void {
+    // Handle case of either string to be `JSON.parse`d or pure object
+    const figure = this.getFigure();
+    this.Plotly = require("@nteract/plotly");
+    this.Plotly.newPlot(this.plotDiv, figure.data, figure.layout, {
+      modeBarButtonsToRemove: ["toImage"],
+      modeBarButtonsToAdd: [
+        {
+          name: "Download plot as a png",
+          icon: this.Plotly.Icons.camera,
+          click: this.downloadImage
+        }
+      ]
+    });
+  }
+
+  shouldComponentUpdate(nextProps: Props): boolean {
+    return this.props.data !== nextProps.data;
+  }
+
+  componentDidUpdate() {
+    const figure = this.getFigure();
+    if (!this.plotDiv) {
+      return;
+    }
+    this.plotDiv.data = figure.data;
+    this.plotDiv.layout = figure.layout;
+    this.Plotly.redraw(this.plotDiv);
+  }
+
+  plotDivRef = (plotDiv: PlotlyHTMLElement | null): void => {
+    this.plotDiv = plotDiv;
+  };
+
+  getFigure = (): Figure => {
+    const figure = this.props.data;
+    if (typeof figure === "string") {
+      return JSON.parse(figure);
+    }
+
+    // The Plotly API *mutates* the figure to include a UID, which means
+    // they won't take our frozen objects
+    if (Object.isFrozen(figure)) {
+      return cloneDeep(figure);
+    }
+
+    const { data = {}, layout = {} } = figure;
+
+    return { data, layout };
+  };
+
+  downloadImage(gd) {
+    this.Plotly.toImage(gd).then(function(dataUrl) {
+      const electron = require("electron");
+      electron.remote.getCurrentWebContents().downloadURL(dataUrl);
+    });
+  }
+
+  render() {
+    const { layout } = this.getFigure();
+    const style: React.CSSProperties = {
+      width: "100%"
+    };
+    if (layout && layout.height && !layout.autosize) {
+      style.height = layout.height;
+    }
+    return <div ref={this.plotDivRef} style={style} />;
+  }
+}
+
+export { PlotlyNullTransform };
+export default PlotlyTransform;

--- a/lib/components/result-view/plotly.js
+++ b/lib/components/result-view/plotly.js
@@ -12,14 +12,14 @@
  */
 
 import { cloneDeep } from "lodash";
-import React from "react";
+import * as React from "react";
 
 interface Props {
-  data: string | object;
+  data: string | Object;
   mediaType: "application/vnd.plotly.v1+json";
 }
 
-type ObjectType = object;
+type ObjectType = Object;
 
 interface FigureLayout extends ObjectType {
   height?: string;
@@ -27,13 +27,13 @@ interface FigureLayout extends ObjectType {
 }
 
 interface Figure extends ObjectType {
-  data: object;
+  data: Object;
   layout: FigureLayout;
 }
 
 class PlotlyHTMLElement extends HTMLDivElement {
-  data: object;
-  layout: object;
+  data: Object;
+  layout: Object;
   newPlot: () => void;
   redraw: () => void;
 }
@@ -62,14 +62,15 @@ export class PlotlyTransform extends React.Component<Props> {
   plotDiv: PlotlyHTMLElement | null;
   Plotly: {
     newPlot: (
-      div: PlotlyHTMLElement | null | undefined,
-      data: object,
+      div: PlotlyHTMLElement | null | void,
+      data: Object,
       layout: FigureLayout
     ) => void,
-    redraw: (div?: PlotlyHTMLElement) => void
+    redraw: (div?: PlotlyHTMLElement) => void,
+    toImage: (gd: any) => Promise<string>
   };
 
-  constructor(props) {
+  constructor(props: Props) {
     super(props);
     this.downloadImage = this.downloadImage.bind(this);
   }
@@ -125,18 +126,16 @@ export class PlotlyTransform extends React.Component<Props> {
     return { data, layout };
   };
 
-  downloadImage(gd) {
+  downloadImage = (gd: any) => {
     this.Plotly.toImage(gd).then(function(dataUrl) {
       const electron = require("electron");
       electron.remote.getCurrentWebContents().downloadURL(dataUrl);
     });
-  }
+  };
 
   render() {
     const { layout } = this.getFigure();
-    const style: React.CSSProperties = {
-      width: "100%"
-    };
+    const style: Object = {};
     if (layout && layout.height && !layout.autosize) {
       style.height = layout.height;
     }

--- a/lib/components/result-view/plotly.js
+++ b/lib/components/result-view/plotly.js
@@ -38,26 +38,16 @@ declare class PlotlyHTMLElement extends HTMLDivElement {
   redraw: () => void;
 }
 
-const NULL_MIMETYPE = "text/vnd.plotly.v1+html";
-const MIMETYPE = "application/vnd.plotly.v1+json";
-
 /*
  * As part of the init notebook mode, Plotly sneaks a <script> tag in to load
  * the plotlyjs lib. We have already loaded this though, so we "handle" the
  * transform by doing nothing and returning null.
  */
-const PlotlyNullTransform = () => null;
-PlotlyNullTransform.MIMETYPE = NULL_MIMETYPE;
-PlotlyNullTransform.defaultProps = {
-  mediaType: NULL_MIMETYPE
-};
 
 export class PlotlyTransform extends React.Component<Props> {
-  static MIMETYPE = MIMETYPE;
-
   static defaultProps = {
     data: "",
-    mediaType: MIMETYPE
+    mediaType: "application/vnd.plotly.v1+json"
   };
 
   plotDiv: HTMLDivElement | null;
@@ -145,5 +135,4 @@ export class PlotlyTransform extends React.Component<Props> {
   }
 }
 
-export { PlotlyNullTransform };
 export default PlotlyTransform;

--- a/lib/components/result-view/plotly.js
+++ b/lib/components/result-view/plotly.js
@@ -31,7 +31,7 @@ interface Figure extends ObjectType {
   layout: FigureLayout;
 }
 
-class PlotlyHTMLElement extends HTMLDivElement {
+declare class PlotlyHTMLElement extends HTMLDivElement {
   data: Object;
   layout: Object;
   newPlot: () => void;
@@ -59,10 +59,10 @@ export class PlotlyTransform extends React.Component<Props> {
     mediaType: MIMETYPE
   };
 
-  plotDiv: PlotlyHTMLElement | null;
+  plotDiv: HTMLDivElement | null;
   Plotly: {
     newPlot: (
-      div: PlotlyHTMLElement | null | void,
+      div: HTMLDivElement | null | void,
       data: Object,
       layout: FigureLayout
     ) => void,
@@ -100,12 +100,13 @@ export class PlotlyTransform extends React.Component<Props> {
     if (!this.plotDiv) {
       return;
     }
-    this.plotDiv.data = figure.data;
-    this.plotDiv.layout = figure.layout;
-    this.Plotly.redraw(this.plotDiv);
+    const plotDiv: PlotlyHTMLElement = (this.plotDiv: any);
+    plotDiv.data = figure.data;
+    plotDiv.layout = figure.layout;
+    this.Plotly.redraw(plotDiv);
   }
 
-  plotDivRef = (plotDiv: PlotlyHTMLElement | null): void => {
+  plotDivRef = (plotDiv: HTMLDivElement | null): void => {
     this.plotDiv = plotDiv;
   };
 

--- a/lib/components/result-view/plotly.js
+++ b/lib/components/result-view/plotly.js
@@ -56,6 +56,7 @@ export class PlotlyTransform extends React.Component<Props> {
   static MIMETYPE = MIMETYPE;
 
   static defaultProps = {
+    data: "",
     mediaType: MIMETYPE
   };
 

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@nteract/markdown": "^4.0.0",
     "@nteract/mathjax": "^4.0.0",
     "@nteract/outputs": "^2.1.5",
-    "@nteract/transform-plotly": "^5.0.0",
+    "@nteract/plotly": "^1.48.3",
     "@nteract/transform-vega": "^5.0.2",
     "anser": "^1.4.4",
     "atom-select-list": "^0.7.0",

--- a/spec/components/result-view/plotly-spec.js
+++ b/spec/components/result-view/plotly-spec.js
@@ -1,0 +1,123 @@
+"use babel";
+
+import { mount } from "enzyme";
+import _ from "lodash";
+import React from "react";
+
+import PlotlyTransform from "../../../lib/components/result-view/plotly";
+
+import plotly from "@nteract/plotly";
+
+function deepFreeze(obj) {
+  // Retrieve the property names defined on obj
+  const propNames = Object.getOwnPropertyNames(obj);
+
+  // Freeze properties before freezing self
+  propNames.forEach(name => {
+    const prop = obj[name];
+
+    // Freeze prop if it is an object
+    if (typeof prop === "object" && prop !== null) {
+      deepFreeze(prop);
+    }
+  });
+
+  // Freeze self (no-op if already frozen)
+  return Object.freeze(obj);
+}
+
+const figure = deepFreeze({
+  data: [
+    { x: [1999, 2000, 2001, 2002], y: [10, 15, 13, 17], type: "scatter" },
+    { x: [1999, 2000, 2001, 2002], y: [16, 5, 11, 9], type: "scatter" }
+  ],
+  layout: {
+    title: "Super Stuff",
+    xaxis: { title: "Year", showgrid: false, zeroline: false },
+    yaxis: { title: "Percent", showline: false },
+    height: "100px"
+  }
+});
+
+describe("PlotlyTransform", () => {
+  it("plots some data from an object", () => {
+    spyOn(plotly, "newPlot");
+    const plotComponent = mount(<PlotlyTransform data={figure} />);
+
+    const instance = plotComponent.instance();
+
+    expect(instance.shouldComponentUpdate({ data: "" })).toBeTruthy();
+    expect(plotly.newPlot).toHaveBeenCalledWith(
+      instance.plotDiv,
+      [
+        { x: [1999, 2000, 2001, 2002], y: [10, 15, 13, 17], type: "scatter" },
+        { x: [1999, 2000, 2001, 2002], y: [16, 5, 11, 9], type: "scatter" }
+      ],
+      {
+        title: "Super Stuff",
+        xaxis: { title: "Year", showgrid: false, zeroline: false },
+        yaxis: { title: "Percent", showline: false },
+        height: "100px"
+      },
+      {
+        modeBarButtonsToRemove: ["toImage"],
+        modeBarButtonsToAdd: [
+          {
+            name: "Download plot as a png",
+            icon: plotly.Icons.camera,
+            click: instance.downloadImage
+          }
+        ]
+      }
+    );
+  });
+
+  it("plots some data from a JSON string", () => {
+    spyOn(plotly, "newPlot");
+    const plotComponent = mount(
+      <PlotlyTransform data={JSON.stringify(figure)} />
+    );
+
+    const instance = plotComponent.instance();
+
+    expect(instance.shouldComponentUpdate({ data: "" })).toBeTruthy();
+    expect(plotly.newPlot).toHaveBeenCalledWith(
+      instance.plotDiv,
+      [
+        { x: [1999, 2000, 2001, 2002], y: [10, 15, 13, 17], type: "scatter" },
+        { x: [1999, 2000, 2001, 2002], y: [16, 5, 11, 9], type: "scatter" }
+      ],
+      {
+        title: "Super Stuff",
+        xaxis: { title: "Year", showgrid: false, zeroline: false },
+        yaxis: { title: "Percent", showline: false },
+        height: "100px"
+      },
+      {
+        modeBarButtonsToRemove: ["toImage"],
+        modeBarButtonsToAdd: [
+          {
+            name: "Download plot as a png",
+            icon: plotly.Icons.camera,
+            click: instance.downloadImage
+          }
+        ]
+      }
+    );
+  });
+
+  it("processes updates", () => {
+    spyOn(plotly, "redraw");
+    const wrapper = mount(<PlotlyTransform data={figure} />);
+
+    const instance = wrapper.instance();
+
+    wrapper.setProps({
+      data: _.set(_.cloneDeep(figure), ["data", 0, "type"], "bar")
+    });
+
+    expect(instance.plotDiv.data[0].type).toEqual("bar");
+
+    expect(plotly.redraw).toHaveBeenCalledWith(instance.plotDiv);
+  });
+});

--- a/styles/hydrogen.less
+++ b/styles/hydrogen.less
@@ -248,6 +248,11 @@ svg:first-child {
     }
   }
 
+  .plot-container.plotly svg {
+    width: inherit !important;
+    height: inherit !important;
+  }
+
   video, img, svg {
     width: unset !important;
     height: unset !important;


### PR DESCRIPTION
# 🌟 Improve Plotly Support 
*This pull request contains modified code from @nteract/transform-plotly*

### Fixes:
- `Download plot as png` button was previously broken only inside an atom context, so using built-in electron functions it has been refactored to work. See #1653.
- While on our master branch, using simple plotly code (example from nteract.io), and output directed to the output pane, the plotly would only render a quarter of itself. This adds styling to override that behavior.

### To-Do:
- [x] test cases modified from @nteract/transform-plotly.

### Incompatible PRs:
- #1699 
---
Closes #1653