### PR TITLE
Update Cell Docs

### DIFF
--- a/docs/Usage/Cells.md
+++ b/docs/Usage/Cells.md
@@ -1,0 +1,98 @@
+ # Cells
+ 
+Cells are of three types − Code, Markdown and Raw.
+
+#### Code Cells
+A code cell allows you to edit and write new code. The programming language you use depends on the [Kernel](../Installation.md#kernels) you chose to use.
+
+When the cell is run (See [Hydrogen: Run Cell](GettingStarted.md#hydrogen-run-cell)), the text is sent as code to the file's kernel, which will run the code. The results that are returned are then displayed inline or optionally in the **Output Area**. Output however could be of many forms not just text. For example, you can output [graphs/plots](Examples.md#static-plots) or [HTML](Examples.md#html).
+
+#### Markdown Cells
+These cells contain text formatted using [**Common Markdown**](https://www.markdownguide.org/cheat-sheet/). All kinds of formatting features are available like making text bold and italic, displaying ordered or unordered list, rendering tabular contents etc. Markdown cells are especially useful to provide documentation to the computational process.
+
+#### Raw Cells
+*Currently Not Supported*
+
+
+## How to create Cells in Hydrogen
+To create cells in Hydrogen, use **cell markers**. If you already have cells from a **Jupyter Notebook** (``.ipynb`` file) that you would like to import, read how to [Import Notebooks](NotebookFiles.md#notebook-import).
+
+### Cell Markers
+
+A cell marker is a special inline comment that defines the lines that begin each cell. The inline comment must start with the comment character registered in the language's grammar file.
+
+- Python: `#`
+- R: `#`
+- Julia: `#`
+- Javascript: `//`
+- C++: `//`
+- Stata: `//`
+- Matlab: `%`
+
+
+### Example Definitions
+
+#### Code Cells
+
+Code cells are defined, by adding the following markers, after the comment character specific to the language you are using.
+
+##### Markers:
+- `%% codecell`
+- `<codecell>`
+- `In[]` (you can have any number of charaters inside the brackets (empty also works))
+
+For example, the following text corresponds to three code cells in a Python file
+```py
+# %% codecell
+print('Hello, world!')
+# <codecell>
+print('foo')
+# In[1]
+print('bar')
+```
+The equivalent code in JavaScript will be
+```js
+// %% codecell
+print('Hello, world!');
+// <codecell>
+print('foo');
+// In[1]
+print('bar');
+```
+
+#### Markdown Cells
+
+Just as for code cells](#code-cells), there are a range of allowed markers to delimit the start of a markdown cell:
+
+- `%% md`
+- `%% [md]`
+- `%% markdown`
+- `%% [markdown]`
+- `<md>`
+- `<markdown>`
+
+Each line of text in the cell's body should be prefixed by the language's comment character. Any common leading whitespace in the cell will be stripped, so the body text can include a space after the comment symbol without having leading whitespace in the output and with indented lists keeping their structure.
+
+For example, here are two markdown cells in a Python file
+```
+# %% [markdown]
+# _italic text_
+# **bold text**
+# <markdown>
+# - Indented
+#     - Lists
+```
+
+the two cells would be exported without any common leading whitespace as
+```md
+_italic text_
+**bold text**
+```
+and
+```md
+- Indented
+    - Lists
+```
+<br>
+
+##### To see how to import and export notebooks with Hydrogen visit [Notebook Import and Export](NotebookFiles.md#notebook-import-and-export)

--- a/docs/Usage/GettingStarted.md
+++ b/docs/Usage/GettingStarted.md
@@ -23,15 +23,14 @@ It's easiest to see these interactions visually:
 If your code starts getting cluttered up with results, run **"Hydrogen: Clear Results"** to remove them all at once.
 
 ## "Hydrogen: Run Cell"
-A "code cell" is a block of lines to be executed at once. You can define them using inline comments. Hydrogen supports a
-multitude of ways to define cells. Pick the one you like best.
-The following is an example for `python` but it will work in any language, just replace `#` with the comment symbol for your desired language:
+Cells are an easy way to separate your code. To learn more about them visit [Cells](Cells.md). 
 
+#### Example:
 <img width=280 src="https://cloud.githubusercontent.com/assets/13285808/17094174/e8ec17b8-524d-11e6-9140-60b43e073619.png">
 
 When you place the cursor inside a cell and hit **"Hydrogen: Run Cell"**, Hydrogen will execute this cell. The command **"Hydrogen: Run Cell And Move Down"** will move the cursor to the next cell after execution.
 
-The addition of these cell markers also allows you to export your text file as a Jupyter Notebook file. See [Notebook Export](NotebookFiles.md#notebook-export) for more detail.
+See [**Notebook Export**](NotebookFiles.md#notebook-export) for more details about exporting your Hydrogen Cells as a Jupyter Notebook.
 
 ## "Hydrogen: Run All" and "Hydrogen: Run All Above"
 These commands will run all code inside the editor or all code above the cursor.

--- a/docs/Usage/NotebookFiles.md
+++ b/docs/Usage/NotebookFiles.md
@@ -6,7 +6,7 @@ Access the import and export commands by opening the [command palette](https://f
 
 ## Notebook Import
 
-Run **"Hydrogen: Import Notebook"** and select the desired notebook file in the file browser that opens. That's it! The file will be imported into a new Atom tab, using [cell markers](#cell-markers) to delimit the individual code and markdown blocks.
+Run **`Hydrogen: Import Notebook`** and select the desired notebook file in the file browser that opens. That's it! The file will be imported into a new Atom tab, using [Cell Markers](Cells.md#cell-markers) to delimit the individual code and markdown blocks.
 
 **Note:** The syntax highlighting package for the given programming language must be installed and active.
 
@@ -20,72 +20,4 @@ print('Hello, world!')
 # A **Markdown** cell!
 ```
 
-### Cell Markers
-
-A cell marker is a special inline comment that defines the lines that begin each cell. The inline comment must start with the comment character registered in the language's grammar file.
-
-- Python: `#`
-- R: `#`
-- Julia: `#`
-- Javascript: `//`
-- C++: `//`
-- Stata: `//`
-- Matlab: `%`
-
-#### Code Cells
-
-After the comment character, you need to add one space plus any of the following markers on the same line:
-
-- `%%`
-- `<codecell>`
-- `In[]` (you can have any number of digits or spaces in the brackets)
-
-For example, the following text corresponds to three code cells in a Python file
-```py
-# %%
-print('Hello, world!')
-# <codecell>
-print('foo')
-# In[1]
-print('bar')
-```
-
-These are the same cell markers used by [**"Hydrogen: Run Cell"**](GettingStarted.md#hydrogen-run-cell).
-
-#### Markdown Cells
-
-You can also create cells with [Markdown](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet)-formatted text. Just as for code cells, there are a range of allowed markers to delimit the start of a markdown cell:
-
-- `%% md`
-- `%% [md]`
-- `%% markdown`
-- `%% [markdown]`
-- `<md>`
-- `<markdown>`
-
-Each line of text in the cell's body should be prefixed by the language's comment character. Any common leading whitespace in the cell will be stripped, so the body text can include a space after the comment symbol without having leading whitespace in the output and with indented lists keeping their structure.
-
-For example, here are two markdown cells in a Python file
-```
-# %% [markdown]
-# _italic text_
-# **bold text**
-# <markdown>
-# - Indented
-#     - Lists
-```
-
-the two cells would be exported without any common leading whitespace as
-```md
-_italic text_
-**bold text**
-```
-and
-```md
-- Indented
-    - Lists
-```
-
-#### Raw Cells
-
-Hydrogen doesn't support the export of [raw cells](https://nbformat.readthedocs.io/en/latest/format_description.html#raw-nbconvert-cells) at this time.
+##### To see how to define cells in Hydrogen visit [Cells](Cells.md)


### PR DESCRIPTION
Ref: #1672 
- Added separate page called 'Cell markers'
- Cross-referenced "Cell markers" and "Import and Export"