### PR TITLE
Fix scroll in output area pane

### DIFF
--- a/lib/components/result-view/list.js
+++ b/lib/components/result-view/list.js
@@ -41,7 +41,9 @@ class ScrollList extends React.Component<Props> {
         hydrogen-wrapoutput={atom.config.get(`Hydrogen.wrapOutput`).toString()}
       >
         {this.props.outputs.map((output, index) => (
-          <Display output={output} key={index} />
+          <div className="scroll-list-item">
+            <Display output={output} key={index} />
+          </div>
         ))}
       </div>
     );

--- a/styles/hydrogen.less
+++ b/styles/hydrogen.less
@@ -287,18 +287,22 @@ svg:first-child {
 
   .multiline-container {
     font-family: monospace;
-    display: block;
-    flex: 0 1 auto;
+    &:not(.scroll-list) {
+      flex: 1;
+      border: solid 2px red;
+    }
   }
   .scroll-list {
+    flex-direction: column;
+    
+    .scroll-list-item {
+      margin: 10px 0;
+    }
+
     .cell_display {
       height: 100%;
       padding: 0;
-
-      > div {
-        margin-bottom: 10px;
-        margin-top: 10px;
-      }
+      
     }
   }
 }


### PR DESCRIPTION
Use flex to ensure scrolling when output pane overflows.

For "list" mode, add a div around each output so we can pad it properly the same way no matter the output.

Fixes #1965