### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/Usage/Cells.md
+++ b/docs/Usage/Cells.md
@@ -68,7 +68,7 @@ print("bar");
 
 #### Markdown Cells
 
-Just as for code cells](#code-cells), there are a range of allowed markers to delimit the start of a markdown cell:
+Just as for [code cells](#code-cells), there are a range of allowed markers to delimit the start of a markdown cell:
 
 - `%% md`
 - `%% [md]`


### PR DESCRIPTION
Add a missing "[" to fix an internal link in the documentation.