### PR TITLE
Enhance autocomplete

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -23,13 +23,12 @@ const Config = {
       default: true,
       order: 0
     },
-    showAutocompleteFirst: {
-      title: "Show Hydrogen's autocomplete suggestions first",
-      includeTitle: false,
+    autocompleteSuggestionPriority: {
+      title: "Autocomple Suggestion Priority",
       description:
-        "If enabled, Hydrogen's autocomplete suggestions will be listed before those of other providers, like snippets.",
-      type: "boolean",
-      default: true,
+        "Specify the sort order of Hydrogen's autocomplete suggestions.\nNote the default providers like snippets have priority of 1.",
+      type: "integer",
+      default: 3,
       order: 1
     },
     importNotebookURI: {

--- a/lib/config.js
+++ b/lib/config.js
@@ -32,9 +32,9 @@ const Config = {
       order: 1
     },
     showInspectorResultsInAutocomplete: {
-      title: "Enable Autocomplete description",
+      title: "Enable Autocomplete description (Experimental)",
       description:
-        "If enabled, Hydrogen will try to show [the results from kernel inspection](https://nteract.gitbooks.io/hydrogen/docs/Usage/GettingStarted.html#hydrogen-toggle-inspector) in each autocomplete suggestion's description. May slow down the autocompletion performance.",
+        "If enabled, Hydrogen will try to show [the results from kernel inspection](https://nteract.gitbooks.io/hydrogen/docs/Usage/GettingStarted.html#hydrogen-toggle-inspector) in each autocomplete suggestion's description. May slow down the autocompletion performance. (Note: Even if you disable this, you would still get autocomplete suggestions.)",
       type: "boolean",
       default: true,
       order: 2

--- a/lib/config.js
+++ b/lib/config.js
@@ -31,13 +31,21 @@ const Config = {
       default: 3,
       order: 1
     },
+    showInspectorResultsInAutocomplete: {
+      title: "Enable Autocomplete description",
+      description:
+        "If enabled, Hydrogen will try to show [the results from kernel inspection](https://nteract.gitbooks.io/hydrogen/docs/Usage/GettingStarted.html#hydrogen-toggle-inspector) in each autocomplete suggestion's description. May slow down the autocompletion performance.",
+      type: "boolean",
+      default: true,
+      order: 2
+    },
     importNotebookURI: {
       title: "Enable Notebook Auto-import",
       description:
         "If enabled, opening a file with extension `.ipynb` will [import the notebook](https://nteract.gitbooks.io/hydrogen/docs/Usage/NotebookFiles.html#notebook-import) file's source into a new tab. If disabled, or if the Hydrogen package is not activated, the raw file will open in Atom as normal.",
       type: "boolean",
       default: true,
-      order: 1.5
+      order: 3
     },
     statusBarDisable: {
       title: "Disable the Hydrogen status bar",
@@ -45,7 +53,7 @@ const Config = {
         "If enabled, no kernel information will be provided in Atom's status bar.",
       type: "boolean",
       default: false,
-      order: 2
+      order: 4
     },
     debug: {
       title: "Enable Debug Messages",
@@ -53,7 +61,7 @@ const Config = {
       description: "If enabled, log debug messages onto the dev console.",
       type: "boolean",
       default: false,
-      order: 3
+      order: 5
     },
     autoScroll: {
       title: "Enable Autoscroll",
@@ -62,7 +70,7 @@ const Config = {
         "If enabled, Hydrogen will automatically scroll to the bottom of the result view.",
       type: "boolean",
       default: true,
-      order: 4
+      order: 6
     },
     wrapOutput: {
       title: "Enable Soft Wrap for Output",
@@ -71,7 +79,7 @@ const Config = {
         "If enabled, your output code from Hydrogen will break long text and items.",
       type: "boolean",
       default: false,
-      order: 4.5
+      order: 7
     },
     outputAreaDefault: {
       title: "View output in the dock by default",
@@ -79,7 +87,7 @@ const Config = {
         "If enabled, output will be displayed in the dock by default rather than inline",
       type: "boolean",
       default: false,
-      order: 5
+      order: 8
     },
     outputAreaDock: {
       title: "Leave output dock open",
@@ -87,7 +95,7 @@ const Config = {
         "Do not close dock when switching to an editor without a running kernel",
       type: "boolean",
       default: false,
-      order: 6
+      order: 9
     },
     outputAreaFontSize: {
       title: "Output area fontsize",
@@ -96,7 +104,7 @@ const Config = {
       type: "integer",
       minimum: 0,
       default: 0,
-      order: 7
+      order: 10
     },
     globalMode: {
       title: "Enable Global Kernel",
@@ -104,7 +112,7 @@ const Config = {
         "If enabled, all files of the same grammar will share a single global kernel (requires Atom restart)",
       type: "boolean",
       default: false,
-      order: 8
+      order: 11
     },
     kernelNotifications: {
       title: "Enable Kernel Notifications",
@@ -113,7 +121,7 @@ const Config = {
         "Notify if kernels writes to stdout. By default, kernel notifications are only displayed in the developer console.",
       type: "boolean",
       default: false,
-      order: 9
+      order: 12
     },
     startDir: {
       title: "Directory to start kernel in",
@@ -135,7 +143,7 @@ const Config = {
         }
       ],
       default: "firstProjectDir",
-      order: 10
+      order: 13
     },
     languageMappings: {
       title: "Language Mappings",
@@ -144,7 +152,7 @@ const Config = {
         'Custom Atom grammars and some kernels use non-standard language names. That leaves Hydrogen unable to figure out what kernel to start for your code. This field should be a valid JSON mapping from a kernel language name to Atom\'s grammar name ``` { "kernel name": "grammar name" } ```. For example ``` { "scala211": "scala", "javascript": "babel es6 javascript", "python": "magicpython" } ```.',
       type: "string",
       default: '{ "python": "magicpython" }',
-      order: 11
+      order: 14
     },
     startupCode: {
       title: "Startup Code",
@@ -153,7 +161,7 @@ const Config = {
         'This code will be executed on kernel startup. Format: `{"kernel": "your code \\nmore code"}`. Example: `{"Python 2": "%matplotlib inline"}`',
       type: "string",
       default: "{}",
-      order: 12
+      order: 15
     },
     gateways: {
       title: "Kernel Gateways",
@@ -162,7 +170,7 @@ const Config = {
         'Hydrogen can connect to remote notebook servers and kernel gateways. Each gateway needs at minimum a name and a value for options.baseUrl. The options are passed directly to the `jupyter-js-services` npm package, which includes documentation for additional fields. Example value: ``` [{ "name": "Remote notebook", "options": { "baseUrl": "http://mysite.com:8888" } }] ```',
       type: "string",
       default: "[]",
-      order: 13
+      order: 16
     }
   }
 };

--- a/lib/services/provided/autocomplete.js
+++ b/lib/services/provided/autocomplete.js
@@ -1,6 +1,8 @@
 /* @flow */
 
 import _ from "lodash";
+import { ansiToText } from "anser";
+
 import { log, char_idx_to_js_idx } from "../../utils";
 import type { Store } from "../../store";
 
@@ -12,7 +14,7 @@ type CompleteReply = {
     _jupyter_types_experimental?: Array<{
       start?: number,
       end?: number,
-      text?: string,
+      text: string,
       type?: string
     }>
   }
@@ -46,10 +48,15 @@ function parseCompletions(results: CompleteReply, prefix: string) {
           match.start && match.end
             ? prefix.slice(match.start, match.end)
             : prefix.slice(cursor_start, cursor_end);
+        const replacedText =
+          (match.start && match.end
+            ? prefix.slice(0, match.start)
+            : prefix.slice(0, cursor_start)) + text;
         const type = match.type;
         return {
           text,
           replacementPrefix,
+          replacedText,
           iconHTML: !type || type === "<unknown>" ? iconHTML : undefined,
           type
         };
@@ -59,11 +66,16 @@ function parseCompletions(results: CompleteReply, prefix: string) {
 
   const replacementPrefix = prefix.slice(cursor_start, cursor_end);
 
-  return _.map(matches, match => ({
-    text: match,
-    replacementPrefix,
-    iconHTML
-  }));
+  return _.map(matches, match => {
+    const text = match;
+    const replacedText = prefix.slice(0, cursor_start) + text;
+    return {
+      text,
+      replacementPrefix,
+      replacedText,
+      iconHTML
+    };
+  });
 }
 
 export function provideAutocompleteResults(
@@ -131,6 +143,34 @@ export function provideAutocompleteResults(
           return resolve(parseCompletions(results, prefix));
         })
       );
+    },
+
+    getSuggestionDetailsOnSelect({
+      text,
+      replacementPrefix,
+      replacedText,
+      iconHTML,
+      type
+    }) {
+      if (!atom.config.get("Hydrogen.showInspectorResultInAutocomplete"))
+        return null;
+
+      const kernel = store.kernel;
+      if (!kernel || kernel.executionState !== "idle") return null;
+
+      return new Promise(resolve => {
+        kernel.inspect(replacedText, replacedText.length, ({ data, found }) => {
+          if (!found || !data["text/plain"]) resolve(null);
+          resolve({
+            text,
+            replacementPrefix,
+            replacedText,
+            iconHTML,
+            type,
+            description: ansiToText(data["text/plain"])
+          });
+        });
+      });
     }
   };
 

--- a/lib/services/provided/autocomplete.js
+++ b/lib/services/provided/autocomplete.js
@@ -39,19 +39,21 @@ function parseCompletions(results: CompleteReply, prefix: string) {
 
   if (metadata && metadata._jupyter_types_experimental) {
     const comps = metadata._jupyter_types_experimental;
-    if (
-      comps.length > 0 &&
-      comps[0].text != null &&
-      comps[0].start != null &&
-      comps[0].end != null
-    ) {
-      return _.map(comps, match => ({
-        text: match.text,
-        replacementPrefix: prefix.slice(match.start, match.end),
-        type: match.type,
-        iconHTML:
-          !match.type || match.type === "<unknown>" ? iconHTML : undefined
-      }));
+    if (comps.length > 0 && comps[0].text) {
+      return _.map(comps, match => {
+        const text = match.text;
+        const replacementPrefix =
+          match.start && match.end
+            ? prefix.slice(match.start, match.end)
+            : prefix.slice(cursor_start, cursor_end);
+        const type = match.type;
+        return {
+          text,
+          replacementPrefix,
+          iconHTML: !type || type === "<unknown>" ? iconHTML : undefined,
+          type
+        };
+      });
     }
   }
 

--- a/lib/services/provided/autocomplete.js
+++ b/lib/services/provided/autocomplete.js
@@ -44,14 +44,10 @@ function parseCompletions(results: CompleteReply, prefix: string) {
     if (comps.length > 0 && comps[0].text) {
       return _.map(comps, match => {
         const text = match.text;
-        const replacementPrefix =
-          match.start && match.end
-            ? prefix.slice(match.start, match.end)
-            : prefix.slice(cursor_start, cursor_end);
-        const replacedText =
-          (match.start && match.end
-            ? prefix.slice(0, match.start)
-            : prefix.slice(0, cursor_start)) + text;
+        const start = match.start && match.end ? match.start : cursor_start;
+        const end = match.start && match.end ? match.end : cursor_end;
+        const replacementPrefix = prefix.slice(start, end);
+        const replacedText = prefix.slice(0, start) + text;
         const type = match.type;
         return {
           text,

--- a/lib/services/provided/autocomplete.js
+++ b/lib/services/provided/autocomplete.js
@@ -93,20 +93,15 @@ export function provideAutocompleteResults(
       return atom.config.get("Hydrogen.autocompleteSuggestionPriority");
     },
 
-    // if `false`, it won't suppress providers with lower priority.
+    // It won't suppress providers with lower priority.
     excludeLowerPriority: false,
 
     // Required: Return a promise, an array of suggestions, or null.
     getSuggestions({ editor, bufferPosition, prefix }) {
-      if (!atom.config.get("Hydrogen.autocomplete") === true) {
-        return null;
-      }
+      if (!atom.config.get("Hydrogen.autocomplete")) return null;
 
       const kernel = store.kernel;
-
-      if (!kernel || kernel.executionState !== "idle") {
-        return null;
-      }
+      if (!kernel || kernel.executionState !== "idle") return null;
 
       const line = editor.getTextInBufferRange([
         [bufferPosition.row, 0],
@@ -121,9 +116,7 @@ export function provideAutocompleteResults(
       }
 
       // return if cursor is at whitespace
-      if (prefix.trimRight().length < prefix.length) {
-        return null;
-      }
+      if (prefix.trimRight().length < prefix.length) return null;
 
       let minimumWordLength = atom.config.get(
         "autocomplete-plus.minimumWordLength"
@@ -132,9 +125,7 @@ export function provideAutocompleteResults(
         minimumWordLength = 3;
       }
 
-      if (prefix.trim().length < minimumWordLength) {
-        return null;
-      }
+      if (prefix.trim().length < minimumWordLength) return null;
 
       log("autocompleteProvider: request:", line, bufferPosition, prefix);
 

--- a/lib/services/provided/autocomplete.js
+++ b/lib/services/provided/autocomplete.js
@@ -143,7 +143,7 @@ export function provideAutocompleteResults(
       iconHTML,
       type
     }) {
-      if (!atom.config.get("Hydrogen.showInspectorResultInAutocomplete"))
+      if (!atom.config.get("Hydrogen.showInspectorResultsInAutocomplete"))
         return null;
 
       const kernel = store.kernel;

--- a/lib/services/provided/autocomplete.js
+++ b/lib/services/provided/autocomplete.js
@@ -78,7 +78,7 @@ export function provideAutocompleteResults(
 
     // The default provider has a suggestion priority of 1.
     get suggestionPriority() {
-      return atom.config.get("Hydrogen.showAutocompleteFirst") ? 3 : 1;
+      return atom.config.get("Hydrogen.autocompleteSuggestionPriority");
     },
 
     // if `false`, it won't suppress providers with lower priority.

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@nteract/outputs": "^2.1.5",
     "@nteract/plotly": "^1.48.3",
     "@nteract/transform-vega": "^5.0.2",
-    "anser": "^1.4.4",
+    "anser": "^1.4.8",
     "atom-select-list": "^0.7.0",
     "escape-carriage": "^1.2.0",
     "escape-string-regexp": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
   "providedServices": {
     "autocomplete.provider": {
       "versions": {
-        "2.0.0": "provideAutocompleteResults"
+        "4.0.0": "provideAutocompleteResults"
       }
     },
     "hydrogen.provider": {

--- a/styles/hydrogen.less
+++ b/styles/hydrogen.less
@@ -355,6 +355,15 @@ svg:first-child {
   }
 }
 
+// -------------- Autocomplete-Plus inside Watches -----------------
+
+.autocomplete-plus {
+  img {
+    display: inline;
+    background-color: transparent;
+  }
+}
+
 // -------------- Input view -----------------
 
 .hydrogen.input-view {
@@ -380,11 +389,8 @@ svg:first-child {
 
 // -------------- Overwrite Autocomplete-Plus style -----------------
 
+// @NOTE: This would pollute global style and could cause some styling issues for users
 .autocomplete-plus {
-  img {
-    display: inline;
-    background-color: transparent;
-  }
   autocomplete-suggestion-list.select-list.popover-list .suggestion-description {
     max-width: 500px;
   }

--- a/styles/hydrogen.less
+++ b/styles/hydrogen.less
@@ -355,14 +355,7 @@ svg:first-child {
   }
 }
 
-// -------------- Autocomplete Inside Watches -----------------
-
-  .autocomplete-plus img {
-    display: inline;
-    background-color: transparent;
-  }
-
-}
+// -------------- Input view -----------------
 
 .hydrogen.input-view {
   .label {
@@ -380,5 +373,19 @@ svg:first-child {
 
   span[style] {
     color: @text-color-info !important;
+  }
+}
+
+}
+
+// -------------- Overwrite Autocomplete-Plus style -----------------
+
+.autocomplete-plus {
+  img {
+    display: inline;
+    background-color: transparent;
+  }
+  autocomplete-suggestion-list.select-list.popover-list .suggestion-description {
+    max-width: 500px;
   }
 }

--- a/types/atom.js.flow
+++ b/types/atom.js.flow
@@ -156,6 +156,7 @@ type atom$ConfigSchema = {
 
   // Managing Settings
   // get method for special cases (@NOTE: This should be listed ABOVE the general case one)
+  get("Hydrogen.autocompleteSuggestionPriority"): number,
   get("Hydrogen.wrapOutput"): boolean,
   // get method for general cases
   get(

--- a/types/autocomplete.js.flow
+++ b/types/autocomplete.js.flow
@@ -1,21 +1,22 @@
 /* @flow */
 
-// One of text or snippet is required.
-// TODO(hansonw): use a union + intersection type
 type atom$AutocompleteSuggestion = {
-  text?: string,
-  snippet?: string,
+  // @NOTE: One of `text` or `snippet` is required.
+  text: string,
+  // snippet: string,
+  replacementPrefix: string,
+  // @NOTE: Only needed for Hydrogen implementation of `getSuggestionDetailsOnSelect`
+  replacedText: string,
+  iconHTML?: string,
+  type?: string,
+  description?: string,
+  descriptionMoreURL?: string,
   displayText?: string,
-  replacementPrefix?: string,
-  type?: ?string,
-  leftLabel?: ?string,
-  leftLabelHTML?: ?string,
-  rightLabel?: ?string,
-  rightLabelHTML?: ?string,
-  className?: ?string,
-  iconHTML?: ?string,
-  description?: ?string,
-  descriptionMoreURL?: ?string,
+  leftLabel?: string,
+  leftLabelHTML?: string,
+  rightLabel?: string,
+  rightLabelHTML?: string,
+  className?: string,
 };
 
 type atom$AutocompleteRequest = {

--- a/types/autocomplete.js.flow
+++ b/types/autocomplete.js.flow
@@ -1,11 +1,17 @@
 /* @flow */
 
+// @TODO?: Use a union + intersection type
 type atom$AutocompleteSuggestion = {
-  // @NOTE: One of `text` or `snippet` is required.
+  /**
+   * @NOTE
+   * Autocomplet-Plus needs either `text` or `snippet` field, but Jupyter kernels don't offer
+   *   "snippet" or "signature" style completions, thus `text` field is defined as required here
+   *   to prevent unnecessary flow condition checks.
+   */
   text: string,
   // snippet: string,
   replacementPrefix: string,
-  // @NOTE: Only needed for Hydrogen implementation of `getSuggestionDetailsOnSelect`
+  /* @NOTE: Only needed for Hydrogen implementation of `getSuggestionDetailsOnSelect` */
   replacedText: string,
   iconHTML?: string,
   type?: string,

--- a/types/autocomplete.js.flow
+++ b/types/autocomplete.js.flow
@@ -37,12 +37,15 @@ export type atom$AutocompleteProvider = {
   +getSuggestions: (
     request: atom$AutocompleteRequest,
   ) => Promise<?Array<atom$AutocompleteSuggestion>> | ?Array<atom$AutocompleteSuggestion>,
+  +getSuggestionDetailsOnSelect?: (
+    suggestion: atom$AutocompleteSuggestion
+  ) => ?Promise<?atom$AutocompleteSuggestion>,
   +disableForSelector?: string,
   +inclusionPriority?: number,
   +excludeLowerPriority?: boolean,
   +suggestionPriority?: number,
   +filterSuggestions?: boolean,
-  +disposable?: () => void,
+  +dispose?: () => void,
   +onDidInsertSuggestion?: (
     insertedSuggestion: atom$SuggestionInsertedRequest,
   ) => void,


### PR DESCRIPTION
- Update autocomplete's API version to 4.0.0: 35bee56
- Ease `jupyter_types_experimental` feature condition check: 400686d
     *  Allow IJulia to get type information in suggestions
     * If `start` and `end` is not in completions, just use `cursor_start`,  `cursor_end`
- Update `showAutocompleteFirst` to `autocompleteSuggestionPriority`: 1e9a8b1
     * Enables an user to specify the number of sort
     * Useful in conjunction with other IDE packages, like IDE-Python
     * **Breaking change** to users
- Show kernel inspection results in autocomplete description: ef667b0
     * Use `getSuggestionDetailsOnSelect` feature: https://github.com/atom/autocomplete-plus/wiki/Provider-API
     * Move `autocomplete` styles into global scope to enable styling
     * Make autocomplete types specific to Hydrogen's implementation

## Overview

![Screenshot 2019-07-31 16 53 19](https://user-images.githubusercontent.com/40514306/62194360-ada0ea00-b3b4-11e9-88b3-f799280eda82.png)
