### PR TITLE
Remove duplicate keybindings

### DIFF
--- a/keymaps/hydrogen.cson
+++ b/keymaps/hydrogen.cson
@@ -14,17 +14,14 @@
     'shift-alt-enter': 'hydrogen:run-cell-and-move-down'
     'alt-i': 'hydrogen:toggle-inspector'
 
-# Override shift-enter and cmd-enter
+# Override cmd-enter
 '.platform-darwin atom-text-editor:not([mini])':
-    'shift-enter': 'hydrogen:run-and-move-down'
     'cmd-alt-enter': 'hydrogen:run-cell'
     'cmd-enter': 'hydrogen:run'
     'cmd-ctrl-enter': 'hydrogen:run-all'
 
 # Override ctrl-enter
 '.platform-win32 atom-text-editor:not([mini]), .platform-linux atom-text-editor:not([mini])':
-    'ctrl-enter': 'hydrogen:run'
-    'ctrl-shift-backspace': 'hydrogen:clear-results'
     'ctrl-alt-enter': 'hydrogen:run-cell'
     'ctrl-enter': 'hydrogen:run'
     'ctrl-shift-alt-enter': 'hydrogen:run-all'


### PR DESCRIPTION
`ctrl-enter` is duplicated in the same schema.
`shift-enter` is duplicated in Darwin.
`ctrl-shift-backspace` is duplicated in Windows/Linux editor.

I'm not an expert on Coffeescript or Atom config, so if there's a valid reason for the duplicates to exist, please let me know.