### PR TITLE
Pin @nteract/markdown dependency to 4.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@babel/runtime-corejs2": "^7.0.0",
     "@jupyterlab/services": "^0.52.0",
     "@nteract/commutable": "^7.1.4",
-    "@nteract/markdown": "^4.0.0",
+    "@nteract/markdown": "4.2.0",
     "@nteract/mathjax": "^4.0.1",
     "@nteract/outputs": "^2.1.5",
     "@nteract/plotly": "^1.48.3",


### PR DESCRIPTION
This is the last version published before the introduction of 
github-markdown-css which is currently causing problems during install
as reported in #1854