### PR TITLE
Use `console.log` instead of `console.debug` and honour Hydrogen setting

### DIFF
--- a/lib/kernel.js
+++ b/lib/kernel.js
@@ -363,7 +363,7 @@ export default class Kernel {
             stream: "status"
           });
         } else {
-          console.warn(
+          log(
             "Kernel: ignoring unexpected value for message.content.status"
           );
         }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -195,7 +195,7 @@ export function hotReloadPackage() {
   const zeromqPathPrefix =
     path.join(packPath, "node_modules", "zeromq") + path.sep;
 
-  console.info(`deactivating ${packName}`);
+  log(`deactivating ${packName}`);
   atom.packages.deactivatePackage(packName);
   atom.packages.unloadPackage(packName);
 
@@ -211,7 +211,7 @@ export function hotReloadPackage() {
 
   atom.packages.loadPackage(packName);
   atom.packages.activatePackage(packName);
-  console.info(`activated ${packName}`);
+  log(`activated ${packName}`);
 }
 
 export function rowRangeForCodeFoldAtBufferRow(

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -170,7 +170,7 @@ export function getEditorDirectory(editor: ?atom$TextEditor) {
 
 export function log(...message: Array<any>) {
   if (atom.config.get("Hydrogen.debug")) {
-    console.debug("Hydrogen:", ...message);
+    console.log("Hydrogen:", ...message);
   }
 }
 

--- a/lib/zmq-kernel.js
+++ b/lib/zmq-kernel.js
@@ -137,7 +137,7 @@ export default class ZMQKernel extends KernelTransport {
       monitor("shellSocket", this.shellSocket);
       monitor("ioSocket", this.ioSocket);
     } catch (err) {
-      console.error("ZMQKernel:", err);
+      log("ZMQKernel:", err);
     }
   }
 


### PR DESCRIPTION
Recent versions of Atom filter out `console.debug` messages from the dev console.


This PR ensures all log messages use `console.log`, by:
* replacing `console.debug` with `console.log` in `utils.js#log`
* replacing the use of `console.info`, `console.warn` and `console.log` with `log`, so that Hydrogen honours the setting to disable debug messages.