### PR TITLE
Fix #1564

### DIFF
--- a/lib/zmq-kernel.js
+++ b/lib/zmq-kernel.js
@@ -162,7 +162,7 @@ export default class ZMQKernel extends KernelTransport {
     let startupCode = Config.getJson("startupCode")[displayName];
     if (startupCode) {
       log("KernelManager: Executing startup code:", startupCode);
-      startupCode = `${startupCode} \n`;
+      startupCode += "\n";
       this.execute(startupCode, (message, channel) => {});
     }
   }


### PR DESCRIPTION
I am not to sure why, but for some reason using a template literal doesn't allow for 2 magic commands to be used in the start up config. I am not even sure there is a benefit to using a template literal, but using a primitive seems to fix the ending comments and issue of #1564. 
The only reason I realized in was the template literally is because of one of our log functions inside `zmq-kernel execute` was surrounding startup code with quotation, but not inline code that worked.

Authors of the commit were @rgbkrk and @lgeiger, so maybe if the peek over they could provide some insight.

- Closes #1564 