### PR TITLE
Remove unneccessery else with return

### DIFF
--- a/lib/components/output-area.js
+++ b/lib/components/output-area.js
@@ -58,10 +58,10 @@ class OutputArea extends React.Component<{ store: store }> {
     if (!kernel) {
       if (atom.config.get("Hydrogen.outputAreaDock")) {
         return <EmptyMessage />;
-      } else {
-        atom.workspace.hide(OUTPUT_AREA_URI);
-        return null;
       }
+
+      atom.workspace.hide(OUTPUT_AREA_URI);
+      return null;
     }
     return (
       <Provider src={mathJaxPath}>

--- a/lib/components/watch-sidebar/index.js
+++ b/lib/components/watch-sidebar/index.js
@@ -14,10 +14,10 @@ const Watches = observer(({ store: { kernel } }: { store: store }) => {
   if (!kernel) {
     if (atom.config.get("Hydrogen.outputAreaDock")) {
       return <EmptyMessage />;
-    } else {
-      atom.workspace.hide(WATCHES_URI);
-      return null;
     }
+
+    atom.workspace.hide(WATCHES_URI);
+    return null;
   }
 
   return (

--- a/lib/ws-kernel-picker.js
+++ b/lib/ws-kernel-picker.js
@@ -206,13 +206,15 @@ export default class WSKernelPicker {
     });
     if (action === "token") {
       return await this.promptForToken(options);
-    } else if (action === "cookie") {
-      return await this.promptForCookie(options);
-    } else {
-      // action === "cancel"
-      this.listView.cancel();
-      return false;
     }
+
+    if (action === "cookie") {
+      return await this.promptForCookie(options);
+    }
+
+    // action === "cancel"
+    this.listView.cancel();
+    return false;
   }
 
   async onGateway(gatewayInfo: any) {


### PR DESCRIPTION
```
if (a) {
   return 'object a';
} else {
   return 'not object a';
}
```

It is the same as:
```
if (a) {
   return 'object a';
}

return 'not object a';
```

But more readable code.