### PR TITLE
Center screen on cursor on run[-cell]-and-move-down

### DIFF
--- a/lib/code-manager.js
+++ b/lib/code-manager.js
@@ -338,6 +338,15 @@ export function getCellsForBreakPoints(
   );
 }
 
+function centerScreenOnCursorPosition(editor: atom$TextEditor) {
+  const cursorPosition = editor.element.pixelPositionForScreenPosition(
+    editor.getCursorScreenPosition()
+  ).top;
+  const editorHeight = editor.element.getHeight();
+
+  editor.element.setScrollTop(cursorPosition - editorHeight / 2);
+}
+
 export function moveDown(editor: atom$TextEditor, row: number) {
   const lastRow = editor.getLastBufferRow();
 
@@ -356,6 +365,8 @@ export function moveDown(editor: atom$TextEditor, row: number) {
     row,
     column: 0
   });
+
+  centerScreenOnCursorPosition(editor);
 }
 
 export function findPrecedingBlock(


### PR DESCRIPTION
When using _run-cell-and-move-down_ (or _run-and-move-down_), the cursor moves to the next cell (or line). But if it is off-screen or too further down, only a few lines of code of the next cell (or lines to come) are visible.

In Jupyter Notebook, the "run cell and select next" command centers the screen on the next cell.

This change modifies the behavior of the _run-cell-and-move-down_ and _run-and-move-down_ to match that of Jupyter Notebook and helps to make the next code to run more visible.