### PR TITLE
Close issue #1963 (tooltip not shown, content not copyable on mac OS)

### DIFF
--- a/styles/hydrogen.less
+++ b/styles/hydrogen.less
@@ -17,6 +17,7 @@
 
 .hydrogen.marker {
   display: flex;
+  position: relative;
 }
 
 .hydrogen {


### PR DESCRIPTION
Closing issue #1963.

Apparently the problem was that atom's `<div>` containing the editor's line of text swallowed the click event that should have been captured by the output cell. This is why a larger output sell solved the problem: one was now able to click below the editor line.

Setting `position: relative;` for the hydrogen marker solves the issue, because now the newly inserted `<div>` lies above the editor line and becomes clickable. No visible changes.