### PR TITLE
rm mobx-react-devtools

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -5,7 +5,7 @@ import {
   CompositeDisposable,
   Disposable,
   Point,
-  TextEditor
+  TextEditor,
 } from "atom";
 
 import _ from "lodash";
@@ -38,14 +38,13 @@ import {
   log,
   reactFactory,
   isMultilanguageGrammar,
-  renderDevTools,
   INSPECTOR_URI,
   WATCHES_URI,
   OUTPUT_AREA_URI,
   KERNEL_MONITOR_URI,
   hotReloadPackage,
   openOrShowDock,
-  kernelSpecProvidesGrammar
+  kernelSpecProvidesGrammar,
 } from "./utils";
 
 import exportNotebook from "./export-notebook";
@@ -75,7 +74,7 @@ const Hydrogen = {
             atom.notifications.addError("Hydrogen", {
               description:
                 "`languageMappings` cannot be updated while kernels are running",
-              dismissable: false
+              dismissable: false,
             });
           }
         }
@@ -83,17 +82,10 @@ const Hydrogen = {
     );
 
     store.subscriptions.add(
-      // enable/disable mobx-react-devtools logging
-      atom.config.onDidChange("Hydrogen.debug", ({ newValue }) =>
-        renderDevTools(newValue)
-      )
-    );
-
-    store.subscriptions.add(
-      atom.config.observe("Hydrogen.statusBarDisable", newValue => {
+      atom.config.observe("Hydrogen.statusBarDisable", (newValue) => {
         store.setConfigValue("Hydrogen.statusBarDisable", Boolean(newValue));
       }),
-      atom.config.observe("Hydrogen.statusBarKernelInfo", newValue => {
+      atom.config.observe("Hydrogen.statusBarKernelInfo", (newValue) => {
         store.setConfigValue("Hydrogen.statusBarKernelInfo", Boolean(newValue));
       })
     );
@@ -143,32 +135,32 @@ const Hydrogen = {
         "hydrogen:fold-current-cell": () => this.foldCurrentCell(),
         "hydrogen:fold-all-but-current-cell": () =>
           this.foldAllButCurrentCell(),
-        "hydrogen:clear-results": () => result.clearResults(store)
+        "hydrogen:clear-results": () => result.clearResults(store),
       })
     );
 
     store.subscriptions.add(
       atom.commands.add("atom-workspace", {
-        "hydrogen:import-notebook": importNotebook
+        "hydrogen:import-notebook": importNotebook,
       })
     );
 
     if (atom.inDevMode()) {
       store.subscriptions.add(
         atom.commands.add("atom-workspace", {
-          "hydrogen:hot-reload-package": () => hotReloadPackage()
+          "hydrogen:hot-reload-package": () => hotReloadPackage(),
         })
       );
     }
 
     store.subscriptions.add(
-      atom.workspace.observeActiveTextEditor(editor => {
+      atom.workspace.observeActiveTextEditor((editor) => {
         store.updateEditor(editor);
       })
     );
 
     store.subscriptions.add(
-      atom.workspace.observeTextEditors(editor => {
+      atom.workspace.observeTextEditors((editor) => {
         const editorSubscriptions = new CompositeDisposable();
         editorSubscriptions.add(
           editor.onDidChangeGrammar(() => {
@@ -193,7 +185,7 @@ const Hydrogen = {
         );
 
         editorSubscriptions.add(
-          editor.onDidChangeTitle(newTitle => store.forceEditorUpdate())
+          editor.onDidChangeTitle((newTitle) => store.forceEditorUpdate())
         );
 
         store.subscriptions.add(editorSubscriptions);
@@ -203,7 +195,7 @@ const Hydrogen = {
     this.hydrogenProvider = null;
 
     store.subscriptions.add(
-      atom.workspace.addOpener(uri => {
+      atom.workspace.addOpener((uri) => {
         switch (uri) {
           case INSPECTOR_URI:
             return new InspectorPane(store);
@@ -221,7 +213,7 @@ const Hydrogen = {
     store.subscriptions.add(
       // Destroy any Panes when the package is deactivated.
       new Disposable(() => {
-        atom.workspace.getPaneItems().forEach(item => {
+        atom.workspace.getPaneItems().forEach((item) => {
           if (
             item instanceof InspectorPane ||
             item instanceof WatchesPane ||
@@ -233,8 +225,6 @@ const Hydrogen = {
         });
       })
     );
-
-    renderDevTools(atom.config.get("Hydrogen.debug") === true);
 
     autorun(() => {
       this.emitter.emit("did-change-kernel", store.kernel);
@@ -337,7 +327,7 @@ const Hydrogen = {
       codeManager.moveDown(editor, row);
     }
 
-    this.checkForKernel(store, kernel => {
+    this.checkForKernel(store, (kernel) => {
       result.createResult(store, { code, row, cellType });
     });
   },
@@ -390,7 +380,7 @@ const Hydrogen = {
           ? codeManager.removeCommentsMarkdownCell(editor, codeNullable)
           : codeNullable;
 
-      this.checkForKernel(store, kernel => {
+      this.checkForKernel(store, (kernel) => {
         result.createResult(store, { code, row, cellType });
       });
     }
@@ -444,7 +434,7 @@ const Hydrogen = {
             ? codeManager.removeCommentsMarkdownCell(editor, codeNullable)
             : codeNullable;
 
-        this.checkForKernel(store, kernel => {
+        this.checkForKernel(store, (kernel) => {
           result.createResult(store, { code, row, cellType });
         });
       }
@@ -481,7 +471,7 @@ const Hydrogen = {
       codeManager.moveDown(editor, row);
     }
 
-    this.checkForKernel(store, kernel => {
+    this.checkForKernel(store, (kernel) => {
       result.createResult(store, { code, row, cellType });
     });
   },
@@ -501,7 +491,7 @@ const Hydrogen = {
   startZMQKernel() {
     kernelManager
       .getAllKernelSpecsForGrammar(store.grammar)
-      .then(kernelSpecs => {
+      .then((kernelSpecs) => {
         if (this.kernelPicker) {
           this.kernelPicker.kernelSpecs = kernelSpecs;
         } else {
@@ -545,12 +535,12 @@ const Hydrogen = {
       editor,
       grammar,
       filePath,
-      kernel
+      kernel,
     }: {
       editor: atom$TextEditor,
       grammar: atom$Grammar,
       filePath: string,
-      kernel?: Kernel
+      kernel?: Kernel,
     },
     callback: (kernel: Kernel) => void
   ) {
@@ -571,7 +561,7 @@ const Hydrogen = {
       filePath,
       (newKernel: Kernel) => callback(newKernel)
     );
-  }
+  },
 };
 
 export default Hydrogen;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -55,7 +55,7 @@ export async function openOrShowDock(URI: string): Promise<?void> {
 
   await atom.workspace.open(URI, {
     searchAllPanes: true,
-    activatePane: false
+    activatePane: false,
   });
   dock = atom.workspace.paneContainerForURI(URI);
   return dock ? dock.show() : null;
@@ -68,7 +68,7 @@ export function grammarToLanguage(grammar: ?atom$Grammar) {
   const mappings = Config.getJson("languageMappings");
   const kernelLanguage = _.findKey(
     mappings,
-    l => l.toLowerCase() === grammarLanguage
+    (l) => l.toLowerCase() === grammarLanguage
   );
 
   return kernelLanguage ? kernelLanguage.toLowerCase() : grammarLanguage;
@@ -84,7 +84,7 @@ export function grammarToLanguage(grammar: ?atom$Grammar) {
  */
 export function msgSpecToNotebookFormat(message: Message) {
   return Object.assign({}, message.content, {
-    output_type: message.header.msg_type
+    output_type: message.header.msg_type,
   });
 }
 
@@ -121,7 +121,7 @@ const markupGrammars = new Set([
   "source.pweave.latex",
   "source.pweave.restructuredtext",
   "source.dyndoc.md.stata",
-  "source.dyndoc.latex.stata"
+  "source.dyndoc.latex.stata",
 ]);
 
 export function isMultilanguageGrammar(grammar: atom$Grammar) {
@@ -160,7 +160,7 @@ export function getEmbeddedScope(
   const scopes = editor
     .scopeDescriptorForBufferPosition(position)
     .getScopesArray();
-  return _.find(scopes, s => s.indexOf("source.embedded.") === 0);
+  return _.find(scopes, (s) => s.indexOf("source.embedded.") === 0);
 }
 
 export function getEditorDirectory(editor: ?atom$TextEditor) {
@@ -172,19 +172,6 @@ export function getEditorDirectory(editor: ?atom$TextEditor) {
 export function log(...message: Array<any>) {
   if (atom.config.get("Hydrogen.debug")) {
     console.log("Hydrogen:", ...message);
-  }
-}
-
-export function renderDevTools(enableLogging: boolean) {
-  if (!atom.devMode) return;
-  try {
-    const devTools = require("mobx-react-devtools");
-    const div = document.createElement("div");
-    document.getElementsByTagName("body")[0].appendChild(div);
-    devTools.setLogEnabled(enableLogging);
-    ReactDOM.render(<devTools.default noPanel />, div);
-  } catch (e) {
-    log("Could not enable dev tools", e);
   }
 }
 
@@ -202,13 +189,13 @@ export function hotReloadPackage() {
 
   // Delete require cache to re-require on activation.
   // But except zeromq native module which is not re-requireable.
-  const packageLibsExceptZeromq = filePath =>
+  const packageLibsExceptZeromq = (filePath) =>
     filePath.startsWith(packPathPrefix) &&
     !filePath.startsWith(zeromqPathPrefix);
 
   Object.keys(require.cache)
     .filter(packageLibsExceptZeromq)
-    .forEach(filePath => delete require.cache[filePath]);
+    .forEach((filePath) => delete require.cache[filePath]);
 
   atom.packages.loadPackage(packName);
   atom.packages.activatePackage(packName);

--- a/package.json
+++ b/package.json
@@ -120,7 +120,6 @@
     "husky": "^4.2.1",
     "lint-staged": "^10.0.7",
     "markdox": "^0.1.10",
-    "mobx-react-devtools": "^6.0.0",
     "prettier": "^2.0.0",
     "react-test-renderer": "^16.0.0"
   }


### PR DESCRIPTION
As stated in [mobx-react-devtools's README](https://github.com/mobxjs/mobx-react-devtools), mobx≧6.0 doesn't require this tool actually.
It would be appreciated if you could tell me how to recover the same kind of functionality since I've never used this tool. Well, I think we can remove this tool for now even if we're not sure about the alternative, I dunno.

/cc @BenRussert @lgeiger 