### PR TITLE
Fix bug while checking for an old version

### DIFF
--- a/lib/utils.tsx
+++ b/lib/utils.tsx
@@ -218,16 +218,12 @@ export function rowRangeForCodeFoldAtBufferRow(
   editor: TextEditor,
   row: number
 ) {
-  if (parseFloat(atom.getVersion()) < 1.22) {
-    return editor.languageMode.rowRangeForCodeFoldAtBufferRow(row);
-  } else {
-    // $FlowFixMe
-    const range = editor.tokenizedBuffer.getFoldableRangeContainingPoint(
-      new Point(row, Infinity),
-      editor.getTabLength()
-    );
-    return range ? [range.start.row, range.end.row] : null;
-  }
+  // $FlowFixMe
+  const range = editor.tokenizedBuffer.getFoldableRangeContainingPoint(
+    new Point(row, Infinity),
+    editor.getTabLength()
+  );
+  return range ? [range.start.row, range.end.row] : null;
 }
 export const EmptyMessage = () => {
   return (


### PR DESCRIPTION
We're keeping a fork of Atom called Pulsar. We decided that our "first beta version" was going to be `1.100`, but the way Hydrogen checks for versions is using `parseFloat`, which translates `1.100` to `1.1` and then it proceeds to use some outdated API.

This PR removes the check (Atom 1.2 is _really old_ and considering that the project is dead anyway...)