### PR TITLE
Bugfix ratio distortion of media in sidebar

### DIFF
--- a/styles/hydrogen.less
+++ b/styles/hydrogen.less
@@ -248,9 +248,11 @@
     video,
     img,
     svg {
-      width: unset !important;
-      height: unset !important;
+      object-fit: contain !important;
+      width: auto !important;
+      height: auto !important;
       max-width: 100% !important;
+      max-height: 100% !important;
     }
   }
 


### PR DESCRIPTION
This PR closes #1443.
In short, it makes sure that media (`img, svg, video`) displayed in the Hydrogen Output Area keep their initial ratio instead of being distorted to fill the whole space.

Before:
![Screenshot from 2021-05-25 10-26-36](https://user-images.githubusercontent.com/13835654/119465356-e1948e80-bd43-11eb-8c35-b98744438e42.png)

After:
![Screenshot from 2021-05-25 10-26-21](https://user-images.githubusercontent.com/13835654/119465385-e8230600-bd43-11eb-9372-1f7616947814.png)
