### PR TITLE
Update status-bar.js

### DIFF
--- a/lib/services/consumed/status-bar/signal-list-view.js
+++ b/lib/services/consumed/status-bar/signal-list-view.js
@@ -4,6 +4,7 @@ import SelectListView from "atom-select-list";
 
 import WSKernel from "../../../ws-kernel";
 import { log } from "../../../utils";
+import type { Store } from "../../../store";
 
 const basicCommands = [
   { name: "Interrupt", value: "interrupt-kernel" },
@@ -21,7 +22,7 @@ export default class SignalListView {
   previouslyFocusedElement: ?HTMLElement;
   selectListView: SelectListView;
   store: ?Store;
-  handleKernelCommand: Function;
+  handleKernelCommand: ?Function;
 
   constructor(store: Store, handleKernelCommand: Function) {
     this.store = store;

--- a/lib/services/consumed/status-bar/signal-list-view.js
+++ b/lib/services/consumed/status-bar/signal-list-view.js
@@ -38,7 +38,7 @@ export default class SignalListView {
       },
       didConfirmSelection: item => {
         log("Selected command:", item);
-        if (this.onConfirmed) this.onConfirmed(item);
+        this.onConfirmed(item);
         this.cancel();
       },
       didCancelSelection: () => this.cancel(),
@@ -47,14 +47,16 @@ export default class SignalListView {
   }
 
   onConfirmed(kernelCommand: { command: string }){
-    	this.handleKernelCommand(kernelCommand, this.store);
+    	if (this.handleKernelCommand) {
+        this.handleKernelCommand(kernelCommand, this.store);
+      }
   }
 
   async toggle() {
     if (this.panel != null) {
       this.cancel();
     }
-
+    if (!this.store) return;
     const kernel = this.store.kernel;
     if (!kernel) return;
     const commands =

--- a/lib/services/consumed/status-bar/signal-list-view.js
+++ b/lib/services/consumed/status-bar/signal-list-view.js
@@ -17,15 +17,15 @@ const wsKernelCommands = [
 ];
 
 export default class SignalListView {
-  onConfirmed: ?(command: { command: string }) => void;
   panel: ?atom$Panel;
   previouslyFocusedElement: ?HTMLElement;
   selectListView: SelectListView;
-  kernel: ?Kernel;
+  store: ?Store;
+  handleKernelCommand: Function;
 
-  constructor(kernel: Kernel) {
-    this.kernel = kernel;
-    this.onConfirmed = null;
+  constructor(store: Store, handleKernelCommand: Function) {
+    this.store = store;
+    this.handleKernelCommand = handleKernelCommand;
     this.selectListView = new SelectListView({
       itemsClassList: ["mark-active"],
       items: [],
@@ -45,12 +45,16 @@ export default class SignalListView {
     });
   }
 
+  onConfirmed(kernelCommand: { command: string }){
+    	this.handleKernelCommand(kernelCommand, this.store);
+  }
+
   async toggle() {
     if (this.panel != null) {
       this.cancel();
     }
 
-    const kernel = this.kernel;
+    const kernel = this.store.kernel;
     if (!kernel) return;
     const commands =
       kernel.transport instanceof WSKernel

--- a/lib/services/consumed/status-bar/status-bar.js
+++ b/lib/services/consumed/status-bar/status-bar.js
@@ -49,8 +49,8 @@ export class StatusBarConsumer {
     if (!signalListView) {
       signalListView = new SignalListView(store, handleKernelCommand);
       this.signalListView = signalListView;
-    }else{
-      signalListView.store = store
+    } else {
+      signalListView.store = store;
     }
     signalListView.toggle();
   }

--- a/lib/services/consumed/status-bar/status-bar.js
+++ b/lib/services/consumed/status-bar/status-bar.js
@@ -53,12 +53,10 @@ export class StatusBarConsumer {
     markers: MarkerStore
   }) {
     let signalListView = this.signalListView;
-    if (!signalListView) {
-      signalListView = new SignalListView(kernel);
-      signalListView.onConfirmed = (kernelCommand: { command: string }) =>
-        this.handleKernelCommand(kernelCommand, { kernel, markers });
-      this.signalListView = signalListView;
-    }
+    signalListView = new SignalListView(kernel);
+    signalListView.onConfirmed = (kernelCommand: { command: string }) =>
+      this.handleKernelCommand(kernelCommand, { kernel, markers });
+    this.signalListView = signalListView;
     signalListView.toggle();
   }
 }

--- a/lib/services/consumed/status-bar/status-bar.js
+++ b/lib/services/consumed/status-bar/status-bar.js
@@ -28,8 +28,6 @@ export class StatusBarConsumer {
       priority: 100
     });
 
-    this.handleKernelCommand = handleKernelCommand;
-
     const onClick = (store: Store) => {
       this.showKernelCommands(store, handleKernelCommand);
     };

--- a/lib/services/consumed/status-bar/status-bar.js
+++ b/lib/services/consumed/status-bar/status-bar.js
@@ -14,7 +14,6 @@ import type MarkerStore from "../../../store/markers";
 
 export class StatusBarConsumer {
   signalListView: SignalListView;
-  handleKernelCommand: Function;
 
   addStatusBar(
     store: Store,
@@ -31,8 +30,8 @@ export class StatusBarConsumer {
 
     this.handleKernelCommand = handleKernelCommand;
 
-    const onClick = ({ kernel, markers }) => {
-      this.showKernelCommands({ kernel, markers });
+    const onClick = (store: Store) => {
+      this.showKernelCommands(store, handleKernelCommand);
     };
 
     reactFactory(
@@ -45,18 +44,14 @@ export class StatusBarConsumer {
     return disposable;
   }
 
-  showKernelCommands({
-    kernel,
-    markers
-  }: {
-    kernel: Kernel,
-    markers: MarkerStore
-  }) {
+  showKernelCommands(store: Store, handleKernelCommand: Function) {
     let signalListView = this.signalListView;
-    signalListView = new SignalListView(kernel);
-    signalListView.onConfirmed = (kernelCommand: { command: string }) =>
-      this.handleKernelCommand(kernelCommand, { kernel, markers });
-    this.signalListView = signalListView;
+    if (!signalListView) {
+      signalListView = new SignalListView(store, handleKernelCommand);
+      this.signalListView = signalListView;
+    }else{
+      signalListView.store = store
+    }
     signalListView.toggle();
   }
 }


### PR DESCRIPTION
fix "Not able to Shut Down kernel twice (Uncaught Error: ENOENT) #1760"
duplicated issues: #1756, #1780, #1778, #1770, #1767, #1764, #1765

Tested scenarios:
1. from #1760 

> 1. open atom
> 2. Initialize kernel (python 3)
> 3. shut down lernel
> 4. Initialize kernel again
> 5. shut down lernel

Pass

2. from #1756

> 1. Open two atom sessions using "atom ." in the command line
> 2. initialize python 3 in one of them
> 3. Change working directory using
> 4. import os
> 5. os.chdir(script_dir)
> 6. Shutdown python kernel

Pass

3. from #1770
test interrupt and restart kernel.

Pass